### PR TITLE
fix support.go known Consumers/Producers and configureApi func

### DIFF
--- a/generator/support.go
+++ b/generator/support.go
@@ -208,13 +208,13 @@ var mediaTypeNames = map[string]string{
 }
 
 var knownProducers = map[string]string{
-	"json": "swagger.JSONProducer",
-	"yaml": "swagger.YAMLProducer",
+	"json": "httpkit.JSONProducer",
+	"yaml": "httpkit.YAMLProducer",
 }
 
 var knownConsumers = map[string]string{
-	"json": "swagger.JSONConsumer",
-	"yaml": "swagger.YAMLConsumer",
+	"json": "httpkit.JSONConsumer",
+	"yaml": "httpkit.YAMLConsumer",
 }
 
 func getSerializer(sers []genSerGroup, ext string) (*genSerGroup, bool) {

--- a/generator/templates/server/main.gotmpl
+++ b/generator/templates/server/main.gotmpl
@@ -50,3 +50,40 @@ func main() {
     log.Fatalln(err)
   }
 }
+
+
+func configureAPI(api *{{.Package}}.{{.AppName}}API) {
+  // configure the api here
+  api.ServeError = errors.ServeError
+
+  {{range .Consumes}}{{if .Implementation}}api.{{.ClassName}}Consumer = {{.Implementation}}()
+  {{else}}api.{{.ClassName}}Consumer = httpkit.ConsumerFunc(func(r io.Reader, target interface{}) error {
+    return errors.NotImplemented("{{.Name}} consumer has not yet been implemented")
+  }){{end}}
+  {{end}}
+  {{range .Produces}}{{if .Implementation}}api.{{.ClassName}}Producer = {{.Implementation}}()
+  {{else}}api.{{.ClassName}}Producer = httpkit.ProducerFunc(func(w io.Writer, data interface{}) error {
+    return errors.NotImplemented("{{.Name}} producer has not yet been implemented")
+  }){{end}}
+  {{end}}
+  {{range .SecurityDefinitions}}
+  {{if .IsBasicAuth}}
+  api.{{.ClassName}}Auth = func(user string, pass string) (*{{.Principal}}, error) {
+    return nil, errors.NotImplemented("basic auth has not yet been implemented")
+  }
+  {{end}}{{if .IsAPIKeyAuth}}
+  api.{{.ClassName}}Auth = func(token string) (*{{.Principal}}, error) {
+    return nil, errors.NotImplemented("api key auth {{.Name}} from {{.Source}} has not yet been implemented")
+  }
+  {{end}}
+  {{end}}
+  {{range .Operations}}{{if .Package}}api.{{.ClassName}}Handler = {{.Package}}.{{.ClassName}}HandlerFunc(func({{if .Params}}params {{.Package}}.{{.ClassName}}Params{{end}}{{if and .Authorized .Params}}, {{end}}{{if .Authorized}}principal *{{.Principal}}{{end}}) ({{if .SuccessModel}}{{if .ReturnsComplexObject}}*{{end}}{{.SuccessModel}}, {{end}}error) {
+    return {{if .SuccessModel}}{{.SuccessZero}}, {{end}}errors.NotImplemented("operation {{.Name}} has not yet been implemented")
+  })
+  {{else}}api.{{.ClassName}}Handler = {{.ClassName}}HandlerFunc(func({{if .Params}}params {{.ClassName}}Params{{end}}{{if and .Authorized .Params}}, {{end}}{{if .Authorized}}principal *{{.Principal}}{{end}}) ({{if .SuccessModel}}{{if .ReturnsComplexObject}}*{{end}}{{.SuccessModel}}, {{end}}error) {
+    return {{if .SuccessModel}}{{.SuccessZero}}, {{end}}errors.NotImplemented("operation {{.Name}} has not yet been implemented")
+  })
+  {{end}}
+  {{end}}
+}
+


### PR DESCRIPTION
Hi, with these changes we are able to compile and run the server that get generated.

The first change changes `swagger` to `httpkit` because httpkit is the right import.

The second change is to move the private function `configureAPI` to main.gotmpl because being in configureapi.gotmpl doesn't make it visible to the main.gotmpl. We realized that they are both in the same package `main` but it is not visible, but moving the function to the main.gotmpl makes it work.
Maybe it is because the package folder is different but it is not clear. 

If you would rather have different PRs, please let us know and we will resubmit.

Thanks. 
