### PR TITLE
Sort model properties and operations before generation.

### DIFF
--- a/generator/model.go
+++ b/generator/model.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -168,6 +169,8 @@ func makeCodegenModel(name, pkg string, schema spec.Schema, specDoc *spec.Docume
 		properties = append(properties, v)
 	}
 
+	sort.Sort(genModelPropertySlice(properties))
+
 	return &genModel{
 		Package:        filepath.Base(pkg),
 		ClassName:      swag.ToGoName(name),
@@ -265,6 +268,12 @@ func makeGenModelProperty(path, paramName, accessor, receiver, indexVar, valueEx
 		XMLName: xmlName,
 	}
 }
+
+type genModelPropertySlice []genModelProperty
+
+func (s genModelPropertySlice) Len() int           { return len(s) }
+func (s genModelPropertySlice) Less(i, j int) bool { return s[i].PropertyName < s[j].PropertyName }
+func (s genModelPropertySlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // TODO:
 // untyped data requires a cast somehow to the inner type

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -267,6 +267,12 @@ func operationDocString(name string, operation spec.Operation) string {
 	return commentedLines(strings.Join([]string{hdr, txtFoot}, "\n"))
 }
 
+type genOperationSlice []genOperation
+
+func (s genOperationSlice) Len() int           { return len(s) }
+func (s genOperationSlice) Less(i, j int) bool { return s[i].Name < s[j].Name }
+func (s genOperationSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
 type genOperation struct {
 	Package        string //`json:"package,omitempty"`        // -
 	ReceiverName   string //`json:"receiverName,omitempty"`   // -

--- a/generator/support.go
+++ b/generator/support.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -391,6 +392,8 @@ func (a *appGenerator) makeCodegenApp() genApp {
 		importPath := filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage, a.APIPackage, k))
 		defaultImports = append(defaultImports, importPath)
 	}
+
+	sort.Sort(genOperationSlice(genOps))
 
 	defaultConsumes := "application/json"
 	rc := a.SpecDoc.RequiredConsumes()


### PR DESCRIPTION
So they are always generated in the same deterministic order.
Otherwise re-running the generator will result in changed code even in
places where the specification is unchanged.