### PR TITLE
Ensure operation.Package has a value.

### DIFF
--- a/generator/client.go
+++ b/generator/client.go
@@ -60,6 +60,7 @@ func (c *clientGenerator) Generate() error {
 
 	opsGroupedByTag := make(map[string][]GenOperation)
 	for _, operation := range app.Operations {
+		operation.Package = c.Package
 		if err := c.generateParameters(&operation); err != nil {
 			return err
 		}


### PR DESCRIPTION
I found that the `package` was not being set correctly when generating the client code. Digging into things, I saw that `operation.Package` wasn't getting a value from the options.

There might be a better way to fix this or it's possible I'm doing something wrong when generating the client code.