### PR TITLE
Allow http status 201 to have a response body

### DIFF
--- a/httpkit/middleware/context.go
+++ b/httpkit/middleware/context.go
@@ -349,7 +349,7 @@ func (c *Context) Respond(rw http.ResponseWriter, r *http.Request, produces []st
 
 	if _, code, ok := route.Operation.SuccessResponse(); ok {
 		rw.WriteHeader(code)
-		if code == 201 || code == 204 || r.Method == "HEAD" {
+		if code == 204 || r.Method == "HEAD" {
 			return
 		}
 


### PR DESCRIPTION
201 Responses should be able to contain a body. There is no rule enforcing HTTP 201 status code to return an empty body. The current code does not allow a 201 response to contain a body.

According to HTTP 1.1 spec:
>201 Created

>The request has been fulfilled and resulted in a new resource being created. The newly created resource can be referenced by the URI(s) returned in the entity of the response, with the most specific URI for the resource given by a Location header field. The response SHOULD include an entity containing a list of resource characteristics and location(s) from which the user or user agent can choose the one most appropriate. The entity format is specified by the media type given in the Content-Type header field. The origin server MUST create the resource before returning the 201 status code. If the action cannot be carried out immediately, the server SHOULD respond with 202 (Accepted) response instead.