### PR TITLE
Fix import path for operations that lack tags

### DIFF
--- a/generator/support.go
+++ b/generator/support.go
@@ -563,7 +563,13 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 			RootPackage:    a.APIPackage,
 		}
 		opGroups = append(opGroups, opGroup)
-		defaultImports = append(defaultImports, filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage, a.APIPackage, k)))
+		var importPath string
+		if k == a.APIPackage {
+			importPath = filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage, a.APIPackage))
+		} else {
+			importPath = filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage, a.APIPackage, k))
+		}
+		defaultImports = append(defaultImports, importPath)
 	}
 	sort.Sort(opGroups)
 


### PR DESCRIPTION
- Before, operations without a "Tag" field in their spec would
  generate incorrect imports (`$PROJECT/restapi/operations/operations`
  instead of `$PROJECT/restapi/operations`)
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/casualjim%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/456109%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/go-swagger/go-swagger/pull/209%23issuecomment-171498933%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-01-14T01%3A48%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/456109%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/casualjim%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/go-swagger/go-swagger/pull/209%23issuecomment-171498933%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/casualjim'><img src='https://avatars.githubusercontent.com/u/456109?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/go-swagger/go-swagger/pull/209?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/go-swagger/go-swagger/pull/209?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/go-swagger/go-swagger/pull/209'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>