### PR TITLE
skip generating server main if it exists:

### DIFF
--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -42,6 +42,7 @@ type Server struct {
 	SkipModels     bool     `long:"skip-models" description:"no models will be generated when this flag is specified"`
 	SkipOperations bool     `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
 	SkipSupport    bool     `long:"skip-support" description:"no supporting files will be generated when this flag is specified"`
+	IncludeMain    bool     `long:"include-main" description:"overwrite main even if it exists already"`
 }
 
 // Execute runs this command
@@ -60,6 +61,7 @@ func (s *Server) Execute(args []string) error {
 		IncludeHandler:    !s.SkipOperations,
 		IncludeParameters: !s.SkipOperations,
 		IncludeResponses:  !s.SkipOperations,
+		IncludeMain:       s.IncludeMain,
 	}
 
 	return generator.GenerateServer(s.Name, s.Models, s.Operations, opts)

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -91,6 +91,7 @@ type GenOpts struct {
 	IncludeHandler    bool
 	IncludeParameters bool
 	IncludeResponses  bool
+	IncludeMain       bool
 }
 
 type generatorOptions struct {

--- a/generator/support.go
+++ b/generator/support.go
@@ -235,12 +235,17 @@ func (a *appGenerator) generateConfigureAPI(app *GenApp) error {
 }
 
 func (a *appGenerator) generateMain(app *GenApp) error {
+	pth := filepath.Join(a.Target, "cmd", swag.ToCommandName(swag.ToGoName(app.Name)+"Server"))
+	if fileExists(pth, "main") && !a.GenOpts.IncludeMain {
+		log.Println("skipped (already exists) main template:", app.Package+".Main")
+		return nil
+	}
 	buf := bytes.NewBuffer(nil)
 	if err := mainTemplate.Execute(buf, app); err != nil {
 		return err
 	}
 	log.Println("rendered main template:", "server."+swag.ToGoName(app.Name))
-	return writeToFile(filepath.Join(a.Target, "cmd", swag.ToCommandName(swag.ToGoName(app.Name)+"Server")), "main", buf.Bytes())
+	return writeToFile(pth, "main", buf.Bytes())
 }
 
 func (a *appGenerator) generateEmbeddedSwaggerJSON(app *GenApp) error {


### PR DESCRIPTION
- The comment for the server main template says that main should only be
  overwritten if an `--include-main` flag is passed to `swagger
  generate`.  This adds that flag and enforces it.

Fixes https://github.com/go-swagger/go-swagger/issues/210
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/casualjim%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/456109%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/go-swagger/go-swagger/pull/211%23issuecomment-171517110%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-01-14T03%3A10%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/456109%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/casualjim%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/go-swagger/go-swagger/pull/211%23issuecomment-171517110%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/casualjim'><img src='https://avatars.githubusercontent.com/u/456109?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/go-swagger/go-swagger/pull/211?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/go-swagger/go-swagger/pull/211?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/go-swagger/go-swagger/pull/211'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>