### PR TITLE
Fixes #263.

### DIFF
--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -121,7 +121,11 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
   var res []error
   {{ if .HasQueryParams }}qs := httpkit.Values(r.URL.Query())
   {{ else if .HasFormParams }}if err := r.ParseMultipartForm(32 << 20); err != nil {
-		return err
+		if err != http.ErrNotMultiPart {
+            return err
+        } else if err := r.ParseForm(); err != nil {
+            return err
+        }
 	}
 	fds := httpkit.Values(r.Form)
   {{ end }}

--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -120,11 +120,17 @@ type {{ pascalize .Name }}Params struct {
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Request, route *middleware.MatchedRoute) error {
   var res []error
   {{ if .HasQueryParams }}qs := httpkit.Values(r.URL.Query())
-  {{ else if .HasFormParams }}if err := r.ParseMultipartForm(32 << 20); err != nil {
-		return err
-	}
-	fds := httpkit.Values(r.Form)
-  {{ end }}
+  {{ else if .HasFormParams }}if r.Header.Get("Content-Type") == "multipart/form-data" {
+    if err := r.ParseMultipartForm(32 << 20); err != nil {
+ 		return err
+ 	}
+  } else {
+    if err := r.ParseForm(); err != nil {
+        return err
+    }
+  }
+  	fds := httpkit.Values(r.Form)
+
 
   {{ range .Params }}
   {{ if not .IsArray }}{{ if .IsQueryParam }}q{{ pascalize .Name }}, qhk{{ pascalize .Name }}, _ := qs.GetOK({{ .Path }})

--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -120,17 +120,11 @@ type {{ pascalize .Name }}Params struct {
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Request, route *middleware.MatchedRoute) error {
   var res []error
   {{ if .HasQueryParams }}qs := httpkit.Values(r.URL.Query())
-  {{ else if .HasFormParams }}if r.Header.Get("Content-Type") == "multipart/form-data" {
-    if err := r.ParseMultipartForm(32 << 20); err != nil {
- 		return err
- 	}
-  } else {
-    if err := r.ParseForm(); err != nil {
-        return err
-    }
-  }
-  	fds := httpkit.Values(r.Form)
-
+  {{ else if .HasFormParams }}if err := r.ParseMultipartForm(32 << 20); err != nil {
+		return err
+	}
+	fds := httpkit.Values(r.Form)
+  {{ end }}
 
   {{ range .Params }}
   {{ if not .IsArray }}{{ if .IsQueryParam }}q{{ pascalize .Name }}, qhk{{ pascalize .Name }}, _ := qs.GetOK({{ .Path }})

--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -121,7 +121,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
   var res []error
   {{ if .HasQueryParams }}qs := httpkit.Values(r.URL.Query())
   {{ else if .HasFormParams }}if err := r.ParseMultipartForm(32 << 20); err != nil {
-		if err != http.ErrNotMultiPart {
+		if err != http.ErrNotMultipart {
             return err
         } else if err := r.ParseForm(); err != nil {
             return err


### PR DESCRIPTION
request.ParseMultipartForm will return an error if the Content-Type is wrong. If the Content-Type is not a multipart this will just call ParseForm instead.