### PR TITLE
scan: strip only special chars that are used in annotations

### DIFF
--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -441,7 +441,7 @@ func (st *sectionedParser) cleanup(lines []string) []string {
 	var lastContent int
 	var uncommented []string
 	for i, v := range lines {
-		str := regexp.MustCompile("^[^\\p{L}\\p{N}\\+]*").ReplaceAllString(v, "")
+		str := regexp.MustCompile(`^[\s/\*-]*`).ReplaceAllString(v, "")
 		uncommented = append(uncommented, str)
 		if str != "" {
 			if seenLine < 0 {

--- a/scan/scanner_test.go
+++ b/scan/scanner_test.go
@@ -377,6 +377,17 @@ For go it will still make a difference though.
 The punctuation here does indeed matter. But it won't for go.
 `
 
+	text3 := `This has a title, and markdown in the description
+
+See how markdown works now, we can have lists:
+
++ first item
++ second item
++ third item
+
+[Links works too](http://localhost)
+`
+
 	st := &sectionedParser{}
 	st.setTitle = func(lines []string) {}
 	st.Parse(ascg(text))
@@ -390,6 +401,13 @@ The punctuation here does indeed matter. But it won't for go.
 
 	assert.EqualValues(t, []string{"This has a title without whitespace."}, st.Title())
 	assert.EqualValues(t, []string{"The punctuation here does indeed matter. But it won't for go."}, st.Description())
+
+	st = &sectionedParser{}
+	st.setTitle = func(lines []string) {}
+	st.Parse(ascg(text3))
+
+	assert.EqualValues(t, []string{"This has a title, and markdown in the description"}, st.Title())
+	assert.EqualValues(t, []string{"See how markdown works now, we can have lists:", "", "+ first item", "+ second item", "+ third item", "", "[Links works too](http://localhost)"}, st.Description())
 }
 
 func dummyBuilder() schemaValidations {


### PR DESCRIPTION
Any feedback is appreciated, and please let me know if special mark-up is not supposed to work.

Fixes #276.