### PR TITLE
Preserve trailing slash in URL path in runtime

### DIFF
--- a/httpkit/client/runtime.go
+++ b/httpkit/client/runtime.go
@@ -135,7 +135,14 @@ func (r *Runtime) Submit(operation *client.Operation) (interface{}, error) {
 	}
 	req.URL.Scheme = r.pickScheme(operation.Schemes)
 	req.URL.Host = r.Host
+	var reinstateSlash bool
+	if req.URL.Path != "" && req.URL.Path[len(req.URL.Path)-1] == '/' {
+		reinstateSlash = true
+	}
 	req.URL.Path = path.Join(r.BasePath, req.URL.Path)
+	if reinstateSlash {
+		req.URL.Path = req.URL.Path + "/"
+	}
 
 	r.clientOnce.Do(func() {
 		r.client = &http.Client{


### PR DESCRIPTION
Given a path like "/api/tasks/" the runtime uses `path.Join` to join the
base path to it which strips any trailing slash. If the path previously
ended with a trailing slash ("/"), it is reinstated after adding the
base path prefix because the behaviour of the server's path handling
cannot be guaranteed.

Fixes #289

Signed-off-by: Jonathan Ingram <jonathan.b.ingram@gmail.com>