### PR TITLE
fix file type parameter when the parameter is required

### DIFF
--- a/generator/templates/client/parameter.gotmpl
+++ b/generator/templates/client/parameter.gotmpl
@@ -83,12 +83,16 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) WriteToRequest(r client.
   }
   {{ else if .IsFormParam }}
   {{ if .IsFileParam }}
+  {{ if .IsNullable}}
   if {{ .ValueExpression }} != nil {
+  {{end}}
     // form file param {{ .Name }}
-    if err := r.SetFileParam({{ printf "%q" .Name }}, {{ .ValueExpression }}); err != nil {
+    if err := r.SetFileParam({{ printf "%q" .Name }}, {{ if not .IsNullable}}&{{end}}{{ .ValueExpression }}); err != nil {
       return err
     }
+  {{ if .IsNullable}}
   }
+  {{ end }}
   {{ else }}
   // form param {{ .Name }}
   {{ if .IsNullable }}var fr{{ pascalize .Name }} {{ .GoType }}


### PR DESCRIPTION
The generated code does not compile if a file parameter has the property "required": true.
For example:
`"parameters": [
    {
        "name": "file",
        "in": "formData",
        "description": "file to upload",
        "required": true,
        "type": "file"
    }
],
"consumes": [
    "multipart/form-data"
],`