### PR TITLE
fix missing httpkit import in models

### DIFF
--- a/generator/model.go
+++ b/generator/model.go
@@ -224,6 +224,7 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 	if pg.GenSchema.HasValidations {
 		defaultImports = []string{
 			"github.com/go-swagger/go-swagger/errors",
+			"github.com/go-swagger/go-swagger/httpkit",
 			"github.com/go-swagger/go-swagger/httpkit/validate",
 		}
 	}


### PR DESCRIPTION
Add the missing import:
github.com/go-swagger/go-swagger/httpkit

To fix #343 