### PR TITLE
Add plain text consumer and producer

### DIFF
--- a/generator/support.go
+++ b/generator/support.go
@@ -347,6 +347,7 @@ var knownProducers = map[string]string{
 	"json": "httpkit.JSONProducer",
 	"yaml": "httpkit.YAMLProducer",
 	"xml":  "httpkit.XMLProducer",
+	"txt":  "httpkit.TextProducer",
 	"bin":  "httpkit.ByteStreamProducer",
 }
 
@@ -354,6 +355,7 @@ var knownConsumers = map[string]string{
 	"json": "httpkit.JSONConsumer",
 	"yaml": "httpkit.YAMLConsumer",
 	"xml":  "httpkit.XMLConsumer",
+	"txt":  "httpkit.TextConsumer",
 	"bin":  "httpkit.ByteStreamConsumer",
 }
 

--- a/httpkit/client/runtime.go
+++ b/httpkit/client/runtime.go
@@ -67,10 +67,12 @@ func New(host, basePath string, schemes []string) *Runtime {
 	rt.Consumers = map[string]httpkit.Consumer{
 		httpkit.JSONMime: httpkit.JSONConsumer(),
 		httpkit.XMLMime:  httpkit.XMLConsumer(),
+		httpkit.TextMime: httpkit.TextConsumer(),
 	}
 	rt.Producers = map[string]httpkit.Producer{
 		httpkit.JSONMime: httpkit.JSONProducer(),
 		httpkit.XMLMime:  httpkit.XMLProducer(),
+		httpkit.TextMime: httpkit.TextProducer(),
 	}
 	rt.Transport = http.DefaultTransport
 	rt.Jar = nil

--- a/httpkit/constants.go
+++ b/httpkit/constants.go
@@ -34,6 +34,8 @@ const (
 	YAMLMime = "application/x-yaml"
 	// XMLMime the xml mime type
 	XMLMime = "application/xml"
+	// TextMime the text mime type
+	TextMime = "text/plain"
 	// MultipartFormMime the multipart form mime type
 	MultipartFormMime = "multipart/form-data"
 )

--- a/httpkit/text.go
+++ b/httpkit/text.go
@@ -1,0 +1,44 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpkit
+
+import (
+	"bytes"
+	"io"
+	"unsafe"
+)
+
+// TextConsumer creates a new text consumer
+func TextConsumer() Consumer {
+	return ConsumerFunc(func(reader io.Reader, data interface{}) error {
+		buf := new(bytes.Buffer)
+		_, err := buf.ReadFrom(reader)
+		if err != nil {
+			return err
+		}
+		b := buf.Bytes()
+		*(data.(*string)) = *(*string)(unsafe.Pointer(&b))
+		return nil
+	})
+}
+
+// TextProducer creates a new text producer
+func TextProducer() Producer {
+	return ProducerFunc(func(writer io.Writer, data interface{}) error {
+		buf := bytes.NewBufferString(data.(string))
+		_, err := buf.WriteTo(writer)
+		return err
+	})
+}

--- a/httpkit/text_test.go
+++ b/httpkit/text_test.go
@@ -1,0 +1,41 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpkit
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var consProdText = `The quick brown fox jumped over the lazy dog.`
+
+func TestTextConsumer(t *testing.T) {
+	cons := TextConsumer()
+	var data string
+	err := cons.Consume(bytes.NewBuffer([]byte(consProdText)), &data)
+	assert.NoError(t, err)
+	assert.Equal(t, consProdText, data)
+}
+
+func TestTextProducer(t *testing.T) {
+	prod := TextProducer()
+	rw := httptest.NewRecorder()
+	err := prod.Produce(rw, consProdText)
+	assert.NoError(t, err)
+	assert.Equal(t, consProdText, rw.Body.String())
+}


### PR DESCRIPTION
Add plain text consumer and producer and use it in client runtime and generator support. Fixes #360.