### PR TITLE
adds validation of reference path

### DIFF
--- a/fixtures/bugs/159/swagger.yml
+++ b/fixtures/bugs/159/swagger.yml
@@ -1,0 +1,21 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: 'Test'
+schemes:
+  - http
+produces:
+  - application/json
+  - "text/plain"
+consumes:
+  - application/json
+paths:
+  /foo:
+    get:
+      summary: Some endpoint
+      responses:
+        200:
+          description: Just successful something.
+          schema:
+            $ref: 'InvalidFoo'
+

--- a/spec/expander.go
+++ b/spec/expander.go
@@ -190,6 +190,7 @@ func (r *schemaLoader) resolveRef(currentRef, ref *Ref, node, target interface{}
 		return nil
 	}
 
+	// Fragment processing
 	if strings.HasPrefix(refURL.String(), "#") {
 		res, _, err := ref.GetPointer().Get(node)
 		if err != nil {
@@ -211,10 +212,12 @@ func (r *schemaLoader) resolveRef(currentRef, ref *Ref, node, target interface{}
 		return nil
 	}
 
-	if refURL.Scheme != "" && refURL.Host != "" {
-		// most definitely take the red pill
+	// Full remote URI processing
+	if (refURL.Scheme != "" && refURL.Host != "") || (refURL.Path != "") {
 		data, _, _, err := r.load(refURL)
-
+		if err != nil {
+			return err
+		}
 		if ((oldRef == nil && currentRef != nil) ||
 			(oldRef != nil && currentRef == nil) ||
 			oldRef.String() != currentRef.String()) &&

--- a/validate/spec_test.go
+++ b/validate/spec_test.go
@@ -139,3 +139,16 @@ func TestIssue123(t *testing.T) {
 		assert.True(t, res.IsValid())
 	}
 }
+
+func TestIssue159(t *testing.T) {
+	fp := filepath.Join("..", "fixtures", "bugs", "159", "swagger.yml")
+
+	// as swagger spec
+	doc, err := spec.YAMLSpec(fp)
+	if assert.NoError(t, err) {
+		validator := intvalidate.NewSpecValidator(doc.Schema(), strfmt.Default)
+		res, _ := validator.Validate(doc)
+		assert.False(t, res.IsValid())
+		assert.EqualError(t, res.Errors[0], "open InvalidFoo: no such file or directory")
+	}
+}


### PR DESCRIPTION
According to JSON reference spec http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-02#section-4 reference must be represented by valid URI which is not only a "link" with schema, but also a path to local file.

This PR supports #159 