### PR TITLE
generate all models if name not specified

### DIFF
--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -23,7 +23,7 @@ import (
 // Model the generate model file command
 type Model struct {
 	shared
-	Name        []string `long:"name" short:"n" required:"true" description:"the model to generate"`
+	Name        []string `long:"name" short:"n" description:"the model to generate"`
 	NoValidator bool     `long:"skip-validator" description:"when present will not generate a model validator"`
 	NoStruct    bool     `long:"skip-struct" description:"when present will not generate the model struct"`
 	DumpData    bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`


### PR DESCRIPTION
In command `generate model ...`, It's not necessary to force `--name` as required. If we don't specify a name, it should generate all models.