### PR TITLE
Allow empty content-type when allowed list is empty

### DIFF
--- a/httpkit/middleware/validation.go
+++ b/httpkit/middleware/validation.go
@@ -58,6 +58,9 @@ func (ub untypedBinder) BindRequest(r *http.Request, route *MatchedRoute, consum
 
 // ContentType validates the content type of a request
 func validateContentType(allowed []string, actual string) *errors.Validation {
+	if len(allowed) == 0 {
+		return nil
+	}
 	mt, _, err := mime.ParseMediaType(actual)
 	if err != nil {
 		return errors.InvalidContentType(actual, allowed)


### PR DESCRIPTION
If allowed list is empty, it means it doesn't matter which content type it is.