### PR TITLE
Add *raw-stream mimetype mapping

### DIFF
--- a/generator/support.go
+++ b/generator/support.go
@@ -341,6 +341,7 @@ var mediaTypeNames = map[*regexp.Regexp]string{
 	regexp.MustCompile("application/.*tar"):          "tar",
 	regexp.MustCompile("application/.*gzip"):         "gzip",
 	regexp.MustCompile("application/.*gz"):           "gzip",
+	regexp.MustCompile("application/.*raw-stream"):   "bin",
 }
 
 var knownProducers = map[string]string{


### PR DESCRIPTION
Added a mapping for application/.*raw-stream to bin mapping for
mimetypes.  We have a specific vendor mimetype that ends in
raw-stream that we would like to get handle.  If this isn't there,
we can get a panic during runtime in some code generation.  If
the generated file restapi/operations/xxx_api.go refers to the
mimetype as the defaultConsumes or defaultProduces, our server
will panic.  Adding this resolves the panic.