### PR TITLE
Add a serve-ui command 

### DIFF
--- a/cmd/swagger/commands/serve_ui.go
+++ b/cmd/swagger/commands/serve_ui.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/go-swagger/go-swagger/spec"
+	"github.com/rs/cors"
+	"github.com/toqueteos/webbrowser"
+)
+
+//ServeUI Show given swagger spec in swagger-ui
+type ServeUI struct {
+}
+
+// Execute this command
+func (s *ServeUI) Execute(args []string) error {
+
+	if len(args) == 0 {
+		return errors.New("The serve-ui command requires the swagger document url to be specified")
+	}
+	swaggerDoc := args[0]
+	specDoc, err := spec.Load(swaggerDoc)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	serveUI(specDoc)
+	return nil
+}
+
+func serveUI(doc *spec.Document) error {
+
+	// parse the url and open in default browser
+	u, err := url.Parse("http://petstore.swagger.io/")
+	if err != nil {
+		return err
+	}
+	q := u.Query()
+	q.Add("url", "http://localhost:8080/swagger.json")
+	u.RawQuery = q.Encode()
+	webbrowser.Open(u.String())
+
+	// serve the swagger.json
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(doc.Raw()))
+	})
+
+	handler := cors.Default().Handler(mux)
+
+	http.ListenAndServe(":8080", handler)
+
+	return nil
+}

--- a/cmd/swagger/swagger.go
+++ b/cmd/swagger/swagger.go
@@ -39,6 +39,11 @@ It aims to represent the contract of your API with a language agnostic descripti
 		log.Fatal(err)
 	}
 
+	_, err = parser.AddCommand("serve-ui", "serve the swagger UI for a given swagger spec ", "serve the swagger UI for a given swagger spec", &commands.ServeUI{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	_, err = parser.AddCommand("init", "initialize a spec document", "initialize a swagger spec document", &commands.InitCmd{})
 	if err != nil {
 		log.Fatal(err)

--- a/vendor/github.com/rs/cors/LICENSE
+++ b/vendor/github.com/rs/cors/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014 Olivier Poitrey <rs@dailymotion.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/rs/cors/README.md
+++ b/vendor/github.com/rs/cors/README.md
@@ -1,0 +1,99 @@
+# Go CORS handler [![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/rs/cors) [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/cors/master/LICENSE) [![build](https://img.shields.io/travis/rs/cors.svg?style=flat)](https://travis-ci.org/rs/cors) [![Coverage](http://gocover.io/_badge/github.com/rs/cors)](http://gocover.io/github.com/rs/cors)
+
+CORS is a `net/http` handler implementing [Cross Origin Resource Sharing W3 specification](http://www.w3.org/TR/cors/) in Golang.
+
+## Getting Started
+
+After installing Go and setting up your [GOPATH](http://golang.org/doc/code.html#GOPATH), create your first `.go` file. We'll call it `server.go`.
+
+```go
+package main
+
+import (
+    "net/http"
+
+    "github.com/rs/cors"
+)
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        w.Write([]byte("{\"hello\": \"world\"}"))
+    })
+
+    // cors.Default() setup the middleware with default options being
+    // all origins accepted with simple methods (GET, POST). See
+    // documentation below for more options.
+    handler := cors.Default().Handler(mux)
+    http.ListenAndServe(":8080", handler)
+}
+```
+
+Install `cors`:
+
+    go get github.com/rs/cors
+
+Then run your server:
+
+    go run server.go
+
+The server now runs on `localhost:8080`:
+
+    $ curl -D - -H 'Origin: http://foo.com' http://localhost:8080/
+    HTTP/1.1 200 OK
+    Access-Control-Allow-Origin: foo.com
+    Content-Type: application/json
+    Date: Sat, 25 Oct 2014 03:43:57 GMT
+    Content-Length: 18
+
+    {"hello": "world"}
+
+### More Examples
+
+* `net/http`: [examples/nethttp/server.go](https://github.com/rs/cors/blob/master/examples/nethttp/server.go)
+* [Goji](https://goji.io): [examples/goji/server.go](https://github.com/rs/cors/blob/master/examples/goji/server.go)
+* [Martini](http://martini.codegangsta.io): [examples/martini/server.go](https://github.com/rs/cors/blob/master/examples/martini/server.go)
+* [Negroni](https://github.com/codegangsta/negroni): [examples/negroni/server.go](https://github.com/rs/cors/blob/master/examples/negroni/server.go)
+* [Alice](https://github.com/justinas/alice): [examples/alice/server.go](https://github.com/rs/cors/blob/master/examples/alice/server.go)
+
+## Parameters
+
+Parameters are passed to the middleware thru the `cors.New` method as follow:
+
+```go
+c := cors.New(cors.Options{
+    AllowedOrigins: []string{"http://foo.com"},
+    AllowCredentials: true,
+})
+
+// Insert the middleware
+handler = c.Handler(handler)
+```
+
+* **AllowedOrigins** `[]string`: A list of origins a cross-domain request can be executed from. If the special `*` value is present in the list, all origins will be allowed. An origin may contain a wildcard (`*`) to replace 0 or more characters (i.e.: `http://*.domain.com`). Usage of wildcards implies a small performance penality. Only one wildcard can be used per origin. The default value is `*`.
+* **AllowOriginFunc** `func (origin string) bool`: A custom function to validate the origin. It take the origin as argument and returns true if allowed or false otherwise. If this option is set, the content of `AllowedOrigins` is ignored
+* **AllowedMethods** `[]string`: A list of methods the client is allowed to use with cross-domain requests. Default value is simple methods (`GET` and `POST`).
+* **AllowedHeaders** `[]string`: A list of non simple headers the client is allowed to use with cross-domain requests.
+* **ExposedHeaders** `[]string`: Indicates which headers are safe to expose to the API of a CORS API specification
+* **AllowCredentials** `bool`: Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates. The default is `false`.
+* **MaxAge** `int`: Indicates how long (in seconds) the results of a preflight request can be cached. The default is `0` which stands for no max age.
+* **OptionsPassthrough** `bool`: Instructs preflight to let other potential next handlers to process the `OPTIONS` method. Turn this on if your application handles `OPTIONS`.
+* **Debug** `bool`: Debugging flag adds additional output to debug server side CORS issues.
+
+See [API documentation](http://godoc.org/github.com/rs/cors) for more info.
+
+## Benchmarks
+
+    BenchmarkWithout          20000000    64.6 ns/op      8 B/op    1 allocs/op
+    BenchmarkDefault          3000000      469 ns/op    114 B/op    2 allocs/op
+    BenchmarkAllowedOrigin    3000000      608 ns/op    114 B/op    2 allocs/op
+    BenchmarkPreflight        20000000    73.2 ns/op      0 B/op    0 allocs/op
+    BenchmarkPreflightHeader  20000000    73.6 ns/op      0 B/op    0 allocs/op
+    BenchmarkParseHeaderList  2000000      847 ns/op    184 B/op    6 allocs/op
+    BenchmarkParse…Single     5000000      290 ns/op     32 B/op    3 allocs/op
+    BenchmarkParse…Normalized 2000000      776 ns/op    160 B/op    6 allocs/op
+
+## Licenses
+
+All source code is licensed under the [MIT License](https://raw.github.com/rs/cors/master/LICENSE).

--- a/vendor/github.com/rs/cors/bench_test.go
+++ b/vendor/github.com/rs/cors/bench_test.go
@@ -1,0 +1,88 @@
+package cors
+
+import (
+	"net/http"
+	"testing"
+)
+
+type FakeResponse struct {
+	header http.Header
+}
+
+func (r FakeResponse) Header() http.Header {
+	return r.header
+}
+
+func (r FakeResponse) WriteHeader(n int) {
+}
+
+func (r FakeResponse) Write(b []byte) (n int, err error) {
+	return len(b), nil
+}
+
+func BenchmarkWithout(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		testHandler.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkDefault(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "somedomain.com")
+	handler := Default().Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkAllowedOrigin(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "somedomain.com")
+	c := New(Options{
+		AllowedOrigins: []string{"somedomain.com"},
+	})
+	handler := c.Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkPreflight(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	handler := Default().Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkPreflightHeader(b *testing.B) {
+	res := FakeResponse{http.Header{}}
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	req.Header.Add("Access-Control-Request-Headers", "Accept")
+	handler := Default().Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(res, req)
+	}
+}

--- a/vendor/github.com/rs/cors/cors.go
+++ b/vendor/github.com/rs/cors/cors.go
@@ -1,0 +1,406 @@
+/*
+Package cors is net/http handler to handle CORS related requests
+as defined by http://www.w3.org/TR/cors/
+
+You can configure it by passing an option struct to cors.New:
+
+    c := cors.New(cors.Options{
+        AllowedOrigins: []string{"foo.com"},
+        AllowedMethods: []string{"GET", "POST", "DELETE"},
+        AllowCredentials: true,
+    })
+
+Then insert the handler in the chain:
+
+    handler = c.Handler(handler)
+
+See Options documentation for more options.
+
+The resulting handler is a standard net/http handler.
+*/
+package cors
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/rs/xhandler"
+	"golang.org/x/net/context"
+)
+
+// Options is a configuration container to setup the CORS middleware.
+type Options struct {
+	// AllowedOrigins is a list of origins a cross-domain request can be executed from.
+	// If the special "*" value is present in the list, all origins will be allowed.
+	// An origin may contain a wildcard (*) to replace 0 or more characters
+	// (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penality.
+	// Only one wildcard can be used per origin.
+	// Default value is ["*"]
+	AllowedOrigins []string
+	// AllowOriginFunc is a custom function to validate the origin. It take the origin
+	// as argument and returns true if allowed or false otherwise. If this option is
+	// set, the content of AllowedOrigins is ignored.
+	AllowOriginFunc func(origin string) bool
+	// AllowedMethods is a list of methods the client is allowed to use with
+	// cross-domain requests. Default value is simple methods (GET and POST)
+	AllowedMethods []string
+	// AllowedHeaders is list of non simple headers the client is allowed to use with
+	// cross-domain requests.
+	// If the special "*" value is present in the list, all headers will be allowed.
+	// Default value is [] but "Origin" is always appended to the list.
+	AllowedHeaders []string
+	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
+	// API specification
+	ExposedHeaders []string
+	// AllowCredentials indicates whether the request can include user credentials like
+	// cookies, HTTP authentication or client side SSL certificates.
+	AllowCredentials bool
+	// MaxAge indicates how long (in seconds) the results of a preflight request
+	// can be cached
+	MaxAge int
+	// OptionsPassthrough instructs preflight to let other potential next handlers to
+	// process the OPTIONS method. Turn this on if your application handles OPTIONS.
+	OptionsPassthrough bool
+	// Debugging flag adds additional output to debug server side CORS issues
+	Debug bool
+}
+
+// Cors http handler
+type Cors struct {
+	// Debug logger
+	Log *log.Logger
+	// Set to true when allowed origins contains a "*"
+	allowedOriginsAll bool
+	// Normalized list of plain allowed origins
+	allowedOrigins []string
+	// List of allowed origins containing wildcards
+	allowedWOrigins []wildcard
+	// Optional origin validator function
+	allowOriginFunc func(origin string) bool
+	// Set to true when allowed headers contains a "*"
+	allowedHeadersAll bool
+	// Normalized list of allowed headers
+	allowedHeaders []string
+	// Normalized list of allowed methods
+	allowedMethods []string
+	// Normalized list of exposed headers
+	exposedHeaders    []string
+	allowCredentials  bool
+	maxAge            int
+	optionPassthrough bool
+}
+
+// New creates a new Cors handler with the provided options.
+func New(options Options) *Cors {
+	c := &Cors{
+		exposedHeaders:    convert(options.ExposedHeaders, http.CanonicalHeaderKey),
+		allowOriginFunc:   options.AllowOriginFunc,
+		allowCredentials:  options.AllowCredentials,
+		maxAge:            options.MaxAge,
+		optionPassthrough: options.OptionsPassthrough,
+	}
+	if options.Debug {
+		c.Log = log.New(os.Stdout, "[cors] ", log.LstdFlags)
+	}
+
+	// Normalize options
+	// Note: for origins and methods matching, the spec requires a case-sensitive matching.
+	// As it may error prone, we chose to ignore the spec here.
+
+	// Allowed Origins
+	if len(options.AllowedOrigins) == 0 {
+		// Default is all origins
+		c.allowedOriginsAll = true
+	} else {
+		c.allowedOrigins = []string{}
+		c.allowedWOrigins = []wildcard{}
+		for _, origin := range options.AllowedOrigins {
+			// Normalize
+			origin = strings.ToLower(origin)
+			if origin == "*" {
+				// If "*" is present in the list, turn the whole list into a match all
+				c.allowedOriginsAll = true
+				c.allowedOrigins = nil
+				c.allowedWOrigins = nil
+				break
+			} else if i := strings.IndexByte(origin, '*'); i >= 0 {
+				// Split the origin in two: start and end string without the *
+				w := wildcard{origin[0:i], origin[i+1 : len(origin)]}
+				c.allowedWOrigins = append(c.allowedWOrigins, w)
+			} else {
+				c.allowedOrigins = append(c.allowedOrigins, origin)
+			}
+		}
+	}
+
+	// Allowed Headers
+	if len(options.AllowedHeaders) == 0 {
+		// Use sensible defaults
+		c.allowedHeaders = []string{"Origin", "Accept", "Content-Type"}
+	} else {
+		// Origin is always appended as some browsers will always request for this header at preflight
+		c.allowedHeaders = convert(append(options.AllowedHeaders, "Origin"), http.CanonicalHeaderKey)
+		for _, h := range options.AllowedHeaders {
+			if h == "*" {
+				c.allowedHeadersAll = true
+				c.allowedHeaders = nil
+				break
+			}
+		}
+	}
+
+	// Allowed Methods
+	if len(options.AllowedMethods) == 0 {
+		// Default is spec's "simple" methods
+		c.allowedMethods = []string{"GET", "POST"}
+	} else {
+		c.allowedMethods = convert(options.AllowedMethods, strings.ToUpper)
+	}
+
+	return c
+}
+
+// Default creates a new Cors handler with default options
+func Default() *Cors {
+	return New(Options{})
+}
+
+// Handler apply the CORS specification on the request, and add relevant CORS headers
+// as necessary.
+func (c *Cors) Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "OPTIONS" {
+			c.logf("Handler: Preflight request")
+			c.handlePreflight(w, r)
+			// Preflight requests are standalone and should stop the chain as some other
+			// middleware may not handle OPTIONS requests correctly. One typical example
+			// is authentication middleware ; OPTIONS requests won't carry authentication
+			// headers (see #1)
+			if c.optionPassthrough {
+				h.ServeHTTP(w, r)
+			}
+		} else {
+			c.logf("Handler: Actual request")
+			c.handleActualRequest(w, r)
+			h.ServeHTTP(w, r)
+		}
+	})
+}
+
+// HandlerC is net/context aware handler
+func (c *Cors) HandlerC(h xhandler.HandlerC) xhandler.HandlerC {
+	return xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		if r.Method == "OPTIONS" {
+			c.logf("Handler: Preflight request")
+			c.handlePreflight(w, r)
+			// Preflight requests are standalone and should stop the chain as some other
+			// middleware may not handle OPTIONS requests correctly. One typical example
+			// is authentication middleware ; OPTIONS requests won't carry authentication
+			// headers (see #1)
+			if c.optionPassthrough {
+				h.ServeHTTPC(ctx, w, r)
+			}
+		} else {
+			c.logf("Handler: Actual request")
+			c.handleActualRequest(w, r)
+			h.ServeHTTPC(ctx, w, r)
+		}
+	})
+}
+
+// HandlerFunc provides Martini compatible handler
+func (c *Cors) HandlerFunc(w http.ResponseWriter, r *http.Request) {
+	if r.Method == "OPTIONS" {
+		c.logf("HandlerFunc: Preflight request")
+		c.handlePreflight(w, r)
+	} else {
+		c.logf("HandlerFunc: Actual request")
+		c.handleActualRequest(w, r)
+	}
+}
+
+// Negroni compatible interface
+func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if r.Method == "OPTIONS" {
+		c.logf("ServeHTTP: Preflight request")
+		c.handlePreflight(w, r)
+		// Preflight requests are standalone and should stop the chain as some other
+		// middleware may not handle OPTIONS requests correctly. One typical example
+		// is authentication middleware ; OPTIONS requests won't carry authentication
+		// headers (see #1)
+		if c.optionPassthrough {
+			next(w, r)
+		}
+	} else {
+		c.logf("ServeHTTP: Actual request")
+		c.handleActualRequest(w, r)
+		next(w, r)
+	}
+}
+
+// handlePreflight handles pre-flight CORS requests
+func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
+	headers := w.Header()
+	origin := r.Header.Get("Origin")
+
+	if r.Method != "OPTIONS" {
+		c.logf("  Preflight aborted: %s!=OPTIONS", r.Method)
+		return
+	}
+	// Always set Vary headers
+	// see https://github.com/rs/cors/issues/10,
+	//     https://github.com/rs/cors/commit/dbdca4d95feaa7511a46e6f1efb3b3aa505bc43f#commitcomment-12352001
+	headers.Add("Vary", "Origin")
+	headers.Add("Vary", "Access-Control-Request-Method")
+	headers.Add("Vary", "Access-Control-Request-Headers")
+
+	if origin == "" {
+		c.logf("  Preflight aborted: empty origin")
+		return
+	}
+	if !c.isOriginAllowed(origin) {
+		c.logf("  Preflight aborted: origin '%s' not allowed", origin)
+		return
+	}
+
+	reqMethod := r.Header.Get("Access-Control-Request-Method")
+	if !c.isMethodAllowed(reqMethod) {
+		c.logf("  Preflight aborted: method '%s' not allowed", reqMethod)
+		return
+	}
+	reqHeaders := parseHeaderList(r.Header.Get("Access-Control-Request-Headers"))
+	if !c.areHeadersAllowed(reqHeaders) {
+		c.logf("  Preflight aborted: headers '%v' not allowed", reqHeaders)
+		return
+	}
+	headers.Set("Access-Control-Allow-Origin", origin)
+	// Spec says: Since the list of methods can be unbounded, simply returning the method indicated
+	// by Access-Control-Request-Method (if supported) can be enough
+	headers.Set("Access-Control-Allow-Methods", strings.ToUpper(reqMethod))
+	if len(reqHeaders) > 0 {
+
+		// Spec says: Since the list of headers can be unbounded, simply returning supported headers
+		// from Access-Control-Request-Headers can be enough
+		headers.Set("Access-Control-Allow-Headers", strings.Join(reqHeaders, ", "))
+	}
+	if c.allowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	if c.maxAge > 0 {
+		headers.Set("Access-Control-Max-Age", strconv.Itoa(c.maxAge))
+	}
+	c.logf("  Preflight response headers: %v", headers)
+}
+
+// handleActualRequest handles simple cross-origin requests, actual request or redirects
+func (c *Cors) handleActualRequest(w http.ResponseWriter, r *http.Request) {
+	headers := w.Header()
+	origin := r.Header.Get("Origin")
+
+	if r.Method == "OPTIONS" {
+		c.logf("  Actual request no headers added: method == %s", r.Method)
+		return
+	}
+	// Always set Vary, see https://github.com/rs/cors/issues/10
+	headers.Add("Vary", "Origin")
+	if origin == "" {
+		c.logf("  Actual request no headers added: missing origin")
+		return
+	}
+	if !c.isOriginAllowed(origin) {
+		c.logf("  Actual request no headers added: origin '%s' not allowed", origin)
+		return
+	}
+
+	// Note that spec does define a way to specifically disallow a simple method like GET or
+	// POST. Access-Control-Allow-Methods is only used for pre-flight requests and the
+	// spec doesn't instruct to check the allowed methods for simple cross-origin requests.
+	// We think it's a nice feature to be able to have control on those methods though.
+	if !c.isMethodAllowed(r.Method) {
+		c.logf("  Actual request no headers added: method '%s' not allowed", r.Method)
+
+		return
+	}
+	headers.Set("Access-Control-Allow-Origin", origin)
+	if len(c.exposedHeaders) > 0 {
+		headers.Set("Access-Control-Expose-Headers", strings.Join(c.exposedHeaders, ", "))
+	}
+	if c.allowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	c.logf("  Actual response added headers: %v", headers)
+}
+
+// convenience method. checks if debugging is turned on before printing
+func (c *Cors) logf(format string, a ...interface{}) {
+	if c.Log != nil {
+		c.Log.Printf(format, a...)
+	}
+}
+
+// isOriginAllowed checks if a given origin is allowed to perform cross-domain requests
+// on the endpoint
+func (c *Cors) isOriginAllowed(origin string) bool {
+	if c.allowOriginFunc != nil {
+		return c.allowOriginFunc(origin)
+	}
+	if c.allowedOriginsAll {
+		return true
+	}
+	origin = strings.ToLower(origin)
+	for _, o := range c.allowedOrigins {
+		if o == origin {
+			return true
+		}
+	}
+	for _, w := range c.allowedWOrigins {
+		if w.match(origin) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMethodAllowed checks if a given method can be used as part of a cross-domain request
+// on the endpoing
+func (c *Cors) isMethodAllowed(method string) bool {
+	if len(c.allowedMethods) == 0 {
+		// If no method allowed, always return false, even for preflight request
+		return false
+	}
+	method = strings.ToUpper(method)
+	if method == "OPTIONS" {
+		// Always allow preflight requests
+		return true
+	}
+	for _, m := range c.allowedMethods {
+		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// areHeadersAllowed checks if a given list of headers are allowed to used within
+// a cross-domain request.
+func (c *Cors) areHeadersAllowed(requestedHeaders []string) bool {
+	if c.allowedHeadersAll || len(requestedHeaders) == 0 {
+		return true
+	}
+	for _, header := range requestedHeaders {
+		header = http.CanonicalHeaderKey(header)
+		found := false
+		for _, h := range c.allowedHeaders {
+			if h == header {
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/rs/cors/cors_test.go
+++ b/vendor/github.com/rs/cors/cors_test.go
@@ -1,0 +1,688 @@
+package cors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("bar"))
+})
+
+func assertHeaders(t *testing.T, resHeaders http.Header, reqHeaders map[string]string) {
+	for name, value := range reqHeaders {
+		if actual := strings.Join(resHeaders[name], ", "); actual != value {
+			t.Errorf("Invalid header `%s', wanted `%s', got `%s'", name, value, actual)
+		}
+	}
+}
+
+func TestNoConfig(t *testing.T) {
+	s := New(Options{
+	// Intentionally left blank.
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestMatchAllOrigin(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"*"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestAllowedOrigin(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestWildcardOrigin(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://*.bar.com"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foo.bar.com")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "http://foo.bar.com",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestDisallowedOrigin(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://barbaz.com")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestDisallowedWildcardOrigin(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://*.bar.com"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foo.baz.com")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestAllowedOriginFunc(t *testing.T) {
+	r, _ := regexp.Compile("^http://foo")
+	s := New(Options{
+		AllowOriginFunc: func(o string) bool {
+			return r.MatchString(o)
+		},
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	res := httptest.NewRecorder()
+	req.Header.Set("Origin", "http://foobar.com")
+	s.Handler(testHandler).ServeHTTP(res, req)
+	assertHeaders(t, res.Header(), map[string]string{
+		"Access-Control-Allow-Origin": "http://foobar.com",
+	})
+
+	res = httptest.NewRecorder()
+	req.Header.Set("Origin", "http://barfoo.com")
+	s.Handler(testHandler).ServeHTTP(res, req)
+	assertHeaders(t, res.Header(), map[string]string{
+		"Access-Control-Allow-Origin": "",
+	})
+}
+
+func TestMaxAge(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://example.com/"},
+		AllowedMethods: []string{"GET"},
+		MaxAge:         10,
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+	req.Header.Add("Access-Control-Request-Method", "GET")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "http://example.com/",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "10",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestAllowedMethod(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+		AllowedMethods: []string{"PUT", "DELETE"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+	req.Header.Add("Access-Control-Request-Method", "PUT")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "PUT",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestDisallowedMethod(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+		AllowedMethods: []string{"PUT", "DELETE"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+	req.Header.Add("Access-Control-Request-Method", "PATCH")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestAllowedHeader(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+		AllowedHeaders: []string{"X-Header-1", "x-header-2"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	req.Header.Add("Access-Control-Request-Headers", "X-Header-2, X-HEADER-1")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "GET",
+		"Access-Control-Allow-Headers":     "X-Header-2, X-Header-1",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestAllowedWildcardHeader(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+		AllowedHeaders: []string{"*"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	req.Header.Add("Access-Control-Request-Headers", "X-Header-2, X-HEADER-1")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "GET",
+		"Access-Control-Allow-Headers":     "X-Header-2, X-Header-1",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestDisallowedHeader(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+		AllowedHeaders: []string{"X-Header-1", "x-header-2"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	req.Header.Add("Access-Control-Request-Headers", "X-Header-3, X-Header-1")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestOriginHeader(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	req.Header.Add("Access-Control-Request-Headers", "origin")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "GET",
+		"Access-Control-Allow-Headers":     "Origin",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestExposedHeader(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+		ExposedHeaders: []string{"X-Header-1", "x-header-2"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "X-Header-1, X-Header-2",
+	})
+}
+
+func TestAllowedCredentials(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins:   []string{"http://foobar.com"},
+		AllowCredentials: true,
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+	req.Header.Add("Access-Control-Request-Method", "GET")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "GET",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestDebug(t *testing.T) {
+	s := New(Options{
+		Debug: true,
+	})
+
+	if s.logf == nil {
+		t.Error("Logger not created when debug=true")
+	}
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestOptionsPassthrough(t *testing.T) {
+	s := New(Options{
+		OptionsPassthrough: true,
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+
+}
+
+func TestDefault(t *testing.T) {
+	s := Default()
+	if s.Log != nil {
+		t.Error("c.log should be nil when Default")
+	}
+	if !s.allowedOriginsAll {
+		t.Error("c.allowedOriginsAll should be true when Default")
+	}
+	if s.allowedHeaders == nil {
+		t.Error("c.allowedHeaders should be nil when Default")
+	}
+	if s.allowedMethods == nil {
+		t.Error("c.allowedMethods should be nil when Default")
+	}
+}
+
+func TestHandlerFunc(t *testing.T) {
+	s := New(Options{
+	// Intentionally left blank.
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	s.HandlerFunc(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestHandlerFuncPreflight(t *testing.T) {
+	s := New(Options{
+	// Intentionally left blank.
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+
+	s.HandlerFunc(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+
+}
+
+func TestNegroniHandler(t *testing.T) {
+	s := New(Options{
+	// Intentionally left blank.
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	s.ServeHTTP(res, req, testHandler)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestNegroniHandlerPreflight(t *testing.T) {
+	s := New(Options{
+		OptionsPassthrough: true,
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+
+	s.ServeHTTP(res, req, testHandler)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestHandlePreflightInvlaidOriginAbortion(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handlePreflight(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestHandlePreflightNoOptionsAbortion(t *testing.T) {
+	s := New(Options{
+	// Intentionally left blank.
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+
+	s.handlePreflight(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestHandleActualRequestAbortsOptionsMethod(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handleActualRequest(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestHandleActualRequestInvlaidOriginAbortion(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handleActualRequest(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestHandleActualRequestAllowsCredentials(t *testing.T) {
+	s := New(Options{
+		AllowCredentials: true,
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handleActualRequest(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "http://example.com/",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestHandleActualRequestInvlaidMethodAbortion(t *testing.T) {
+	s := New(Options{
+		AllowedMethods:   []string{"POST"},
+		AllowCredentials: true,
+	})
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://example.com/")
+
+	s.handleActualRequest(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Vary": "Origin",
+		"Access-Control-Allow-Origin":      "",
+		"Access-Control-Allow-Methods":     "",
+		"Access-Control-Allow-Headers":     "",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
+func TestIsMethodAllowedReturnsFalseWithNoMethods(t *testing.T) {
+	s := New(Options{
+	// Intentionally left blank.
+	})
+	s.allowedMethods = []string{}
+	if s.isMethodAllowed("") {
+		t.Error("IsMethodAllowed should return false when c.allowedMethods is nil.")
+	}
+}
+
+func TestIsMethodAllowedReturnsTrueWithOptions(t *testing.T) {
+	s := New(Options{
+	// Intentionally left blank.
+	})
+	if !s.isMethodAllowed("OPTIONS") {
+		t.Error("IsMethodAllowed should return true when c.allowedMethods is nil.")
+	}
+}

--- a/vendor/github.com/rs/cors/examples/alice/server.go
+++ b/vendor/github.com/rs/cors/examples/alice/server.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/justinas/alice"
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	chain := alice.New(c.Handler).Then(mux)
+	http.ListenAndServe(":8080", chain)
+}

--- a/vendor/github.com/rs/cors/examples/default/server.go
+++ b/vendor/github.com/rs/cors/examples/default/server.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	// Use default options
+	handler := cors.Default().Handler(mux)
+	http.ListenAndServe(":8080", handler)
+}

--- a/vendor/github.com/rs/cors/examples/goji/server.go
+++ b/vendor/github.com/rs/cors/examples/goji/server.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+	"github.com/zenazn/goji"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+	goji.Use(c.Handler)
+
+	goji.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	goji.Serve()
+}

--- a/vendor/github.com/rs/cors/examples/martini/server.go
+++ b/vendor/github.com/rs/cors/examples/martini/server.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/go-martini/martini"
+	"github.com/martini-contrib/render"
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Use(c.HandlerFunc)
+
+	m.Get("/", func(r render.Render) {
+		r.JSON(200, map[string]interface{}{"hello": "world"})
+	})
+
+	m.Run()
+}

--- a/vendor/github.com/rs/cors/examples/negroni/server.go
+++ b/vendor/github.com/rs/cors/examples/negroni/server.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/codegangsta/negroni"
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	n := negroni.Classic()
+	n.Use(c)
+	n.UseHandler(mux)
+	n.Run(":3000")
+}

--- a/vendor/github.com/rs/cors/examples/nethttp/server.go
+++ b/vendor/github.com/rs/cors/examples/nethttp/server.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://foo.com"},
+	})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	http.ListenAndServe(":8080", c.Handler(handler))
+}

--- a/vendor/github.com/rs/cors/examples/openbar/server.go
+++ b/vendor/github.com/rs/cors/examples/openbar/server.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+func main() {
+	c := cors.New(cors.Options{
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE"},
+		AllowCredentials: true,
+	})
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})
+
+	http.ListenAndServe(":8080", c.Handler(h))
+}

--- a/vendor/github.com/rs/cors/examples/xhandler/server.go
+++ b/vendor/github.com/rs/cors/examples/xhandler/server.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+	"github.com/rs/xhandler"
+	"golang.org/x/net/context"
+)
+
+func main() {
+	c := xhandler.Chain{}
+
+	// Use default options
+	c.UseC(cors.Default().HandlerC)
+
+	mux := http.NewServeMux()
+	mux.Handle("/", c.Handler(xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"hello\": \"world\"}"))
+	})))
+
+	http.ListenAndServe(":8080", mux)
+}

--- a/vendor/github.com/rs/cors/utils.go
+++ b/vendor/github.com/rs/cors/utils.go
@@ -1,0 +1,70 @@
+package cors
+
+import "strings"
+
+const toLower = 'a' - 'A'
+
+type converter func(string) string
+
+type wildcard struct {
+	prefix string
+	suffix string
+}
+
+func (w wildcard) match(s string) bool {
+	return len(s) >= len(w.prefix+w.suffix) && strings.HasPrefix(s, w.prefix) && strings.HasSuffix(s, w.suffix)
+}
+
+// convert converts a list of string using the passed converter function
+func convert(s []string, c converter) []string {
+	out := []string{}
+	for _, i := range s {
+		out = append(out, c(i))
+	}
+	return out
+}
+
+// parseHeaderList tokenize + normalize a string containing a list of headers
+func parseHeaderList(headerList string) []string {
+	l := len(headerList)
+	h := make([]byte, 0, l)
+	upper := true
+	// Estimate the number headers in order to allocate the right splice size
+	t := 0
+	for i := 0; i < l; i++ {
+		if headerList[i] == ',' {
+			t++
+		}
+	}
+	headers := make([]string, 0, t)
+	for i := 0; i < l; i++ {
+		b := headerList[i]
+		if b >= 'a' && b <= 'z' {
+			if upper {
+				h = append(h, b-toLower)
+			} else {
+				h = append(h, b)
+			}
+		} else if b >= 'A' && b <= 'Z' {
+			if !upper {
+				h = append(h, b+toLower)
+			} else {
+				h = append(h, b)
+			}
+		} else if b == '-' || (b >= '0' && b <= '9') {
+			h = append(h, b)
+		}
+
+		if b == ' ' || b == ',' || i == l-1 {
+			if len(h) > 0 {
+				// Flush the found header
+				headers = append(headers, string(h))
+				h = h[:0]
+				upper = true
+			}
+		} else {
+			upper = b == '-'
+		}
+	}
+	return headers
+}

--- a/vendor/github.com/rs/cors/utils_test.go
+++ b/vendor/github.com/rs/cors/utils_test.go
@@ -1,0 +1,70 @@
+package cors
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWildcard(t *testing.T) {
+	w := wildcard{"foo", "bar"}
+	if !w.match("foobar") {
+		t.Error("foo*bar should match foobar")
+	}
+	if !w.match("foobazbar") {
+		t.Error("foo*bar should match foobazbar")
+	}
+	if w.match("foobaz") {
+		t.Error("foo*bar should not match foobaz")
+	}
+
+	w = wildcard{"foo", "oof"}
+	if w.match("foof") {
+		t.Error("foo*oof should not match foof")
+	}
+}
+
+func TestConvert(t *testing.T) {
+	s := convert([]string{"A", "b", "C"}, strings.ToLower)
+	e := []string{"a", "b", "c"}
+	if s[0] != e[0] || s[1] != e[1] || s[2] != e[2] {
+		t.Errorf("%v != %v", s, e)
+	}
+}
+
+func TestParseHeaderList(t *testing.T) {
+	h := parseHeaderList("header, second-header, THIRD-HEADER, Numb3r3d-H34d3r")
+	e := []string{"Header", "Second-Header", "Third-Header", "Numb3r3d-H34d3r"}
+	if h[0] != e[0] || h[1] != e[1] || h[2] != e[2] {
+		t.Errorf("%v != %v", h, e)
+	}
+}
+
+func TestParseHeaderListEmpty(t *testing.T) {
+	if len(parseHeaderList("")) != 0 {
+		t.Error("should be empty sclice")
+	}
+	if len(parseHeaderList(" , ")) != 0 {
+		t.Error("should be empty sclice")
+	}
+}
+
+func BenchmarkParseHeaderList(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseHeaderList("header, second-header, THIRD-HEADER")
+	}
+}
+
+func BenchmarkParseHeaderListSingle(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseHeaderList("header")
+	}
+}
+
+func BenchmarkParseHeaderListNormalized(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseHeaderList("Header1, Header2, Third-Header")
+	}
+}

--- a/vendor/github.com/rs/xhandler/LICENSE
+++ b/vendor/github.com/rs/xhandler/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Olivier Poitrey <rs@dailymotion.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/rs/xhandler/README.md
+++ b/vendor/github.com/rs/xhandler/README.md
@@ -1,0 +1,134 @@
+# XHandler
+
+[![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/rs/xhandler) [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/xhandler/master/LICENSE) [![Build Status](https://travis-ci.org/rs/xhandler.svg?branch=master)](https://travis-ci.org/rs/xhandler) [![Coverage](http://gocover.io/_badge/github.com/rs/xhandler)](http://gocover.io/github.com/rs/xhandler)
+
+XHandler is a bridge between [net/context](https://godoc.org/golang.org/x/net/context) and `http.Handler`.
+
+It lets you enforce `net/context` in your handlers without sacrificing compatibility with existing `http.Handlers` nor imposing a specific router.
+
+Thanks to `net/context` deadline management, `xhandler` is able to enforce a per request deadline and will cancel the context when the client closes the connection unexpectedly.
+
+You may create your own `net/context` aware handler pretty much the same way as you would do with http.Handler.
+
+Read more about xhandler on [Dailymotion engineering blog](http://engineering.dailymotion.com/our-way-to-go/).
+
+## Installing
+
+    go get -u github.com/rs/xhandler
+
+## Usage
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/rs/cors"
+	"github.com/rs/xhandler"
+	"golang.org/x/net/context"
+)
+
+type myMiddleware struct {
+	next xhandler.HandlerC
+}
+
+func (h myMiddleware) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	ctx = context.WithValue(ctx, "test", "World")
+	h.next.ServeHTTPC(ctx, w, r)
+}
+
+func main() {
+	c := xhandler.Chain{}
+
+	// Add close notifier handler so context is cancelled when the client closes
+	// the connection
+	c.UseC(xhandler.CloseHandler)
+
+	// Add timeout handler
+	c.UseC(xhandler.TimeoutHandler(2 * time.Second))
+
+	// Middleware putting something in the context
+	c.UseC(func(next xhandler.HandlerC) xhandler.HandlerC {
+		return myMiddleware{next: next}
+	})
+
+	// Mix it with a non-context-aware middleware handler
+	c.Use(cors.Default().Handler)
+
+	// Final handler (using handlerFuncC), reading from the context
+	xh := xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		value := ctx.Value("test").(string)
+		w.Write([]byte("Hello " + value))
+	})
+
+	// Bridge context aware handlers with http.Handler using xhandler.Handle()
+	http.Handle("/test", c.Handler(xh))
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+### Using xmux
+
+Xhandler comes with an optional context aware [muxer](https://github.com/rs/xmux) forked from [httprouter](https://github.com/julienschmidt/httprouter):
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/rs/xhandler"
+	"github.com/rs/xmux"
+	"golang.org/x/net/context"
+)
+
+func main() {
+	c := xhandler.Chain{}
+
+	// Append a context-aware middleware handler
+	c.UseC(xhandler.CloseHandler)
+
+	// Another context-aware middleware handler
+	c.UseC(xhandler.TimeoutHandler(2 * time.Second))
+
+	mux := xmux.New()
+
+	// Use c.Handler to terminate the chain with your final handler
+	mux.GET("/welcome/:name", xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "Welcome %s!", xmux.Params(ctx).Get("name"))
+	}))
+
+	if err := http.ListenAndServe(":8080", c.Handler(mux)); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+See [xmux](https://github.com/rs/xmux) for more examples.
+
+## Context Aware Middleware
+
+Here is a list of `net/context` aware middleware handlers implementing `xhandler.HandlerC` interface.
+
+Feel free to put up a PR linking your middleware if you have built one:
+
+| Middleware | Author | Description |
+| ---------- | ------ | ----------- |
+| [xmux](https://github.com/rs/xmux) | [Olivier Poitrey](https://github.com/rs) | HTTP request muxer |
+| [xlog](https://github.com/rs/xlog) | [Olivier Poitrey](https://github.com/rs) | HTTP handler logger |
+| [xstats](https://github.com/rs/xstats) | [Olivier Poitrey](https://github.com/rs) | A generic client for service instrumentation |
+| [xaccess](https://github.com/rs/xaccess) | [Olivier Poitrey](https://github.com/rs) | HTTP handler access logger with [xlog](https://github.com/rs/xlog) and [xstats](https://github.com/rs/xstats) |
+| [cors](https://github.com/rs/cors) | [Olivier Poitrey](https://github.com/rs) | [Cross Origin Resource Sharing](http://www.w3.org/TR/cors/) (CORS) support |
+
+## Licenses
+
+All source code is licensed under the [MIT License](https://raw.github.com/rs/xhandler/master/LICENSE).

--- a/vendor/github.com/rs/xhandler/chain.go
+++ b/vendor/github.com/rs/xhandler/chain.go
@@ -1,0 +1,93 @@
+package xhandler
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// Chain is an helper to chain middleware handlers together for an easier
+// management.
+type Chain []func(next HandlerC) HandlerC
+
+// UseC appends a context-aware handler to the middleware chain.
+func (c *Chain) UseC(f func(next HandlerC) HandlerC) {
+	*c = append(*c, f)
+}
+
+// Use appends a standard http.Handler to the middleware chain without
+// lossing track of the context when inserted between two context aware handlers.
+//
+// Caveat: the f function will be called on each request so you are better to put
+// any initialization sequence outside of this function.
+func (c *Chain) Use(f func(next http.Handler) http.Handler) {
+	xf := func(next HandlerC) HandlerC {
+		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			n := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTPC(ctx, w, r)
+			})
+			f(n).ServeHTTP(w, r)
+		})
+	}
+	*c = append(*c, xf)
+}
+
+// Handler wraps the provided final handler with all the middleware appended to
+// the chain and return a new standard http.Handler instance.
+// The context.Background() context is injected automatically.
+func (c Chain) Handler(xh HandlerC) http.Handler {
+	ctx := context.Background()
+	return c.HandlerCtx(ctx, xh)
+}
+
+// HandlerFC is an helper to provide a function (HandlerFuncC) to Handler().
+//
+// HandlerFC is equivalent to:
+//  c.Handler(xhandler.HandlerFuncC(xhc))
+func (c Chain) HandlerFC(xhf HandlerFuncC) http.Handler {
+	ctx := context.Background()
+	return c.HandlerCtx(ctx, HandlerFuncC(xhf))
+}
+
+// HandlerH is an helper to provide a standard http handler (http.HandlerFunc)
+// to Handler(). Your final handler won't have access the context though.
+func (c Chain) HandlerH(h http.Handler) http.Handler {
+	ctx := context.Background()
+	return c.HandlerCtx(ctx, HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
+	}))
+}
+
+// HandlerF is an helper to provide a standard http handler function
+// (http.HandlerFunc) to Handler(). Your final handler won't have access
+// the context though.
+func (c Chain) HandlerF(hf http.HandlerFunc) http.Handler {
+	ctx := context.Background()
+	return c.HandlerCtx(ctx, HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		hf(w, r)
+	}))
+}
+
+// HandlerCtx wraps the provided final handler with all the middleware appended to
+// the chain and return a new standard http.Handler instance.
+func (c Chain) HandlerCtx(ctx context.Context, xh HandlerC) http.Handler {
+	return New(ctx, c.HandlerC(xh))
+}
+
+// HandlerC wraps the provided final handler with all the middleware appended to
+// the chain and returns a HandlerC instance.
+func (c Chain) HandlerC(xh HandlerC) HandlerC {
+	for i := len(c) - 1; i >= 0; i-- {
+		xh = c[i](xh)
+	}
+	return xh
+}
+
+// HandlerCF wraps the provided final handler func with all the middleware appended to
+// the chain and returns a HandlerC instance.
+//
+// HandlerCF is equivalent to:
+//  c.HandlerC(xhandler.HandlerFuncC(xhc))
+func (c Chain) HandlerCF(xhc HandlerFuncC) HandlerC {
+	return c.HandlerC(HandlerFuncC(xhc))
+}

--- a/vendor/github.com/rs/xhandler/chain_example_test.go
+++ b/vendor/github.com/rs/xhandler/chain_example_test.go
@@ -1,0 +1,52 @@
+package xhandler_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/cors"
+	"github.com/rs/xhandler"
+	"golang.org/x/net/context"
+)
+
+func ExampleChain() {
+	c := xhandler.Chain{}
+	// Append a context-aware middleware handler
+	c.UseC(xhandler.CloseHandler)
+
+	// Mix it with a non-context-aware middleware handler
+	c.Use(cors.Default().Handler)
+
+	// Another context-aware middleware handler
+	c.UseC(xhandler.TimeoutHandler(2 * time.Second))
+
+	mux := http.NewServeMux()
+
+	// Use c.Handler to terminate the chain with your final handler
+	mux.Handle("/", c.Handler(xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "Welcome to the home page!")
+	})))
+
+	// You can reuse the same chain for other handlers
+	mux.Handle("/api", c.Handler(xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "Welcome to the API!")
+	})))
+}
+
+func ExampleIf() {
+	c := xhandler.Chain{}
+
+	// Add timeout handler only if the path match a prefix
+	c.UseC(xhandler.If(
+		func(ctx context.Context, w http.ResponseWriter, r *http.Request) bool {
+			return strings.HasPrefix(r.URL.Path, "/with-timeout/")
+		},
+		xhandler.TimeoutHandler(2*time.Second),
+	))
+
+	http.Handle("/", c.Handler(xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "Welcome to the home page!")
+	})))
+}

--- a/vendor/github.com/rs/xhandler/chain_test.go
+++ b/vendor/github.com/rs/xhandler/chain_test.go
@@ -1,0 +1,112 @@
+package xhandler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+func TestAppendHandlerC(t *testing.T) {
+	init := 0
+	h1 := func(next HandlerC) HandlerC {
+		init++
+		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			ctx = context.WithValue(ctx, "test", 1)
+			next.ServeHTTPC(ctx, w, r)
+		})
+	}
+	h2 := func(next HandlerC) HandlerC {
+		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			ctx = context.WithValue(ctx, "test", 2)
+			next.ServeHTTPC(ctx, w, r)
+		})
+	}
+	c := Chain{}
+	c.UseC(h1)
+	c.UseC(h2)
+	assert.Len(t, c, 2)
+
+	h := c.Handler(HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		// Test ordering
+		assert.Equal(t, 2, ctx.Value("test"), "second handler should overwrite first handler's context value")
+	}))
+
+	h.ServeHTTP(nil, nil)
+	h.ServeHTTP(nil, nil)
+	assert.Equal(t, 1, init, "handler init called once")
+}
+
+func TestAppendHandler(t *testing.T) {
+	init := 0
+	h1 := func(next HandlerC) HandlerC {
+		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			ctx = context.WithValue(ctx, "test", 1)
+			next.ServeHTTPC(ctx, w, r)
+		})
+	}
+	h2 := func(next http.Handler) http.Handler {
+		init++
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Change r and w values
+			w = httptest.NewRecorder()
+			r = &http.Request{}
+			next.ServeHTTP(w, r)
+		})
+	}
+	c := Chain{}
+	c.UseC(h1)
+	c.Use(h2)
+	assert.Len(t, c, 2)
+
+	h := c.Handler(HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		// Test ordering
+		assert.Equal(t, 1, ctx.Value("test"),
+			"the first handler value should be pass through the second (non-aware) one")
+		// Test r and w overwrite
+		assert.NotNil(t, w)
+		assert.NotNil(t, r)
+	}))
+
+	h.ServeHTTP(nil, nil)
+	h.ServeHTTP(nil, nil)
+	// There's no safe way to not initialize non ctx aware handlers on each request :/
+	//assert.Equal(t, 1, init, "handler init called once")
+}
+
+func TestChainHandlerC(t *testing.T) {
+	handlerCalls := 0
+	h1 := func(next HandlerC) HandlerC {
+		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			handlerCalls++
+			ctx = context.WithValue(ctx, "test", 1)
+			next.ServeHTTPC(ctx, w, r)
+		})
+	}
+	h2 := func(next HandlerC) HandlerC {
+		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			handlerCalls++
+			ctx = context.WithValue(ctx, "test", 2)
+			next.ServeHTTPC(ctx, w, r)
+		})
+	}
+
+	c := Chain{}
+	c.UseC(h1)
+	c.UseC(h2)
+	h := c.HandlerC(HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		handlerCalls++
+
+		assert.Equal(t, 2, ctx.Value("test"),
+			"second handler should overwrite first handler's context value")
+		assert.Equal(t, 1, ctx.Value("mainCtx"),
+			"the mainCtx value should be pass through")
+	}))
+
+	mainCtx := context.WithValue(context.Background(), "mainCtx", 1)
+	h.ServeHTTPC(mainCtx, nil, nil)
+
+	assert.Equal(t, 3, handlerCalls, "all handler called once")
+}

--- a/vendor/github.com/rs/xhandler/middleware.go
+++ b/vendor/github.com/rs/xhandler/middleware.go
@@ -1,0 +1,59 @@
+package xhandler
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// CloseHandler returns a Handler cancelling the context when the client
+// connection close unexpectedly.
+func CloseHandler(next HandlerC) HandlerC {
+	return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		// Cancel the context if the client closes the connection
+		if wcn, ok := w.(http.CloseNotifier); ok {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithCancel(ctx)
+			defer cancel()
+
+			notify := wcn.CloseNotify()
+			go func() {
+				select {
+				case <-notify:
+					cancel()
+				case <-ctx.Done():
+				}
+			}()
+		}
+
+		next.ServeHTTPC(ctx, w, r)
+	})
+}
+
+// TimeoutHandler returns a Handler which adds a timeout to the context.
+//
+// Child handlers have the responsability to obey the context deadline and to return
+// an appropriate error (or not) response in case of timeout.
+func TimeoutHandler(timeout time.Duration) func(next HandlerC) HandlerC {
+	return func(next HandlerC) HandlerC {
+		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			ctx, _ = context.WithTimeout(ctx, timeout)
+			next.ServeHTTPC(ctx, w, r)
+		})
+	}
+}
+
+// If is a special handler that will skip insert the condNext handler only if a condition
+// applies at runtime.
+func If(cond func(ctx context.Context, w http.ResponseWriter, r *http.Request) bool, condNext func(next HandlerC) HandlerC) func(next HandlerC) HandlerC {
+	return func(next HandlerC) HandlerC {
+		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			if cond(ctx, w, r) {
+				condNext(next).ServeHTTPC(ctx, w, r)
+			} else {
+				next.ServeHTTPC(ctx, w, r)
+			}
+		})
+	}
+}

--- a/vendor/github.com/rs/xhandler/middleware_test.go
+++ b/vendor/github.com/rs/xhandler/middleware_test.go
@@ -1,0 +1,88 @@
+package xhandler
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+func TestTimeoutHandler(t *testing.T) {
+	ctx := context.WithValue(context.Background(), contextKey, "value")
+	xh := TimeoutHandler(time.Second)(&handler{})
+	h := New(ctx, xh)
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	h.ServeHTTP(w, r)
+	assert.Equal(t, "value with deadline", w.Body.String())
+}
+
+type closeNotifyWriter struct {
+	*httptest.ResponseRecorder
+	closed bool
+}
+
+func (w *closeNotifyWriter) CloseNotify() <-chan bool {
+	notify := make(chan bool, 1)
+	if w.closed {
+		// return an already "closed" notifier
+		notify <- true
+	}
+	return notify
+}
+
+func TestCloseHandlerClientClose(t *testing.T) {
+	ctx := context.WithValue(context.Background(), contextKey, "value")
+	xh := CloseHandler(&handler{})
+	h := New(ctx, xh)
+	w := &closeNotifyWriter{ResponseRecorder: httptest.NewRecorder(), closed: true}
+	r, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	h.ServeHTTP(w, r)
+	assert.Equal(t, "value canceled", w.Body.String())
+}
+
+func TestCloseHandlerRequestEnds(t *testing.T) {
+	ctx := context.WithValue(context.Background(), contextKey, "value")
+	xh := CloseHandler(&handler{})
+	h := New(ctx, xh)
+	w := &closeNotifyWriter{ResponseRecorder: httptest.NewRecorder(), closed: false}
+	r, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	h.ServeHTTP(w, r)
+	assert.Equal(t, "value", w.Body.String())
+}
+
+func TestIf(t *testing.T) {
+	trueHandler := HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/true", r.URL.Path)
+	})
+	falseHandler := HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		assert.NotEqual(t, "/true", r.URL.Path)
+	})
+	ctx := context.WithValue(context.Background(), contextKey, "value")
+	xh := If(
+		func(ctx context.Context, w http.ResponseWriter, r *http.Request) bool {
+			return r.URL.Path == "/true"
+		},
+		func(next HandlerC) HandlerC {
+			return trueHandler
+		},
+	)(falseHandler)
+	h := New(ctx, xh)
+	r, _ := http.NewRequest("GET", "http://example.com/true", nil)
+	h.ServeHTTP(nil, r)
+	r, _ = http.NewRequest("GET", "http://example.com/false", nil)
+	h.ServeHTTP(nil, r)
+}

--- a/vendor/github.com/rs/xhandler/xhandler.go
+++ b/vendor/github.com/rs/xhandler/xhandler.go
@@ -1,0 +1,42 @@
+// Package xhandler provides a bridge between http.Handler and net/context.
+//
+// xhandler enforces net/context in your handlers without sacrificing
+// compatibility with existing http.Handlers nor imposing a specific router.
+//
+// Thanks to net/context deadline management, xhandler is able to enforce
+// a per request deadline and will cancel the context in when the client close
+// the connection unexpectedly.
+//
+// You may create net/context aware middlewares pretty much the same way as
+// you would do with http.Handler.
+package xhandler // import "github.com/rs/xhandler"
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// HandlerC is a net/context aware http.Handler
+type HandlerC interface {
+	ServeHTTPC(context.Context, http.ResponseWriter, *http.Request)
+}
+
+// HandlerFuncC type is an adapter to allow the use of ordinary functions
+// as a xhandler.Handler. If f is a function with the appropriate signature,
+// xhandler.HandlerFuncC(f) is a xhandler.Handler object that calls f.
+type HandlerFuncC func(context.Context, http.ResponseWriter, *http.Request)
+
+// ServeHTTPC calls f(ctx, w, r).
+func (f HandlerFuncC) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	f(ctx, w, r)
+}
+
+// New creates a conventional http.Handler injecting the provided root
+// context to sub handlers. This handler is used as a bridge between conventional
+// http.Handler and context aware handlers.
+func New(ctx context.Context, h HandlerC) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTPC(ctx, w, r)
+	})
+}

--- a/vendor/github.com/rs/xhandler/xhandler_example_test.go
+++ b/vendor/github.com/rs/xhandler/xhandler_example_test.go
@@ -1,0 +1,67 @@
+package xhandler_test
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/rs/xhandler"
+	"golang.org/x/net/context"
+)
+
+type key int
+
+const contextKey key = 0
+
+func newContext(ctx context.Context, value string) context.Context {
+	return context.WithValue(ctx, contextKey, value)
+}
+
+func fromContext(ctx context.Context) (string, bool) {
+	value, ok := ctx.Value(contextKey).(string)
+	return value, ok
+}
+
+func ExampleHandle() {
+	var xh xhandler.HandlerC
+	xh = xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		value, _ := fromContext(ctx)
+		w.Write([]byte("Hello " + value))
+	})
+
+	xh = (func(next xhandler.HandlerC) xhandler.HandlerC {
+		return xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			ctx = newContext(ctx, "World")
+			next.ServeHTTPC(ctx, w, r)
+		})
+	})(xh)
+
+	ctx := context.Background()
+	// Bridge context aware handlers with http.Handler using xhandler.Handle()
+	http.Handle("/", xhandler.New(ctx, xh))
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleHandleTimeout() {
+	var xh xhandler.HandlerC
+	xh = xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello World"))
+		if _, ok := ctx.Deadline(); ok {
+			w.Write([]byte(" with deadline"))
+		}
+	})
+
+	// This handler adds a timeout to the handler
+	xh = xhandler.TimeoutHandler(5 * time.Second)(xh)
+
+	ctx := context.Background()
+	// Bridge context aware handlers with http.Handler using xhandler.Handle()
+	http.Handle("/", xhandler.New(ctx, xh))
+
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/vendor/github.com/rs/xhandler/xhandler_test.go
+++ b/vendor/github.com/rs/xhandler/xhandler_test.go
@@ -1,0 +1,61 @@
+package xhandler
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+type handler struct{}
+
+type key int
+
+const contextKey key = 0
+
+func newContext(ctx context.Context, value string) context.Context {
+	return context.WithValue(ctx, contextKey, value)
+}
+
+func fromContext(ctx context.Context) (string, bool) {
+	value, ok := ctx.Value(contextKey).(string)
+	return value, ok
+}
+
+func (h handler) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	// Leave other go routines a chance to run
+	time.Sleep(time.Nanosecond)
+	value, _ := fromContext(ctx)
+	if _, ok := ctx.Deadline(); ok {
+		value += " with deadline"
+	}
+	if ctx.Err() == context.Canceled {
+		value += " canceled"
+	}
+	w.Write([]byte(value))
+}
+
+func TestHandle(t *testing.T) {
+	ctx := context.WithValue(context.Background(), contextKey, "value")
+	h := New(ctx, &handler{})
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "http://example.com/foo", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	h.ServeHTTP(w, r)
+	assert.Equal(t, "value", w.Body.String())
+}
+
+func TestHandlerFunc(t *testing.T) {
+	ok := false
+	xh := HandlerFuncC(func(context.Context, http.ResponseWriter, *http.Request) {
+		ok = true
+	})
+	xh.ServeHTTPC(nil, nil, nil)
+	assert.True(t, ok)
+}

--- a/vendor/github.com/rs/xhandler/xmux/README.md
+++ b/vendor/github.com/rs/xhandler/xmux/README.md
@@ -1,0 +1,1 @@
+Xmux did move to it's [own repository](https://github.com/rs/xmux/blob/master/README.md)

--- a/vendor/github.com/toqueteos/webbrowser/CONTRIBUTING.md
+++ b/vendor/github.com/toqueteos/webbrowser/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# webbrowser contributing guide
+
+Any changes are welcomed!
+
+1. Be nice.
+2. Don't be afraid to ask, but please try search first.
+
+## Looking for contact info?
+
+- Twitter: [@toqueteos](https://twitter.com/toqueteos)
+- Mail: `toqueteos AT gmail DOT com`

--- a/vendor/github.com/toqueteos/webbrowser/LICENSE.md
+++ b/vendor/github.com/toqueteos/webbrowser/LICENSE.md
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+Copyright (c) 2013-15 by Carlos Cobo and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/toqueteos/webbrowser/README.md
+++ b/vendor/github.com/toqueteos/webbrowser/README.md
@@ -1,0 +1,42 @@
+# webbrowser [![Build Status](https://travis-ci.org/toqueteos/webbrowser.png?branch=master)](https://travis-ci.org/toqueteos/webbrowser) [![GoDoc](http://godoc.org/github.com/toqueteos/webbrowser?status.png)](http://godoc.org/github.com/toqueteos/webbrowser) [![GitHub release](https://img.shields.io/github/release/toqueteos/webbrowser.svg)](https://github.com/toqueteos/webbrowser/releases)
+
+webbrowser provides a simple API for opening web pages on your default browser. It's inspired on [Python's webbrowser](http://docs.python.org/3.3/library/webbrowser.html) package but lacks some of its features (open new window).
+
+It just opens a webpage, most browsers will open it on a new tab.
+
+## Installation
+
+Copy & Paste fans: `go get github.com/toqueteos/webbrowser`
+
+## Usage
+
+Import the package (once you have installed it):
+
+    import "github.com/toqueteos/webbrowser"
+
+Then use the `Open` function.
+
+    webbrowser.Open("http://golang.org")
+
+That's it!
+
+Need a full blown example? Checkout [examples/simple.go].
+
+## Already disliking it?
+
+No problem! There's alternative libraries that may be better to your needs:
+
+- https://github.com/pkg/browser, it does what webbrowser does and more!
+- https://github.com/skratchdot/open-golang, it even provides a `xdg-open` implementation in case you don't have it!
+
+## Crossplatform support
+
+The package is guaranteed to work on `windows`, `linux` and `darwin`. It also has default support for `freebsd`, `openbsd` and `netbsd` but these three have not been tested yet (that I'm aware of).
+
+## License
+
+It is licensed under the MIT open source license, please see the [LICENSE.txt] file for more information.
+
+## Thanks...
+
+Miki Tebeka wrote a nicer version that wasn't on godoc.org when I did this, [check it out!](https://bitbucket.org/tebeka/go-wise/src/d8db9bf5c4d1/desktop.go?at=default).

--- a/vendor/github.com/toqueteos/webbrowser/doc.go
+++ b/vendor/github.com/toqueteos/webbrowser/doc.go
@@ -1,0 +1,3 @@
+// Package webbrowser provides a simple API for opening web pages on your
+// default browser.
+package webbrowser

--- a/vendor/github.com/toqueteos/webbrowser/examples/simple.go
+++ b/vendor/github.com/toqueteos/webbrowser/examples/simple.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/toqueteos/webbrowser"
+
+func main() {
+	webbrowser.Open("http://golang.org")
+	webbrowser.Open("http://reddit.com")
+}

--- a/vendor/github.com/toqueteos/webbrowser/webbrowser.go
+++ b/vendor/github.com/toqueteos/webbrowser/webbrowser.go
@@ -1,0 +1,111 @@
+package webbrowser
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func init() {
+	// Register a generic browser, if any, for current OS.
+	if os, ok := osCommand[runtime.GOOS]; ok {
+		Candidates = append(Candidates, GenericBrowser{os.cmd, os.args})
+	}
+}
+
+type args struct {
+	cmd  string
+	args []string
+}
+
+var (
+	osCommand = map[string]*args{
+		"darwin":  &args{"open", nil},
+		"freebsd": &args{"xdg-open", nil},
+		"linux":   &args{"xdg-open", nil},
+		"netbsd":  &args{"xdg-open", nil},
+		"openbsd": &args{"xdg-open", nil}, // It may be open instead
+		"windows": &args{"cmd", []string{"/c", "start"}},
+	}
+	ErrCantOpen     = errors.New("webbrowser.Open: can't open webpage")
+	ErrNoCandidates = errors.New("webbrowser.Open: no browser candidate found for your OS.")
+)
+
+// List of registered `Browser`s that will be tried with Open.
+var Candidates []Browser
+
+type Browser interface {
+	Open(string) error
+}
+
+// GenericBrowser just holds a command name and its arguments; the url will be
+// appended as last arg. If you need to use string replacement for url define
+// your own implementation.
+type GenericBrowser struct {
+	Cmd  string
+	Args []string
+}
+
+func (gb GenericBrowser) Open(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+
+	// Enforce a scheme (windows requires scheme to be set to work properly).
+	if u.Scheme != "https" {
+		u.Scheme = "http"
+	}
+	s = u.String()
+
+	// Escape characters not allowed by cmd/bash
+	switch runtime.GOOS {
+	case "windows":
+		s = strings.Replace(s, "&", `^&`, -1)
+	}
+
+	var cmd *exec.Cmd
+	if gb.Args != nil {
+		cmd = exec.Command(gb.Cmd, append(gb.Args, s)...)
+	} else {
+		cmd = exec.Command(gb.Cmd, s)
+	}
+	return cmd.Run()
+}
+
+// Open opens an URL on the first available candidate found.
+func Open(s string) error {
+	if len(Candidates) == 0 {
+		return ErrNoCandidates
+	}
+
+	for _, b := range Candidates {
+		err := b.Open(s)
+		if err == nil {
+			return nil
+		}
+	}
+
+	// Try to determine if there's a display available (only linux) and we
+	// aren't on a terminal (all but windows).
+	switch runtime.GOOS {
+	case "linux":
+		// No display, no need to open a browser. Lynx users **MAY** have
+		// something to say about this.
+		if os.Getenv("DISPLAY") == "" {
+			return fmt.Errorf("Tried to open %q on default webbrowser, no screen found.\n", s)
+		}
+		fallthrough
+	case "darwin":
+		// Check SSH env vars.
+		if os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_TTY") != "" {
+			return fmt.Errorf("Tried to open %q on default webbrowser, but you are running a shell session.\n", s)
+		}
+	}
+
+	return ErrCantOpen
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -57,11 +57,29 @@
 			"path": "/difflib"
 		},
 		{
+			"importpath": "github.com/rs/cors",
+			"repository": "https://github.com/rs/cors",
+			"revision": "5950cf11d77f8a61b432a25dd4d444b4ced01379",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/rs/xhandler",
+			"repository": "https://github.com/rs/xhandler",
+			"revision": "d9d9599b6aaf6a058cb7b1f48291ded2cbd13390",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/stretchr/testify/assert",
 			"repository": "https://github.com/stretchr/testify",
 			"revision": "6fe211e493929a8aac0469b93f28b1d0688a9a3a",
 			"branch": "master",
 			"path": "/assert"
+		},
+		{
+			"importpath": "github.com/toqueteos/webbrowser",
+			"repository": "https://github.com/toqueteos/webbrowser",
+			"revision": "21fc9f95c83442fd164094666f7cb4f9fdd56cd6",
+			"branch": "master"
 		},
 		{
 			"importpath": "github.com/tylerb/graceful",


### PR DESCRIPTION
This PR adds a serve-ui command to swagger

The command is pretty simplistic. 
1. Given a swagger spec path, it loads the spec 
2. Host the spec.json on a server  
3. Open petstore.swagger.io with the locally hosted spec. 

This would allow users to get a quick view of their specification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-swagger/go-swagger/425)
<!-- Reviewable:end -->
