### PR TITLE
make http.Request available to hanlders via params

### DIFF
--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -99,6 +99,10 @@ func New{{ pascalize .Name }}Params() {{ pascalize .Name }}Params {
 //
 // swagger:parameters {{ .Name }}
 type {{ pascalize .Name }}Params struct {
+
+  // HTTP Request Object
+  HTTPRequest *http.Request
+
   {{ range .Params }}/*{{ if .Description }}{{ .Description }}{{ end }}{{ if .Required }}
   Required: true{{ end }}{{ if .Maximum }}
   Maximum: {{ if .ExclusiveMaximum }}< {{ end }}{{ .Maximum }}{{ end }}{{ if .Minimum }}
@@ -122,6 +126,8 @@ type {{ pascalize .Name }}Params struct {
 // for simple values it will use straight method calls
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Request, route *middleware.MatchedRoute) error {
   var res []error
+  {{ .ReceiverName }}.HTTPRequest = r
+
   {{ if .HasQueryParams }}qs := httpkit.Values(r.URL.Query())
   {{ else if .HasFormParams }}if err := r.ParseMultipartForm(32 << 20); err != nil {
 		if err != http.ErrNotMultipart {


### PR DESCRIPTION
This gives handlers access to the http.Request object itself via Params.

I liked this approach better than just supplying the RequestURL, because now handlers can build the URLs themselves or use the http.Request as per their need.

