### PR TITLE
Improve error message

### DIFF
--- a/scan/schema.go
+++ b/scan/schema.go
@@ -880,7 +880,15 @@ func parseProperty(scp *schemaParser, gofile *ast.File, fld ast.Expr, prop swagg
 	case *ast.InterfaceType:
 		prop.Schema().Typed("object", "")
 	default:
-		return fmt.Errorf("%s is unsupported for a schema", ftpe)
+		pos := "unknown file:unknown position"
+		if scp != nil {
+			if scp.program != nil {
+				if scp.program.Fset != nil {
+					pos = scp.program.Fset.Position(fld.Pos()).String()
+				}
+			}
+		}
+		return fmt.Errorf("Expr (%s) is unsupported for a schema", pos)
 	}
 	return nil
 }


### PR DESCRIPTION
Error messages improved. By example:

Old message is:
&{%!s(token.Pos=1478849) %!s(*ast.FieldList=&{1478853 [0xc8217db440] 1478870}) %!s(*ast.FieldList=&{1478872 [0xc8217db480 0xc8217db4c0] 1478888})} is unsupported for a schema

New message is:
Expr (/path/src/gopkg.in/mgo.v2/session.go:386:13) is unsupported for a schema