### PR TITLE
Fixed bug in httpkit/client/runtime.go Submit()

### DIFF
--- a/httpkit/client/runtime.go
+++ b/httpkit/client/runtime.go
@@ -157,7 +157,7 @@ func (r *Runtime) Submit(operation *client.Operation) (interface{}, error) {
 	req.URL.Scheme = r.pickScheme(operation.Schemes)
 	req.URL.Host = r.Host
 	var reinstateSlash bool
-	if req.URL.Path != "" && req.URL.Path[len(req.URL.Path)-1] == '/' {
+	if req.URL.Path != "" && req.URL.Path != "/" && req.URL.Path[len(req.URL.Path)-1] == '/' {
 		reinstateSlash = true
 	}
 	req.URL.Path = path.Join(r.BasePath, req.URL.Path)


### PR DESCRIPTION
The functionality to determine the value of reinstateSlash would
set it to true in the case where req.URL.Path is "/".  This would
result in an extra "/" being appended to req.URL.Path after it was
joined with the BasePath, causing requests to fail.  The path.Join()
function calls path.Clean() on each path element to be joined.
Clean() will return a trailing "/" on a path element only if it is
"/".