### PR TITLE
Fix https://github.com/go-swagger/go-swagger/issues/449

### DIFF
--- a/fixtures/goparsing/classification/operations/todo_operation.go
+++ b/fixtures/goparsing/classification/operations/todo_operation.go
@@ -90,7 +90,7 @@ func ServeAPI(host, basePath string, schemes []string) error {
 	//
 	// Security:
 	// api_key:
-	// oauth: read, write
+	// oauth: orders:read, https://www.googleapis.com/auth/userinfo.email
 	//
 	// Responses:
 	// default: genericError

--- a/scan/routes_test.go
+++ b/scan/routes_test.go
@@ -51,6 +51,7 @@ func TestRoutesParser(t *testing.T) {
 		"Lists pets filtered by some parameters.",
 		"This will show all available pets by default.\nYou can get the pets that are out of stock",
 		[]string{"pets", "users"},
+		[]string{"read", "write"},
 	)
 	assertOperation(t,
 		po.Post,
@@ -58,6 +59,7 @@ func TestRoutesParser(t *testing.T) {
 		"Create a pet based on the parameters.",
 		"",
 		[]string{"pets", "users"},
+		[]string{"read", "write"},
 	)
 
 	po, ok = ops.Paths["/orders"]
@@ -69,6 +71,7 @@ func TestRoutesParser(t *testing.T) {
 		"lists orders filtered by some parameters.",
 		"",
 		[]string{"orders"},
+		[]string{"orders:read", "https://www.googleapis.com/auth/userinfo.email"},
 	)
 	assertOperation(t,
 		po.Post,
@@ -76,6 +79,7 @@ func TestRoutesParser(t *testing.T) {
 		"create an order based on the parameters.",
 		"",
 		[]string{"orders"},
+		[]string{"read", "write"},
 	)
 
 	po, ok = ops.Paths["/orders/{id}"]
@@ -87,6 +91,7 @@ func TestRoutesParser(t *testing.T) {
 		"gets the details for an order.",
 		"",
 		[]string{"orders"},
+		[]string{"read", "write"},
 	)
 
 	assertOperation(t,
@@ -95,6 +100,7 @@ func TestRoutesParser(t *testing.T) {
 		"Update the details for an order.",
 		"When the order doesn't exist this will return an error.",
 		[]string{"orders"},
+		[]string{"read", "write"},
 	)
 
 	assertOperation(t,
@@ -103,10 +109,11 @@ func TestRoutesParser(t *testing.T) {
 		"delete a particular order.",
 		"",
 		nil,
+		[]string{"read", "write"},
 	)
 }
 
-func assertOperation(t *testing.T, op *spec.Operation, id, summary, description string, tags []string) {
+func assertOperation(t *testing.T, op *spec.Operation, id, summary, description string, tags, scopes []string) {
 	assert.NotNil(t, op)
 	assert.Equal(t, summary, op.Summary)
 	assert.Equal(t, description, op.Description)
@@ -121,7 +128,7 @@ func assertOperation(t *testing.T, op *spec.Operation, id, summary, description 
 
 	vv, ok := op.Security[1]["oauth"]
 	assert.True(t, ok)
-	assert.EqualValues(t, []string{"read", "write"}, vv)
+	assert.EqualValues(t, scopes, vv)
 
 	assert.NotNil(t, op.Responses.Default)
 	assert.Equal(t, "#/responses/genericError", op.Responses.Default.Ref.String())

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -72,7 +72,6 @@ var (
 			rxOpID + "\\p{Zs}*$")
 
 	rxSpace              = regexp.MustCompile("\\p{Zs}+")
-	rxNotAlNumSpaceComma = regexp.MustCompile("[^\\p{L}\\p{N}\\p{Zs},]")
 	rxPunctuationEnd     = regexp.MustCompile("\\p{Po}$")
 	rxStripComments      = regexp.MustCompile("^[^\\p{L}\\p{N}\\p{Pd}\\p{Pc}\\+]*")
 	rxStripTitleComments = regexp.MustCompile("^[^\\p{L}]*[Pp]ackage\\p{Zs}+[^\\p{Zs}]+\\p{Zs}*")

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -485,11 +485,12 @@ func (ss *setSecurityDefinitions) Parse(lines []string) error {
 		var key string
 
 		if len(kv) > 1 {
-			scs := strings.Split(rxNotAlNumSpaceComma.ReplaceAllString(kv[1], ""), ",")
+			scs := strings.Split(kv[1], ",")
 			for _, scope := range scs {
 				tr := strings.TrimSpace(scope)
 				if tr != "" {
-					scopes = append(scopes, strings.TrimSpace(scope))
+					tr = strings.SplitAfter(tr, " ")[0]
+					scopes = append(scopes, strings.TrimSpace(tr))
 				}
 			}
 


### PR DESCRIPTION
This PR aims to fix:  https://github.com/go-swagger/go-swagger/issues/449

I changed the `/fixtures/goparsing/classification/operations/todo_operation.go` file in order to test more general scopes (For example Google uses URL as scopes).

I changed the  `scan/routes_test.go` accordingly.

I removed the useless regexp that I replaced with a simple TrimAfter followed by a TrimSpace. This is possibile because following the specifications scopes can't contain spaces (must be url encoded if present).

Signed-off-by: Paolo Galeone <nessuno@nerdz.eu>