### PR TITLE
X nullable first

### DIFF
--- a/generator/pointer_test.go
+++ b/generator/pointer_test.go
@@ -67,16 +67,16 @@ type builtinVal struct {
 }
 
 func nullableExt() spec.Extensions {
-	return map[string]interface{}{"x-nullable": true}
+	return spec.Extensions{"x-nullable": true}
 }
 func isNullableExt() spec.Extensions {
-	return map[string]interface{}{"x-isnullable": true}
+	return spec.Extensions{"x-isnullable": true}
 }
 func notNullableExt() spec.Extensions {
-	return map[string]interface{}{"x-nullable": false}
+	return spec.Extensions{"x-nullable": false}
 }
 func isNotNullableExt() spec.Extensions {
-	return map[string]interface{}{"x-isnullable": false}
+	return spec.Extensions{"x-isnullable": false}
 }
 
 var boolPointerVals = []builtinVal{
@@ -95,13 +95,13 @@ var boolPointerVals = []builtinVal{
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: true, Default: nil, Required: false, ReadOnly: false, Extensions: isNullableExt()},
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: true, Default: nil, Required: true, ReadOnly: true, Extensions: isNullableExt()},
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: true, Default: true, Required: true, ReadOnly: true, Extensions: isNullableExt()},
-	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: true, Default: true, Required: false, ReadOnly: false, Extensions: notNullableExt()},
-	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: true, Default: nil, Required: true, ReadOnly: false, Extensions: notNullableExt()},
+	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: true, Required: false, ReadOnly: false, Extensions: notNullableExt()},
+	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: nil, Required: true, ReadOnly: false, Extensions: notNullableExt()},
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: nil, Required: false, ReadOnly: false, Extensions: notNullableExt()},
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: nil, Required: true, ReadOnly: true, Extensions: notNullableExt()},
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: true, Required: true, ReadOnly: true, Extensions: notNullableExt()},
-	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: true, Default: true, Required: false, ReadOnly: false, Extensions: isNotNullableExt()},
-	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: true, Default: nil, Required: true, ReadOnly: false, Extensions: isNotNullableExt()},
+	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: true, Required: false, ReadOnly: false, Extensions: isNotNullableExt()},
+	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: nil, Required: true, ReadOnly: false, Extensions: isNotNullableExt()},
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: nil, Required: false, ReadOnly: false, Extensions: isNotNullableExt()},
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: nil, Required: true, ReadOnly: true, Extensions: isNotNullableExt()},
 	builtinVal{Type: "boolean", Format: "", Expected: "bool", Nullable: false, Default: true, Required: true, ReadOnly: true, Extensions: isNotNullableExt()},
@@ -566,7 +566,10 @@ func assertBuiltinVal(t testing.TB, resolver *typeResolver, aliased bool, i int,
 }
 
 func assertBuiltinSliceElem(t testing.TB, resolver *typeResolver, aliased bool, i int, val builtinVal) bool {
-	val.Nullable = val.Extensions != nil && (boolExtension(val.Extensions, xIsNullable) || boolExtension(val.Extensions, xNullable))
+	val.Nullable = false
+	if nullableExtension(val.Extensions) != nil {
+		val.Nullable = *nullableExtension(val.Extensions)
+	}
 	sliceType := "[]" + val.Expected
 	if val.Nullable {
 		sliceType = "[]*" + val.Expected
@@ -623,7 +626,10 @@ func assertBuiltinSliceElem(t testing.TB, resolver *typeResolver, aliased bool, 
 }
 
 func assertBuiltinAdditionalPropertiesElem(t testing.TB, resolver *typeResolver, aliased bool, i int, val builtinVal) bool {
-	val.Nullable = val.Extensions != nil && (boolExtension(val.Extensions, xIsNullable) || boolExtension(val.Extensions, xNullable))
+	val.Nullable = false
+	if nullableExtension(val.Extensions) != nil {
+		val.Nullable = *nullableExtension(val.Extensions)
+	}
 	sliceType := "map[string]" + val.Expected
 	if val.Nullable {
 		sliceType = "map[string]*" + val.Expected

--- a/generator/types.go
+++ b/generator/types.go
@@ -552,13 +552,12 @@ func nullableExtension(ext spec.Extensions) *bool {
 }
 
 func boolExtension(ext spec.Extensions, key string) *bool {
-	var res *bool
 	if v, ok := ext[key]; ok {
 		if bb, ok := v.(bool); ok {
-			res = &bb
+			return &bb
 		}
 	}
-	return res
+	return nil
 }
 
 func (t *typeResolver) ResolveSchema(schema *spec.Schema, isAnonymous, isRequired bool) (result resolvedType, err error) {

--- a/generator/types.go
+++ b/generator/types.go
@@ -489,15 +489,19 @@ func (t *typeResolver) resolveObject(schema *spec.Schema, isAnonymous bool) (res
 }
 
 func nullableBool(schema *spec.Schema, isRequired bool) bool {
+	if nullable := nullableExtension(schema.Extensions); nullable != nil {
+		return *nullable
+	}
 	required := isRequired && schema.Default == nil && !schema.ReadOnly
 	optional := !isRequired && (schema.Default != nil || schema.ReadOnly)
-	extension := boolExtension(schema.Extensions, xIsNullable) || boolExtension(schema.Extensions, xNullable)
 
-	return extension || required || optional
+	return required || optional
 }
 
 func nullableNumber(schema *spec.Schema, isRequired bool) bool {
-	extension := boolExtension(schema.Extensions, xIsNullable) || boolExtension(schema.Extensions, xNullable)
+	if nullable := nullableExtension(schema.Extensions); nullable != nil {
+		return *nullable
+	}
 	hasDefault := schema.Default != nil && !swag.IsZero(schema.Default)
 
 	isMin := schema.Minimum != nil && *schema.Minimum != 0
@@ -508,36 +512,53 @@ func nullableNumber(schema *spec.Schema, isRequired bool) bool {
 	bcMinMax := (schema.Minimum != nil && schema.Maximum != nil && (*schema.Minimum < 0 && 0 < *schema.Maximum))
 
 	nullable := !schema.ReadOnly && (isRequired || (hasDefault && !(isMin || isMax || isMinMax)) || bcMin || bcMax || bcMinMax)
-	return extension || nullable
+	return nullable
 }
 
 func nullableString(schema *spec.Schema, isRequired bool) bool {
-	extension := boolExtension(schema.Extensions, xIsNullable) || boolExtension(schema.Extensions, xNullable)
+	if nullable := nullableExtension(schema.Extensions); nullable != nil {
+		return *nullable
+	}
 	hasDefault := schema.Default != nil && !swag.IsZero(schema.Default)
 
 	isMin := schema.MinLength != nil && *schema.MinLength != 0
 	bcMin := schema.MinLength != nil && *schema.MinLength == 0
 
 	nullable := !schema.ReadOnly && (isRequired || (hasDefault && !isMin) || bcMin)
-	return extension || nullable
+	return nullable
 }
 
 func nullableStrfmt(schema *spec.Schema, isRequired bool) bool {
-	extension := boolExtension(schema.Extensions, xIsNullable) || boolExtension(schema.Extensions, xNullable)
+	notBinary := schema.Format != binary
+	if nullable := nullableExtension(schema.Extensions); nullable != nil && notBinary {
+		return *nullable
+	}
 	hasDefault := schema.Default != nil && !swag.IsZero(schema.Default)
 
 	nullable := !schema.ReadOnly && (isRequired || hasDefault)
-	return schema.Format != "binary" && (extension || nullable)
+	return notBinary && nullable
 }
 
-func boolExtension(ext spec.Extensions, key string) bool {
-	if v, ok := ext[key]; ok {
-		if bb, ok := v.(bool); ok {
-			return bb
-		}
+func nullableExtension(ext spec.Extensions) *bool {
+	if ext == nil {
+		return nil
 	}
 
-	return false
+	if boolPtr := boolExtension(ext, xNullable); boolPtr != nil {
+		return boolPtr
+	}
+
+	return boolExtension(ext, xIsNullable)
+}
+
+func boolExtension(ext spec.Extensions, key string) *bool {
+	var res *bool
+	if v, ok := ext[key]; ok {
+		if bb, ok := v.(bool); ok {
+			res = &bb
+		}
+	}
+	return res
 }
 
 func (t *typeResolver) ResolveSchema(schema *spec.Schema, isAnonymous, isRequired bool) (result resolvedType, err error) {


### PR DESCRIPTION
This change introduces a precedence for a user defined attribute x-nullable.
x-nullable is an extension that actually gives user a freedom to optionally define code generator behavior for nullable and non nullable values.