### PR TITLE
Required flag is reset for array items.

### DIFF
--- a/generator/discriminators_test.go
+++ b/generator/discriminators_test.go
@@ -243,7 +243,7 @@ func TestGenerateModel_Discriminator_Billforward(t *testing.T) {
 				if assert.NoError(t, err) {
 					res := string(b)
 					//assertInCode(t, "err", res)
-					assertInCode(t, "err := validate.RequiredString(\"priceExplanation\"+\".\"+strconv.Itoa(i), \"body\", string(m.priceExplanationField[i]))", res)
+					assertInCode(t, "swag.IsZero(m.priceExplanationField[i])", res)
 				}
 			}
 		}

--- a/generator/model.go
+++ b/generator/model.go
@@ -932,18 +932,23 @@ func (sg *schemaGenContext) buildArray() error {
 	if err := elProp.makeGenSchema(); err != nil {
 		return err
 	}
+
 	sg.MergeResult(elProp, false)
 	sg.GenSchema.IsBaseType = elProp.GenSchema.IsBaseType
 	sg.GenSchema.ItemsEnum = elProp.GenSchema.Enum
 	elProp.GenSchema.Suffix = "Items"
 	sg.GenSchema.GoType = "[]" + elProp.GenSchema.GoType
+
 	// TODO: this is probably not right. Should just respect what type resolvers said
 	nn := elProp.GenSchema.IsNullable
 	elProp.GenSchema.IsNullable = sg.TypeResolver.IsNullable(sg.Schema.Items.Schema) && !elProp.GenSchema.HasDiscriminator
 	if nn && !elProp.GenSchema.HasDiscriminator && !elProp.GenSchema.IsPrimitive {
 		sg.GenSchema.GoType = "[]*" + elProp.GenSchema.GoType
 	}
-	sg.GenSchema.Items = &elProp.GenSchema
+
+	schemaCopy := elProp.GenSchema
+	schemaCopy.Required = false
+	sg.GenSchema.Items = &schemaCopy
 	if sg.Named {
 		sg.GenSchema.AliasedType = sg.GenSchema.GoType
 	}


### PR DESCRIPTION
For some reason the schema for array item is enforced in such way that array items become required.
I created a copy of the originating schema and reset required flag for it. Test update was necessary.