### PR TITLE
Prevents parsing structs that are needed when parsing dicovered schemas

### DIFF
--- a/fixtures/goparsing/bookings/api.go
+++ b/fixtures/goparsing/bookings/api.go
@@ -24,6 +24,25 @@ import (
 	"github.com/go-swagger/scan-repo-boundary/makeplans"
 )
 
+// Customer of the site.
+//
+// swagger:model Customer
+type Customer struct {
+	Name string `json:"name"`
+}
+
+// IgnoreMe should not be added to definitions since it is not annotated.
+type IgnoreMe struct {
+	Name string `json:"name"`
+}
+
+// DateRange represents a scheduled appointments time
+// DateRange should be in definitions since it's being used in a response
+type DateRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
 // BookingResponse represents a scheduled appointment
 //
 // swagger:response BookingResponse
@@ -32,7 +51,11 @@ type BookingResponse struct {
 	//
 	// in: body
 	// required: true
-	Booking makeplans.Booking `json:"booking"`
+	Body struct {
+		Booking  makeplans.Booking `json:"booking"`
+		Customer Customer          `json:"customer"`
+		Dates    DateRange         `json:"dates"`
+	}
 }
 
 // Bookings swagger:route GET /admin/bookings/ booking Bookings

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -299,7 +299,7 @@ func (a *appScanner) processDiscovered() error {
 		}
 		a.discovered = nil
 		for _, sd := range queue {
-			if err := a.parseSchema(sd.File); err != nil {
+			if err := a.parseDiscoveredSchema(sd); err != nil {
 				return err
 			}
 		}
@@ -312,6 +312,17 @@ func (a *appScanner) processDiscovered() error {
 func (a *appScanner) parseSchema(file *ast.File) error {
 	sp := newSchemaParser(a.prog)
 	if err := sp.Parse(file, a.definitions); err != nil {
+		return err
+	}
+	a.discovered = append(a.discovered, sp.postDecls...)
+	return nil
+}
+
+func (a *appScanner) parseDiscoveredSchema(sd schemaDecl) error {
+	sp := newSchemaParser(a.prog)
+	sp.discovered = &sd
+
+	if err := sp.Parse(sd.File, a.definitions); err != nil {
 		return err
 	}
 	a.discovered = append(a.discovered, sp.postDecls...)

--- a/scan/scanner_test.go
+++ b/scan/scanner_test.go
@@ -59,15 +59,23 @@ func TestAppScanner_NewSpec(t *testing.T) {
 	}
 }
 
-func TestAppScanner_BookingCrossRepo(t *testing.T) {
+func TestAppScanner_Definitions(t *testing.T) {
 	scanner, err := newAppScanner(&Opts{BasePath: "../fixtures/goparsing/bookings"}, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, scanner)
 	doc, err := scanner.Parse()
 	assert.NoError(t, err)
 	if assert.NotNil(t, doc) {
-		_, ok := doc.Definitions["BookingResponse"]
-		assert.False(t, ok)
+		_, ok := doc.Definitions["Booking"]
+		assert.True(t, ok, "Should include cross repo structs")
+		_, ok = doc.Definitions["Customer"]
+		assert.True(t, ok, "Should include package structs with swagger:model")
+		_, ok = doc.Definitions["DateRange"]
+		assert.True(t, ok, "Should include package structs that are used in responses")
+		_, ok = doc.Definitions["BookingResponse"]
+		assert.False(t, ok, "Should not include responses")
+		_, ok = doc.Definitions["IgnoreMe"]
+		assert.False(t, ok, "Should not include un-annotated/un-referenced structs")
 	}
 }
 

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -160,9 +160,10 @@ func (sd *schemaDecl) inferNames() (goName string, name string) {
 }
 
 type schemaParser struct {
-	program   *loader.Program
-	postDecls []schemaDecl
-	known     map[string]spec.Schema
+	program    *loader.Program
+	postDecls  []schemaDecl
+	known      map[string]spec.Schema
+	discovered *schemaDecl
 }
 
 func newSchemaParser(prog *loader.Program) *schemaParser {
@@ -197,6 +198,13 @@ func (scp *schemaParser) parseDecl(definitions map[string]spec.Schema, decl *sch
 	// the package and type are recorded in the extensions
 	// once type name is found convert it to a schema, by looking up the schema in the
 	// definitions dictionary that got passed into this parse method
+
+	// if our schemaParser is parsing a discovered schemaDecl and it does not match
+	// the current schemaDecl we can skip parsing.
+	if scp.discovered != nil && scp.discovered.Name != decl.Name {
+		return nil
+	}
+
 	decl.inferNames()
 	schema := definitions[decl.Name]
 	schPtr := &schema


### PR DESCRIPTION
When parsing discovered schemas it includes all structs including ones that should not be included. This patch makes the schemaParser aware of the discovered schema so we can use that information to exclude schema that are not needed.