### PR TITLE
skip fields in parameter structs with struct tag `json:"-"`

### DIFF
--- a/fixtures/goparsing/classification/operations/noparams.go
+++ b/fixtures/goparsing/classification/operations/noparams.go
@@ -52,6 +52,7 @@ type ComplexerOneParams struct {
 	mods.NotSelected
 	mods.Notable
 	CreatedAt strfmt.DateTime `json:"createdAt"`
+	Secret    string          `json:"-"`
 
 	// in: formData
 	Informity string `json:"informity"`

--- a/scan/parameters.go
+++ b/scan/parameters.go
@@ -296,7 +296,10 @@ func (pp *paramStructParser) parseStructType(gofile *ast.File, operation *spec.O
 					if strings.TrimSpace(tv) != "" {
 						st := reflect.StructTag(tv)
 						jsonTag := st.Get("json")
-						if jsonTag != "" && jsonTag != "-" {
+						if jsonTag == "-" {
+							continue
+						}
+						if jsonTag != "" {
 							nm = strings.Split(jsonTag, ",")[0]
 						}
 					}


### PR DESCRIPTION
Signed-off-by: Jake Burkhead <jake.b@socialcodeinc.com>

relates to https://github.com/go-swagger/go-swagger/issues/520