### PR TITLE
Fix issue #560 Go builtin support

### DIFF
--- a/fixtures/goparsing/classification/models/nomodel.go
+++ b/fixtures/goparsing/classification/models/nomodel.go
@@ -192,7 +192,7 @@ type AllOfModel struct {
 	CreatedAt strfmt.DateTime `json:"createdAt"`
 }
 
-// A PrimateModel is a struct with nothing but primitives.
+// A PrimateModel is a struct with nothing but builtins.
 //
 // It only has values 1 level deep and each of those is of a very simple
 // builtin type.
@@ -216,6 +216,10 @@ type PrimateModel struct {
 
 	N float32 `json:"n"`
 	O float64 `json:"o"`
+
+	P byte `json:"p"`
+
+	Q uintptr `json:"q"`
 }
 
 // A FormattedModel is a struct with only strfmt types

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -382,34 +382,53 @@ type swaggerTypable interface {
 	Level() int
 }
 
+// Map all Go builtin types that have Json representation to Swagger/Json types.
+// See https://golang.org/pkg/builtin/ and http://swagger.io/specification/
 func swaggerSchemaForType(typeName string, prop swaggerTypable) error {
 	switch typeName {
 	case "bool":
 		prop.Typed("boolean", "")
-	case "error", "rune", "string":
-		prop.Typed("string", "")
-	case "int8":
-		prop.Typed("integer", "int8")
-	case "int16":
-		prop.Typed("integer", "int16")
-	case "int32":
-		prop.Typed("integer", "int32")
-	case "int", "int64":
-		prop.Typed("integer", "int64")
-	case "uint8":
+	case "byte":
 		prop.Typed("integer", "uint8")
-	case "uint16":
-		prop.Typed("integer", "uint16")
-	case "uint32":
-		prop.Typed("integer", "uint32")
-	case "uint", "uint64":
-		prop.Typed("integer", "uint64")
+	case "complex128", "complex64":
+		return fmt.Errorf("unsupported builtin %q (no JSON marshaller)", typeName)
+	case "error":
+		// TODO: error is often marshalled into a string but not always (e.g. errors package creates
+		// errors that are marshalled into an empty object), this could be handled the same way
+		// custom JSON marshallers are handled (in future)
+		prop.Typed("string", "")
 	case "float32":
 		prop.Typed("number", "float")
 	case "float64":
 		prop.Typed("number", "double")
+	case "int":
+		prop.Typed("integer", "int64")
+	case "int16":
+		prop.Typed("integer", "int16")
+	case "int32":
+		prop.Typed("integer", "int32")
+	case "int64":
+		prop.Typed("integer", "int64")
+	case "int8":
+		prop.Typed("integer", "int8")
+	case "rune":
+		prop.Typed("integer", "int32")
+	case "string":
+		prop.Typed("string", "")
+	case "uint":
+		prop.Typed("integer", "uint64")
+	case "uint16":
+		prop.Typed("integer", "uint16")
+	case "uint32":
+		prop.Typed("integer", "uint32")
+	case "uint64":
+		prop.Typed("integer", "uint64")
+	case "uint8":
+		prop.Typed("integer", "uint8")
+	case "uintptr":
+		prop.Typed("integer", "uint64")
 	default:
-		return fmt.Errorf("unknown primitive %q", typeName)
+		return fmt.Errorf("unknown builtin %q", typeName)
 	}
 	return nil
 }

--- a/scan/schema_test.go
+++ b/scan/schema_test.go
@@ -238,7 +238,7 @@ func TestAliasedTypes(t *testing.T) {
 func TestParsePrimitiveSchemaProperty(t *testing.T) {
 	schema := noModelDefs["PrimateModel"]
 	assertProperty(t, &schema, "boolean", "a", "", "A")
-	assertProperty(t, &schema, "string", "b", "", "B")
+	assertProperty(t, &schema, "integer", "b", "int32", "B")
 	assertProperty(t, &schema, "string", "c", "", "C")
 	assertProperty(t, &schema, "integer", "d", "int64", "D")
 	assertProperty(t, &schema, "integer", "e", "int8", "E")
@@ -252,6 +252,8 @@ func TestParsePrimitiveSchemaProperty(t *testing.T) {
 	assertProperty(t, &schema, "integer", "m", "uint64", "M")
 	assertProperty(t, &schema, "number", "n", "float", "N")
 	assertProperty(t, &schema, "number", "o", "double", "O")
+	assertProperty(t, &schema, "integer", "p", "uint8", "P")
+	assertProperty(t, &schema, "integer", "q", "uint64", "Q")
 }
 
 func TestParseStringFormatSchemaProperty(t *testing.T) {


### PR DESCRIPTION
* added support for byte, uintptr

* added error for complex64, complex128, there's no default JSON
marshaller

* changed rune from string to int32 according to Go docs