### PR TITLE
Fix issue #563 Added StarExpr in parseEmbeddedType

### DIFF
--- a/fixtures/goparsing/classification/models/nomodel.go
+++ b/fixtures/goparsing/classification/models/nomodel.go
@@ -192,6 +192,17 @@ type AllOfModel struct {
 	CreatedAt strfmt.DateTime `json:"createdAt"`
 }
 
+// An Embedded is to be embedded in EmbeddedStarExpr
+type Embedded struct {
+	EmbeddedMember int64 `json:"embeddedMember"`
+}
+
+// An EmbeddedStarExpr for testing the embedded StarExpr
+type EmbeddedStarExpr struct {
+	*Embedded
+	NotEmbedded int64 `json:"notEmbedded"`
+}
+
 // A PrimateModel is a struct with nothing but builtins.
 //
 // It only has values 1 level deep and each of those is of a very simple

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -289,6 +289,14 @@ func (scp *schemaParser) parseEmbeddedType(gofile *ast.File, schema *spec.Schema
 		if st, ok := ts.Type.(*ast.InterfaceType); ok {
 			return scp.parseInterfaceType(file, schema, st, seenPreviously)
 		}
+	case *ast.StarExpr:
+		return scp.parseEmbeddedType(gofile, schema, tpe.X, seenPreviously)
+	default:
+		return fmt.Errorf(
+			"parseEmbeddedType: unsupported type %v at position %#v",
+			expr,
+			scp.program.Fset.Position(tpe.Pos()),
+		)
 	}
 	return fmt.Errorf("unable to resolve embedded struct for: %v\n", expr)
 }

--- a/scan/schema_test.go
+++ b/scan/schema_test.go
@@ -192,6 +192,13 @@ func TestEmbeddedAllOf(t *testing.T) {
 	assertProperty(t, &asch, "string", "cat", "", "Cat")
 }
 
+func TestEmbeddedStarExpr(t *testing.T) {
+	schema := noModelDefs["EmbeddedStarExpr"]
+
+	assertProperty(t, &schema, "integer", "embeddedMember", "int64", "EmbeddedMember")
+	assertProperty(t, &schema, "integer", "notEmbedded", "int64", "NotEmbedded")
+}
+
 func TestAliasedTypes(t *testing.T) {
 	schema := noModelDefs["OtherTypes"]
 	assertProperty(t, &schema, "string", "named", "", "Named")


### PR DESCRIPTION
Any suggestions on how to test this? Seems like the test in scan/classifier_test.go are similar, maybe add model with embedded pointer in fixtures/goparsing/classification/models/ ? Didn't find an example that would test whether the JSON model  is correct (e.g. we want the embedded type to be there as optional).

The committed change produces correct  swagger, as far as I can tell, i.e. the members of embedded type are all there and optional.