### PR TITLE
Command Line Flags Example

### DIFF
--- a/examples/tutorials/todo-list/server-complete/restapi/configure_todo_list.go
+++ b/examples/tutorials/todo-list/server-complete/restapi/configure_todo_list.go
@@ -17,8 +17,19 @@ import (
 
 // This file is safe to edit. Once it exists it will not be overwritten
 
-func configureFlags(api *operations.TodoListAPI) {
+var exampleFlags = struct {
+	Example1 string `long:"example1" description:"Sample for showing how to configure cmd-line flags"`
+	Example2 string `long:"example2" description:"Further info at https://github.com/jessevdk/go-flags"`
+}{}
 
+func configureFlags(api *operations.TodoListAPI) {
+	api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{
+		swag.CommandLineOptionsGroup{
+			ShortDescription: "Example Flags",
+			LongDescription:  "",
+			Options:          &exampleFlags,
+		},
+	}
 }
 
 var items = make(map[int64]*models.Item)


### PR DESCRIPTION
Within the `server-complete` example code, show how someone would use the facilities for adding command line flags.

Closes #572 

Signed-off-by: Nelson Carpentier <nelz9999@gmail.com>