### PR TITLE
Expose server handler which can be used for writing tests

### DIFF
--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -184,6 +184,11 @@ func (s *Server) Shutdown() error {
 	return nil
 }
 
+// GetHandler returns a handler useful for testing
+func (s *Server) GetHandler() http.Handler {
+	return s.handler
+}
+
 // tcpKeepAliveListener is copied from the stdlib net/http package
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted


### PR DESCRIPTION
We would like to propose exposing the server handler via a getter so that we can use the handler in test suites. See below for an example use case:

```go
package apitests

import (
	"io"
	"log"
	"net/http/httptest"

	"github.com/go-openapi/loads"
	"github.com/xiwenc/someService/restapi"
	"github.com/xiwenc/someService/restapi/operations"
)

var testserver *httptest.Server

func setup() {
	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
	if err != nil {
		log.Fatalln(err)
	}

	api := operations.ExampleServiceAPI(swaggerSpec)
	server := restapi.NewServer(api)
	server.ConfigureAPI()
	testserver = httptest.NewServer(server.GetHandler()) // The proposed change would enable easier usage of the handler in tests
}

func teardown() {
	testserver.Close()
}

func TestSample(t *testing.T) {
	setup()
	// do some requests to testserver.URL
	// assert.Equal(t, 201, response.StatusCode, "Great success")
	teardown()
}
```