### PR TITLE
Add the ability to use a model as a response.

### DIFF
--- a/fixtures/goparsing/classification/operations_body/todo_operation_body.go
+++ b/fixtures/goparsing/classification/operations_body/todo_operation_body.go
@@ -1,0 +1,203 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+// ListPetParams the params for the list pets query
+type ListPetParams struct {
+	// OutOfStock when set to true only the pets that are out of stock will be returned
+	OutOfStock bool
+}
+
+// ServeAPI serves the API for this record store
+func ServeAPI(host, basePath string, schemes []string) error {
+
+	// swagger:route GET /pets pets users listPets
+	//
+	// Lists pets filtered by some parameters.
+	//
+	// This will show all available pets by default.
+	// You can get the pets that are out of stock
+	//
+	// Consumes:
+	// application/json
+	// application/x-protobuf
+	//
+	// Produces:
+	// application/json
+	// application/x-protobuf
+	//
+	// Schemes: http, https, ws, wss
+	//
+	// Security:
+	// api_key:
+	// oauth: read, write
+	//
+	// Responses:
+	// default: body:genericError
+	// 200: body:someResponse
+	// 422: body:validationError
+	mountItem("GET", basePath+"/pets", nil)
+
+	/* swagger:route POST /pets pets users createPet
+
+	Create a pet based on the parameters.
+
+	Consumes:
+	- application/json
+	- application/x-protobuf
+
+	Produces:
+	- application/json
+	- application/x-protobuf
+
+	Schemes: http, https, ws, wss
+
+	Responses:
+	default: body:genericError
+	200: body:someResponse
+	422: body:validationError
+
+	Security:
+	api_key:
+	oauth: read, write */
+	mountItem("POST", basePath+"/pets", nil)
+
+	// swagger:route GET /orders orders listOrders
+	//
+	// lists orders filtered by some parameters.
+	//
+	// Consumes:
+	// application/json
+	// application/x-protobuf
+	//
+	// Produces:
+	// application/json
+	// application/x-protobuf
+	//
+	// Schemes: http, https, ws, wss
+	//
+	// Security:
+	// api_key:
+	// oauth: orders:read, https://www.googleapis.com/auth/userinfo.email
+	//
+	// Responses:
+	// default: body:genericError
+	// 200: body:someResponse
+	// 422: body:validationError
+	mountItem("GET", basePath+"/orders", nil)
+
+	// swagger:route POST /orders orders createOrder
+	//
+	// create an order based on the parameters.
+	//
+	// Consumes:
+	// application/json
+	// application/x-protobuf
+	//
+	// Produces:
+	// application/json
+	// application/x-protobuf
+	//
+	// Schemes: http, https, ws, wss
+	//
+	// Security:
+	// api_key:
+	// oauth: read, write
+	//
+	// Responses:
+	// default: body:genericError
+	// 200: body:someResponse
+	// 422: body:validationError
+	mountItem("POST", basePath+"/orders", nil)
+
+	// swagger:route GET /orders/{id} orders orderDetails
+	//
+	// gets the details for an order.
+	//
+	// Consumes:
+	// application/json
+	// application/x-protobuf
+	//
+	// Produces:
+	// application/json
+	// application/x-protobuf
+	//
+	// Schemes: http, https, ws, wss
+	//
+	// Security:
+	// api_key:
+	// oauth: read, write
+	//
+	// Responses:
+	// default: body:genericError
+	// 200: body:someResponse
+	// 422: body:validationError
+	mountItem("GET", basePath+"/orders/:id", nil)
+
+	// swagger:route PUT /orders/{id} orders updateOrder
+	//
+	// Update the details for an order.
+	//
+	// When the order doesn't exist this will return an error.
+	//
+	// Consumes:
+	// application/json
+	// application/x-protobuf
+	//
+	// Produces:
+	// application/json
+	// application/x-protobuf
+	//
+	// Schemes: http, https, ws, wss
+	//
+	// Security:
+	// api_key:
+	// oauth: read, write
+	//
+	// Responses:
+	// default: body:genericError
+	// 200: body:someResponse
+	// 422: body:validationError
+	mountItem("PUT", basePath+"/orders/:id", nil)
+
+	// swagger:route DELETE /orders/{id} deleteOrder
+	//
+	// delete a particular order.
+	//
+	// Consumes:
+	// application/json
+	// application/x-protobuf
+	//
+	// Produces:
+	// application/json
+	// application/x-protobuf
+	//
+	// Schemes: http, https, ws, wss
+	//
+	// Security:
+	// api_key:
+	// oauth: read, write
+	//
+	// Responses:
+	// default: body:genericError
+	// 200: body:someResponse
+	// 422: body:validationError
+	mountItem("DELETE", basePath+"/orders/:id", nil)
+
+	return nil
+}
+
+// not really used but I need a method to decorate the calls to
+func mountItem(method, path string, handler interface{}) {}

--- a/scan/routes_test.go
+++ b/scan/routes_test.go
@@ -15,6 +15,7 @@
 package scan
 
 import (
+	"encoding/json"
 	goparser "go/parser"
 	"log"
 	"testing"
@@ -113,6 +114,91 @@ func TestRoutesParser(t *testing.T) {
 	)
 }
 
+func TestRoutesParserBody(t *testing.T) {
+	docFile := "../fixtures/goparsing/classification/operations_body/todo_operation_body.go"
+	fileTree, err := goparser.ParseFile(classificationProg.Fset, docFile, nil, goparser.ParseComments)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rp := newRoutesParser(classificationProg)
+	var ops spec.Paths
+	err = rp.Parse(fileTree, &ops)
+	assert.NoError(t, err)
+
+	assert.Len(t, ops.Paths, 3)
+
+	po, ok := ops.Paths["/pets"]
+	assert.True(t, ok)
+	assert.NotNil(t, po.Get)
+	assertOperationBody(t,
+		po.Get,
+		"listPets",
+		"Lists pets filtered by some parameters.",
+		"This will show all available pets by default.\nYou can get the pets that are out of stock",
+		[]string{"pets", "users"},
+		[]string{"read", "write"},
+	)
+	assertOperationBody(t,
+		po.Post,
+		"createPet",
+		"Create a pet based on the parameters.",
+		"",
+		[]string{"pets", "users"},
+		[]string{"read", "write"},
+	)
+
+	po, ok = ops.Paths["/orders"]
+	assert.True(t, ok)
+	assert.NotNil(t, po.Get)
+	assertOperationBody(t,
+		po.Get,
+		"listOrders",
+		"lists orders filtered by some parameters.",
+		"",
+		[]string{"orders"},
+		[]string{"orders:read", "https://www.googleapis.com/auth/userinfo.email"},
+	)
+	assertOperationBody(t,
+		po.Post,
+		"createOrder",
+		"create an order based on the parameters.",
+		"",
+		[]string{"orders"},
+		[]string{"read", "write"},
+	)
+
+	po, ok = ops.Paths["/orders/{id}"]
+	assert.True(t, ok)
+	assert.NotNil(t, po.Get)
+	assertOperationBody(t,
+		po.Get,
+		"orderDetails",
+		"gets the details for an order.",
+		"",
+		[]string{"orders"},
+		[]string{"read", "write"},
+	)
+
+	assertOperationBody(t,
+		po.Put,
+		"updateOrder",
+		"Update the details for an order.",
+		"When the order doesn't exist this will return an error.",
+		[]string{"orders"},
+		[]string{"read", "write"},
+	)
+
+	assertOperationBody(t,
+		po.Delete,
+		"deleteOrder",
+		"delete a particular order.",
+		"",
+		nil,
+		[]string{"read", "write"},
+	)
+}
+
 func assertOperation(t *testing.T, op *spec.Operation, id, summary, description string, tags, scopes []string) {
 	assert.NotNil(t, op)
 	assert.Equal(t, summary, op.Summary)
@@ -139,4 +225,37 @@ func assertOperation(t *testing.T, op *spec.Operation, id, summary, description 
 	rsp, ok = op.Responses.StatusCodeResponses[422]
 	assert.True(t, ok)
 	assert.Equal(t, "#/responses/validationError", rsp.Ref.String())
+}
+
+func assertOperationBody(t *testing.T, op *spec.Operation, id, summary, description string, tags, scopes []string) {
+	assert.NotNil(t, op)
+	assert.Equal(t, summary, op.Summary)
+	assert.Equal(t, description, op.Description)
+	assert.Equal(t, id, op.ID)
+	assert.EqualValues(t, tags, op.Tags)
+	assert.EqualValues(t, []string{"application/json", "application/x-protobuf"}, op.Consumes)
+	assert.EqualValues(t, []string{"application/json", "application/x-protobuf"}, op.Produces)
+	assert.EqualValues(t, []string{"http", "https", "ws", "wss"}, op.Schemes)
+	assert.Len(t, op.Security, 2)
+	_, ok := op.Security[0]["api_key"]
+	assert.True(t, ok)
+
+	vv, ok := op.Security[1]["oauth"]
+	assert.True(t, ok)
+	assert.EqualValues(t, scopes, vv)
+
+	assert.NotNil(t, op.Responses.Default)
+	data, _ := json.MarshalIndent(op.Responses.Default, "    ", "")
+	log.Println(string(data))
+	assert.Equal(t, "", op.Responses.Default.Ref.String())
+	assert.Equal(t, "#/definitions/genericError", op.Responses.Default.Schema.Ref.String())
+
+	rsp, ok := op.Responses.StatusCodeResponses[200]
+	assert.True(t, ok)
+	assert.Equal(t, "", rsp.Ref.String())
+	assert.Equal(t, "#/definitions/someResponse", rsp.Schema.Ref.String())
+	rsp, ok = op.Responses.StatusCodeResponses[422]
+	assert.True(t, ok)
+	assert.Equal(t, "", rsp.Ref.String())
+	assert.Equal(t, "#/definitions/validationError", rsp.Schema.Ref.String())
 }

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -569,11 +569,20 @@ func (ss *setOpResponses) Parse(lines []string) error {
 			var ref spec.Ref
 			var err error
 			if arrays == 0 {
-				ref, err = spec.NewRef("#/responses/" + value)
+				if strings.HasPrefix(value, "body:") {
+					isDefinitionRef = true
+					ref, err = spec.NewRef("#/definitions/" + value[5:])
+				} else {
+					ref, err = spec.NewRef("#/responses/" + value)
+				}
 			} else {
 				isDefinitionRef = true
 				ref, err = spec.NewRef("#/definitions/" + value)
 			}
+			if err != nil {
+				return err
+			}
+
 			if _, ok := ss.responses[value]; !ok {
 				if _, ok := ss.definitions[value]; ok {
 					isDefinitionRef = true


### PR DESCRIPTION
Example:
``` 
//swagger:model Person

// swagger:route GET /person/{id} people getPerson
//
// Get the person by id.
//
// Returns a person
//
// Consumes:
// - application/json
//
// Produces:
// - application/json
//
// Schemes: https
//
// Responses:
//     200: body:Person
```

Properly uses a person from a schema defined with the swagger spec when using generate spec.

Closes #595
Closes #140