### PR TITLE
Fix packageForFile picking incorrect package

### DIFF
--- a/scan/schema.go
+++ b/scan/schema.go
@@ -754,9 +754,13 @@ func (scp *schemaParser) createParser(nm string, schema, ps *spec.Schema, fld *a
 }
 
 func (scp *schemaParser) packageForFile(gofile *ast.File) (*loader.PackageInfo, error) {
-	for pkg, pkgInfo := range scp.program.AllPackages {
-		if pkg.Name() == gofile.Name.Name {
-			return pkgInfo, nil
+	for _, pkgInfo := range scp.program.AllPackages {
+		if pkgInfo.Importable {
+			for _, fil := range pkgInfo.Files {
+				if fil.Pos() == gofile.Pos() {
+					return pkgInfo, nil
+				}
+			}
 		}
 	}
 	fn := scp.program.Fset.File(gofile.Pos()).Name()


### PR DESCRIPTION
If there are multiple packages of the same name, it might pick the wrong one. Pos will absolutely pick the correct file.

This fixes my app in #608, but it unfortunately breaks the test suite because `gofile.Pos()` (`../fixtures/goparsing/classification/models/nomodel.go`) is different to `fil.Pos()` (`/Users/ben/go/src/github.com/go-swagger/go-swagger/fixtures/goparsing/classification/operations/noparams.go`). I'm not sure why one is relative and one isn't, and I copied the code from elsewhere in the file, so I'm not sure why this doesn't work. Any ideas?

Also – not quite sure how to write a test for this, because I think the behaviour is non-deterministic depending on what order files are scanned...