### PR TITLE
Fix scopes to be initialized to an empty array

### DIFF
--- a/scan/routes_test.go
+++ b/scan/routes_test.go
@@ -208,8 +208,11 @@ func assertOperation(t *testing.T, op *spec.Operation, id, summary, description 
 	assert.EqualValues(t, []string{"application/json", "application/x-protobuf"}, op.Produces)
 	assert.EqualValues(t, []string{"http", "https", "ws", "wss"}, op.Schemes)
 	assert.Len(t, op.Security, 2)
-	_, ok := op.Security[0]["api_key"]
+	akv, ok := op.Security[0]["api_key"]
 	assert.True(t, ok)
+	// akv must be defined & not empty
+	assert.NotNil(t, akv)
+	assert.Empty(t, akv)
 
 	vv, ok := op.Security[1]["oauth"]
 	assert.True(t, ok)
@@ -236,8 +239,11 @@ func assertOperationBody(t *testing.T, op *spec.Operation, id, summary, descript
 	assert.EqualValues(t, []string{"application/json", "application/x-protobuf"}, op.Produces)
 	assert.EqualValues(t, []string{"http", "https", "ws", "wss"}, op.Schemes)
 	assert.Len(t, op.Security, 2)
-	_, ok := op.Security[0]["api_key"]
+	akv, ok := op.Security[0]["api_key"]
 	assert.True(t, ok)
+	// akv must be defined & not empty
+	assert.NotNil(t, akv)
+	assert.Empty(t, akv)
 
 	vv, ok := op.Security[1]["oauth"]
 	assert.True(t, ok)

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -481,7 +481,7 @@ func (ss *setSecurityDefinitions) Parse(lines []string) error {
 	var result []map[string][]string
 	for _, line := range lines {
 		kv := strings.SplitN(line, ":", 2)
-		var scopes []string
+		scopes := []string{}
 		var key string
 
 		if len(kv) > 1 {


### PR DESCRIPTION
* According to the Security Object Requirements[1] for "other security
  scheme types, the array MUST be empty." Initializing the scopes
  slice fixes this issue by no longer returing "null" in the json.
  This also works for the case of oauth as the security type since
  that is expecting an array of scopes.

  [1] http://swagger.io/specification/#securityRequirementObject

Signed-off-by: Harley Laue <losinggeneration@gmail.com>