### PR TITLE
fix issue with map type

### DIFF
--- a/scan/schema.go
+++ b/scan/schema.go
@@ -906,6 +906,9 @@ func (scp *schemaParser) parseIdentProperty(pkg *loader.PackageInfo, expr *ast.I
 	case *ast.InterfaceType:
 		return scp.makeRef(file, gd, ts, prop)
 
+	case *ast.MapType:
+		return scp.makeRef(file, gd, ts, prop)
+
 	default:
 		err := swaggerSchemaForType(expr.Name, prop)
 		if err != nil {


### PR DESCRIPTION
issue with parsing custom types for maps

```go
type MapType map[string]string
type MapTypeArr map[string][]string

type MyStruct struct {
    Field   MapType
    Field2   MapTypeArr
}
```

I have problem with writing test for it fast, just have to spend more time to understand what is going on there and create the test.
 
Looks like there is one issue more, but i didn't find it yet.
example is here: 
https://github.com/gaplyk/go-swagger-issue