### PR TITLE
Tests for issue with maps

### DIFF
--- a/fixtures/goparsing/classification/models/extranomodel.go
+++ b/fixtures/goparsing/classification/models/extranomodel.go
@@ -71,6 +71,9 @@ type SomeObject map[string]interface{}
 // SomeStringMap is a type that refines a string value map
 type SomeStringMap map[string]string
 
+// SomeArrayStringMap is a type that refines a array of strings value map
+type SomeArrayStringMap map[string][]string
+
 // SomeIntMap is a type that refines an int value map
 type SomeIntMap map[string]int64
 

--- a/fixtures/goparsing/classification/models/nomodel.go
+++ b/fixtures/goparsing/classification/models/nomodel.go
@@ -120,12 +120,14 @@ type NoModel struct {
 
 // A OtherTypes struct contains type aliases
 type OtherTypes struct {
-	Named       SomeStringType `json:"named"`
-	Numbered    SomeIntType    `json:"numbered"`
-	Dated       SomeTimeType   `json:"dated"`
-	Timed       SomeTimedType  `json:"timed"`
-	Petted      SomePettedType `json:"petted"`
-	Somethinged SomethingType  `json:"somethinged"`
+	Named       SomeStringType     `json:"named"`
+	Numbered    SomeIntType        `json:"numbered"`
+	Dated       SomeTimeType       `json:"dated"`
+	Timed       SomeTimedType      `json:"timed"`
+	Petted      SomePettedType     `json:"petted"`
+	Somethinged SomethingType      `json:"somethinged"`
+	StrMap      SomeStringMap      `json:"strMap"`
+	StrArrMap   SomeArrayStringMap `json:"strArrMap"`
 
 	ManyNamed       SomeStringsType `json:"manyNamed"`
 	ManyNumbered    SomeIntsType    `json:"manyNumbered"`

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -906,6 +906,9 @@ func (scp *schemaParser) parseIdentProperty(pkg *loader.PackageInfo, expr *ast.I
 	case *ast.InterfaceType:
 		return scp.makeRef(file, gd, ts, prop)
 
+	case *ast.MapType:
+		return scp.makeRef(file, gd, ts, prop)
+
 	default:
 		err := swaggerSchemaForType(expr.Name, prop)
 		if err != nil {

--- a/scan/schema_test.go
+++ b/scan/schema_test.go
@@ -212,6 +212,8 @@ func TestAliasedTypes(t *testing.T) {
 	assertRef(t, &schema, "timed", "Timed", "#/definitions/SomeTimedType")
 	assertRef(t, &schema, "petted", "Petted", "#/definitions/SomePettedType")
 	assertRef(t, &schema, "somethinged", "Somethinged", "#/definitions/SomethingType")
+	assertRef(t, &schema, "strMap", "StrMap", "#/definitions/SomeStringMap")
+	assertRef(t, &schema, "strArrMap", "StrArrMap", "#/definitions/SomeArrayStringMap")
 
 	assertRef(t, &schema, "manyNamed", "ManyNamed", "#/definitions/SomeStringsType")
 	assertRef(t, &schema, "manyNumbered", "ManyNumbered", "#/definitions/SomeIntsType")


### PR DESCRIPTION
issue with parsing custom types for maps

```go
type MapType map[string]string
type MapTypeArr map[string][]string

type MyStruct struct {
    Field   MapType
    Field2   MapTypeArr
}
```

I have problem with writing test for it fast, just have to spend more time to understand what is going on there and create the test.
 
Looks like there is one issue more, but i didn't find it yet.
example is here: 
https://github.com/gaplyk/go-swagger-issue