### PR TITLE
Correcting typo

### DIFF
--- a/examples/task-tracker/client/tasks/add_comment_to_task_responses.go
+++ b/examples/task-tracker/client/tasks/add_comment_to_task_responses.go
@@ -21,7 +21,7 @@ type AddCommentToTaskReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *AddCommentToTaskReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/task-tracker/client/tasks/create_task_responses.go
+++ b/examples/task-tracker/client/tasks/create_task_responses.go
@@ -19,7 +19,7 @@ type CreateTaskReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *CreateTaskReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/task-tracker/client/tasks/delete_task_responses.go
+++ b/examples/task-tracker/client/tasks/delete_task_responses.go
@@ -19,7 +19,7 @@ type DeleteTaskReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *DeleteTaskReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/task-tracker/client/tasks/get_task_comments_responses.go
+++ b/examples/task-tracker/client/tasks/get_task_comments_responses.go
@@ -19,7 +19,7 @@ type GetTaskCommentsReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *GetTaskCommentsReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/task-tracker/client/tasks/get_task_details_responses.go
+++ b/examples/task-tracker/client/tasks/get_task_details_responses.go
@@ -19,7 +19,7 @@ type GetTaskDetailsReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *GetTaskDetailsReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/task-tracker/client/tasks/list_tasks_responses.go
+++ b/examples/task-tracker/client/tasks/list_tasks_responses.go
@@ -21,7 +21,7 @@ type ListTasksReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *ListTasksReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/task-tracker/client/tasks/update_task_responses.go
+++ b/examples/task-tracker/client/tasks/update_task_responses.go
@@ -19,7 +19,7 @@ type UpdateTaskReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *UpdateTaskReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/task-tracker/client/tasks/upload_task_file_responses.go
+++ b/examples/task-tracker/client/tasks/upload_task_file_responses.go
@@ -19,7 +19,7 @@ type UploadTaskFileReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *UploadTaskFileReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/todo-list/client/todos/add_one_responses.go
+++ b/examples/todo-list/client/todos/add_one_responses.go
@@ -19,7 +19,7 @@ type AddOneReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *AddOneReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/todo-list/client/todos/destroy_one_responses.go
+++ b/examples/todo-list/client/todos/destroy_one_responses.go
@@ -19,7 +19,7 @@ type DestroyOneReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *DestroyOneReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/todo-list/client/todos/find_responses.go
+++ b/examples/todo-list/client/todos/find_responses.go
@@ -19,7 +19,7 @@ type FindReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *FindReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/examples/todo-list/client/todos/update_one_responses.go
+++ b/examples/todo-list/client/todos/update_one_responses.go
@@ -19,7 +19,7 @@ type UpdateOneReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *UpdateOneReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/generator/templates/client/response.gotmpl
+++ b/generator/templates/client/response.gotmpl
@@ -100,7 +100,7 @@ type {{ pascalize .Name }}Reader struct {
   writer  io.Writer{{ end }}
 }
 
-// ReadResponse reads a server response into the recieved {{ .ReceiverName }}.
+// ReadResponse reads a server response into the received {{ .ReceiverName }}.
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Reader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
   switch response.Code() {
   {{ range $key, $value := .Responses }}

--- a/vendor/github.com/asaskevich/govalidator/validator.go
+++ b/vendor/github.com/asaskevich/govalidator/validator.go
@@ -62,7 +62,7 @@ func IsURL(str string) bool {
 }
 
 // IsRequestURL check if the string rawurl, assuming
-// it was recieved in an HTTP request, is a valid
+// it was received in an HTTP request, is a valid
 // URL confirm to RFC 3986
 func IsRequestURL(rawurl string) bool {
 	url, err := url.ParseRequestURI(rawurl)
@@ -76,7 +76,7 @@ func IsRequestURL(rawurl string) bool {
 }
 
 // IsRequestURI check if the string rawurl, assuming
-// it was recieved in an HTTP request, is an
+// it was received in an HTTP request, is an
 // absolute URI or an absolute path.
 func IsRequestURI(rawurl string) bool {
 	_, err := url.ParseRequestURI(rawurl)


### PR DESCRIPTION
Spotted that the code had 'recieved' in it, both in templates and comments. This patch changes that to 'received'