### PR TITLE
Default https host before mutating it.

### DIFF
--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -216,6 +216,11 @@ func (s *Server) Listen() error {
 		if s.TLSCertificateKey == "" {
 			s.Fatalf("the required flag `--tls-key` was not specified")
 		}
+
+    // Use http host if https host wasn't defined
+    if s.TLSHost == "" {
+      s.TLSHost = s.Host
+    }
   }
 
   if s.hasScheme(schemeUnix) {
@@ -242,9 +247,6 @@ func (s *Server) Listen() error {
   }
 
   if s.hasScheme(schemeHTTPS) {
-    if s.TLSHost == "" {
-      s.TLSHost = s.Host
-    }
     tlsListener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.TLSHost, s.TLSPort))
     if err != nil {
       return err

--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -2,10 +2,10 @@ package {{ .APIPackage }}
 
 import (
 	"crypto/tls"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	flags "github.com/jessevdk/go-flags"
@@ -232,7 +232,7 @@ func (s *Server) Listen() error {
   }
 
   if s.hasScheme(schemeHTTP) {
-    listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.Host, s.Port))
+    listener, err := net.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)))
     if err != nil {
       return err
     }
@@ -247,7 +247,7 @@ func (s *Server) Listen() error {
   }
 
   if s.hasScheme(schemeHTTPS) {
-    tlsListener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.TLSHost, s.TLSPort))
+    tlsListener, err := net.Listen("tcp", net.JoinHostPort(s.TLSHost, strconv.Itoa(s.TLSPort)))
     if err != nil {
       return err
     }


### PR DESCRIPTION
Hi,

I found the following problem: if I will run the server with `--host=0.0.0.0` and I have both http and https schemes - the server will panic with `listen tcp: too many colons in address :::0`.

I think I figured out what's going wrong:
1. here https://github.com/go-swagger/go-swagger/blob/master/generator/templates/server/server.gotmpl#L230 `s.Host` is being used to construct the address. This works fine.
2. here https://github.com/go-swagger/go-swagger/blob/master/generator/templates/server/server.gotmpl#L239 `s.Host` will be re-assigned with the value from the `swag.SplitHostPort(listener.Addr().String())`. This works mostly fine except when the host is `0.0.0.0`. In this case `s.Host` will be `::` which apparently would mean all interfaces.
3. and finally here https://github.com/go-swagger/go-swagger/blob/master/generator/templates/server/server.gotmpl#L248 tlsListener will use the modified `s.Host`. And if it was changed to `::` the resulting address will be `:::0` (instead of `[::]:0`).

I'm not sure what was the best way to fix the issue, so I just moved the assignment of the https host to the top before its modification. Please tell me if you think there's a better way.

PS: thanks for the amazing go-swagger project!
