### PR TITLE
Bug fixes for generating operation models

### DIFF
--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -30,6 +30,7 @@ type Operation struct {
 	NoHandler     bool     `long:"skip-handler" description:"when present will not generate an operation handler"`
 	NoStruct      bool     `long:"skip-parameters" description:"when present will not generate the parameter model struct"`
 	NoResponses   bool     `long:"skip-responses" description:"when present will not generate the response model struct"`
+	NoValidator   bool     `long:"skip-validator" description:"when present will not generate a model validator"`
 	DumpData      bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
 }
 
@@ -44,6 +45,7 @@ func (o *Operation) Execute(args []string) error {
 		!o.NoHandler,
 		!o.NoStruct,
 		!o.NoResponses,
+		!o.NoValidator,
 		generator.GenOpts{
 			Spec:          string(o.Spec),
 			Target:        string(o.Target),

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -564,9 +564,15 @@ func (b *codeGenOpBuilder) MakeResponse(receiver, name string, isSuccess bool, r
 	sort.Sort(res.Headers)
 
 	if resp.Schema != nil {
+		var title string
+		if resp.Schema.Title != "" {
+			title = resp.Schema.Title
+		} else {
+			title = name + "Body"
+		}
 		sc := schemaGenContext{
 			Path:             fmt.Sprintf("%q", name),
-			Name:             name + "Body",
+			Name:             title,
 			Receiver:         receiver,
 			ValueExpr:        receiver,
 			IndexVar:         "i",
@@ -592,7 +598,7 @@ func (b *codeGenOpBuilder) MakeResponse(receiver, name string, isSuccess bool, r
 		schema := sc.GenSchema
 		if schema.IsAnonymous {
 
-			schema.Name = swag.ToGoName(sc.Name + " Body")
+			schema.Name = swag.ToGoName(sc.Name)
 			nm := schema.Name
 			if b.ExtraSchemas == nil {
 				b.ExtraSchemas = make(map[string]GenSchema)


### PR DESCRIPTION
Fixes #676

* adds `--skip-validator` to `swagger generate operation` so that models can be generated without validation
* fixes a bug where anonymous response objects were created with a suffix of `BodyBody`. Now only one `Body` as appended
* adds support for setting the name of an anonymous schema from the `title`

If any of this is controversial I'd be happy to split it into a separate PR to get the rest merged.