### PR TITLE
Allow x-nullable for nested models

### DIFF
--- a/generator/typeresolver_test.go
+++ b/generator/typeresolver_test.go
@@ -462,7 +462,7 @@ func TestTypeResolver_AnonymousStructs(t *testing.T) {
 
 		rt, err = resolver.ResolveSchema(parent, true, true)
 		if assert.NoError(t, err) {
-			assert.True(t, rt.IsNullable)
+			assert.False(t, rt.IsNullable)
 			assert.True(t, rt.IsAnonymous)
 			assert.True(t, rt.IsComplexObject)
 		}

--- a/generator/types.go
+++ b/generator/types.go
@@ -346,13 +346,19 @@ func (t *typeResolver) resolveFormat(schema *spec.Schema, isAnonymous bool, isRe
 }
 
 func (t *typeResolver) isNullable(schema *spec.Schema) bool {
-	return t.checkIsNullable(xIsNullable, schema) || t.checkIsNullable(xNullable, schema)
-}
+	check := func(extension string) (bool, bool) {
+		v, found := schema.Extensions[extension]
+		nullable, cast := v.(bool)
+		return nullable, found && cast
+	}
 
-func (t *typeResolver) checkIsNullable(extension string, schema *spec.Schema) bool {
-	v, found := schema.Extensions[extension]
-	nullable, cast := v.(bool)
-	return (found && cast && nullable) || len(schema.Properties) > 0
+	if nullable, ok := check(xIsNullable); ok {
+		return nullable
+	}
+	if nullable, ok := check(xNullable); ok {
+		return nullable
+	}
+	return len(schema.Properties) > 0
 }
 
 func (t *typeResolver) firstType(schema *spec.Schema) string {


### PR DESCRIPTION
Re discussion in slack (https://goswagger.slack.com/archives/general/p1475701532000329)

`false` values for `x-nullable` were being ignored. This allows nested models to be non-pointers.