### PR TITLE
Fix issue with empty schema 

### DIFF
--- a/scan/schema.go
+++ b/scan/schema.go
@@ -690,7 +690,7 @@ func (scp *schemaParser) parseStructType(gofile *ast.File, bschema *spec.Schema,
 			schema.Properties[nm] = ps
 		}
 	}
-	if schema != nil && hasAllOf {
+	if schema != nil && hasAllOf && len(schema.Properties) > 0 {
 		bschema.AllOf = append(bschema.AllOf, *schema)
 	}
 	for k := range schema.Properties {


### PR DESCRIPTION
of properties when allOf is exists in the struct

example: 
```go 
type EmbeddedModel struct {
	Field string `json:"field"`
}

type AllOfStruct struct {
    // swagger:allOf
    EmbeddedModel
}
````

the result gonna be:
```json
"AllOfStruct":{
   "allOf":[
      {"type":"object","properties":{"field":{"type":"string","x-go-name":"Field"}}},
      {"type":"object"}
   ]
}
```