### PR TITLE
Support x-go-name in code generation

### DIFF
--- a/generator/model.go
+++ b/generator/model.go
@@ -522,13 +522,6 @@ func (sg *schemaGenContext) buildProperties() error {
 		log.Printf("building properties %s (parent: %s)", sg.Name, sg.Container)
 	}
 
-	//var discriminatorField string
-	//if sg.Discrimination != nil {
-	//dis, ok := sg.Discriminated["#/definitions/"+sg.Container]
-	//if ok {
-
-	//}
-	//}
 	for k, v := range sg.Schema.Properties {
 		if Debug {
 			bbb, _ := json.MarshalIndent(sg.Schema, "", "  ")
@@ -1150,6 +1143,14 @@ func (sg *schemaGenContext) buildAliased() error {
 	return nil
 }
 
+func (sg *schemaGenContext) GoName() string {
+	name, _ := sg.Schema.Extensions.GetString("x-go-name")
+	if name != "" {
+		return name
+	}
+	return sg.Name
+}
+
 func (sg *schemaGenContext) makeGenSchema() error {
 	if Debug {
 		log.Printf("making gen schema (anon: %t, req: %t, tuple: %t) %s\n", !sg.Named, sg.Required, sg.IsTuple, sg.Name)
@@ -1166,7 +1167,7 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	sg.GenSchema.Location = "body"
 	sg.GenSchema.ValueExpression = sg.ValueExpr
 	sg.GenSchema.KeyVar = sg.KeyVar
-	sg.GenSchema.Name = sg.Name
+	sg.GenSchema.Name = sg.GoName()
 	sg.GenSchema.Title = sg.Schema.Title
 	sg.GenSchema.Description = sg.Schema.Description
 	sg.GenSchema.ReceiverName = sg.Receiver

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -534,15 +534,9 @@ func (b *codeGenOpBuilder) MakeResponse(receiver, name string, isSuccess bool, r
 	sort.Sort(res.Headers)
 
 	if resp.Schema != nil {
-		var title string
-		if resp.Schema.Title != "" {
-			title = resp.Schema.Title
-		} else {
-			title = name + "Body"
-		}
 		sc := schemaGenContext{
 			Path:             fmt.Sprintf("%q", name),
-			Name:             title,
+			Name:             name + "Body",
 			Receiver:         receiver,
 			ValueExpr:        receiver,
 			IndexVar:         "i",

--- a/generator/types.go
+++ b/generator/types.go
@@ -570,11 +570,8 @@ func boolExtension(ext spec.Extensions, key string) *bool {
 
 func (t *typeResolver) ResolveSchema(schema *spec.Schema, isAnonymous, isRequired bool) (result resolvedType, err error) {
 	if Debug {
-		// bbb, _ := json.MarshalIndent(schema, "", "  ")
 		_, file, pos, _ := runtime.Caller(1)
 		log.Printf("%s:%d: resolving schema (anon: %t, req: %t) %s\n", filepath.Base(file), pos, isAnonymous, isRequired, t.ModelName /*bbb*/)
-		// tt, _ := json.MarshalIndent(t, "", "  ")
-		// log.Println("resolver", string(tt))
 	}
 	if schema == nil {
 		result.IsInterface = true


### PR DESCRIPTION
Fixes #701 
Fixes #402 

The second commit is reverting one of my earlier changes. I didn't realize that `x-go-name` was the correct way to set the name of the model. Trying to set the name from a title will probably break things.