### PR TITLE
added enum support

### DIFF
--- a/scan/enum.go
+++ b/scan/enum.go
@@ -1,0 +1,81 @@
+package scan
+
+import (
+	"go/ast"
+	"strconv"
+	"unicode"
+	"strings"
+)
+
+func upperSnakeCase(s string) string {
+	in := []rune(s)
+	isLower := func(idx int) bool {
+		return idx >= 0 && idx < len(in) && unicode.IsLower(in[idx])
+	}
+
+	out := make([]rune, 0, len(in) + len(in) / 2)
+
+	for i, r := range in {
+		if unicode.IsUpper(r) {
+			r = unicode.ToLower(r)
+			if i > 0 && in[i - 1] != '_' && (isLower(i - 1) || isLower(i + 1)) {
+				out = append(out, '_')
+			}
+		}
+		out = append(out, r)
+	}
+
+	return strings.ToUpper(string(out))
+}
+
+func getEnumBasicLitValue(basicLit *ast.BasicLit) interface{} {
+	switch(basicLit.Kind.String()){
+	case "INT":
+		if result, err := strconv.ParseInt(basicLit.Value, 10, 64); err == nil {
+			return result
+		}
+	case "FLOAT":
+		if result, err := strconv.ParseFloat(basicLit.Value, 64); err == nil {
+			return result
+		}
+	default:
+		return strings.Trim(basicLit.Value, "\"")
+	}
+	return nil;
+}
+
+func getEnumValues(file *ast.File, typeName string) (list []interface{}) {
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+
+		if !ok {
+			continue
+		}
+
+		if (genDecl.Tok.String() == "const") {
+			for _, spec := range genDecl.Specs {
+				if valueSpec, ok := spec.(*ast.ValueSpec); ok {
+					switch valueSpec.Type.(type) {
+					case *ast.Ident:
+						if (valueSpec.Type.(*ast.Ident).Name == typeName) {
+							if basicLit, ok := valueSpec.Values[0].(*ast.BasicLit); ok {
+								list = append(list, getEnumBasicLitValue(basicLit))
+							}
+						}
+					default:
+						var name = valueSpec.Names[0].Name
+						if (strings.HasPrefix(name, upperSnakeCase(typeName))) {
+							var values = strings.SplitN(name, "__", 2);
+							if (len(values) == 2) {
+								list = append(list, values[1])
+							}
+						}
+					}
+
+				}
+
+			}
+		}
+	}
+	return
+}

--- a/scan/parameters.go
+++ b/scan/parameters.go
@@ -38,6 +38,10 @@ func (pt paramTypable) Typed(tpe, format string) {
 	pt.param.Typed(tpe, format)
 }
 
+func (pt paramTypable) WithEnum(values ...interface{}) {
+	pt.param.WithEnum(values...);
+}
+
 func (pt paramTypable) SetRef(ref spec.Ref) {
 	pt.param.Ref = ref
 }
@@ -79,6 +83,10 @@ func (pt itemsTypable) Typed(tpe, format string) {
 
 func (pt itemsTypable) SetRef(ref spec.Ref) {
 	pt.items.Ref = ref
+}
+
+func (pt itemsTypable) WithEnum(values ...interface{}) {
+	pt.items.WithEnum(values...);
 }
 
 func (pt itemsTypable) Schema() *spec.Schema {

--- a/scan/responses.go
+++ b/scan/responses.go
@@ -36,6 +36,10 @@ func (ht responseTypable) Typed(tpe, format string) {
 	ht.header.Typed(tpe, format)
 }
 
+func (ht responseTypable) WithEnum(values ...interface{}) {
+	ht.header.WithEnum(values)
+}
+
 func bodyTypable(in string, schema *spec.Schema) (swaggerTypable, *spec.Schema) {
 	if in == "body" {
 		// get the schema for items on the schema property

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -430,6 +430,7 @@ type swaggerTypable interface {
 	Typed(string, string)
 	SetRef(spec.Ref)
 	Items() swaggerTypable
+	WithEnum(...interface{})
 	Schema() *spec.Schema
 	Level() int
 }


### PR DESCRIPTION
Just spike for the `enum`

The usage like `swagger: strfmt`, and will be two way to collection the enum values:

* if const be typed, we will use the value of const which defined by the target type
* if `iota` const setted, we will use the typename of const with prefix (snake upper case) equals target type

```go
// swagger:enum
type Level string

const (
	LEVEL_1 Level = "ONE"
	LEVEL_2 Level = "TWO"
	LEVEL_3 Level = "THREE"
)

// swagger:enum
type LevelInt int

const (
        // LEVEL_INT will be type and ONE will be the value
	LEVEL_INT__ONE = iota + 1
	LEVEL_INT__TWO
)

// swagger:model
type Model struct {
	level Level
	levelInt LevelInt;
}
```

will be

```yaml
definitions:
  Model:
     type: "object"
     properties:
        level: 
         type: "string"
         enum: 
           - "ONE"
           - "TWO"
           - "THREE"
       levelInt: 
         type: "string"
         enum: 
           - "ONE"
           - "TWO"
```