### PR TITLE
Adds support for parsing `[]*Foo` in parameters

### DIFF
--- a/fixtures/goparsing/classification/operations/noparams.go
+++ b/fixtures/goparsing/classification/operations/noparams.go
@@ -45,6 +45,22 @@ type OrderBodyParams struct {
 	Order *models.StoreOrder `json:"order"`
 }
 
+// An MultipleOrderParams model.
+//
+// This is used for operations that want multiple orders as the body
+// swagger:parameters getOrders
+type MultipleOrderParams struct {
+	// The orders
+	// required: true
+	Orders []*OrderBodyParams `json:"orders"`
+
+	// And another thing
+	// in: body
+	Another []struct {
+		That string `json:"that"`
+	} `json:"another"`
+}
+
 // A ComplexerOneParams is composed of a SimpleOne and some extra fields
 // swagger:parameters yetAnotherOperation
 type ComplexerOneParams struct {

--- a/scan/parameters_test.go
+++ b/scan/parameters_test.go
@@ -35,7 +35,7 @@ func TestScanFileParam(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	assert.Len(t, noParamOps, 6)
+	assert.Len(t, noParamOps, 7)
 
 	of, ok := noParamOps["myOperation"]
 	assert.True(t, ok)
@@ -59,7 +59,7 @@ func TestParamsParser(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	assert.Len(t, noParamOps, 6)
+	assert.Len(t, noParamOps, 7)
 
 	cr, ok := noParamOps["yetAnotherOperation"]
 	assert.True(t, ok)
@@ -103,6 +103,16 @@ func TestParamsParser(t *testing.T) {
 	assert.Equal(t, "body", bodyParam.In)
 	assert.Equal(t, "#/definitions/order", bodyParam.Schema.Ref.String())
 	assert.True(t, bodyParam.Required)
+
+	mop, ok := noParamOps["getOrders"]
+	assert.True(t, ok)
+	assert.Len(t, mop.Parameters, 2)
+	ordersParam := mop.Parameters[0]
+	assert.Equal(t, "The orders", ordersParam.Description)
+	assert.True(t, ordersParam.Required)
+	assert.Equal(t, "array", ordersParam.Type)
+	otherParam := mop.Parameters[1]
+	assert.Equal(t, "And another thing", otherParam.Description)
 
 	op, ok := noParamOps["someOperation"]
 	assert.True(t, ok)


### PR DESCRIPTION
Pulls the simple loop out in favor of a recursive function to handle `ast.StarExpr`. This does not extend to something like

```go
// swagger:parameters fooBar
type FooBarParams struct {
	// Other things
	Other []*[]struct {
		Those string `json:"those"`
	} `json:"other"`
}
```

but I assumed that would be ok as I can't see a real use for that construct.
