### PR TITLE
805 support array type validation

### DIFF
--- a/generator/templates/header.gotmpl
+++ b/generator/templates/header.gotmpl
@@ -5,6 +5,7 @@ package {{.Package}}
 
 {{if or .Imports .DefaultImports }}import (
   strfmt "github.com/go-openapi/strfmt"
+  goruntime "runtime"
 
   {{range .DefaultImports }}{{ printf "%q" .}}
   {{end}}

--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -5,38 +5,38 @@ if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}S
 }
 {{ end }}
 {{if .MinLength}}
-if err := validate.MinLength({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, string({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.MinLength}}); err != nil {
+if err := validate.MinLength({{ if .Path }}{{ .Path }}{{else}}propName{{end}}, {{ printf "%q" .Location }}, string({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.MinLength}}); err != nil {
   return err
 }
 {{end}}
 {{if .MaxLength}}
-if err := validate.MaxLength({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, string({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.MaxLength}}); err != nil {
+if err := validate.MaxLength({{ if .Path }}{{ .Path }}{{else}}propName{{end}}, {{ printf "%q" .Location }}, string({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.MaxLength}}); err != nil {
   return err
 }
 {{end}}
 {{if .Pattern}}
-if err := validate.Pattern({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, string({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), `{{.Pattern}}`); err != nil {
+if err := validate.Pattern({{ if .Path }}{{ .Path }}{{else}}propName{{end}}, {{ printf "%q" .Location }}, string({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), `{{.Pattern}}`); err != nil {
   return err
 }
 {{end}}
 {{if .Minimum}}
-if err := validate.Minimum{{ if eq .SwaggerType "integer" }}Int{{ end }}({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ if eq .SwaggerType "integer" }}int{{ else }}float{{ end }}64({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.Minimum}}, {{.ExclusiveMinimum}}); err != nil {
+if err := validate.Minimum{{ if eq .SwaggerType "integer" }}Int{{ end }}({{ if .Path }}{{ .Path }}{{else}}propName{{end}}, {{ printf "%q" .Location }}, {{ if eq .SwaggerType "integer" }}int{{ else }}float{{ end }}64({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.Minimum}}, {{.ExclusiveMinimum}}); err != nil {
   return err
 }
 {{end}}
 {{if .Maximum}}
-if err := validate.Maximum{{ if eq .SwaggerType "integer" }}Int{{ end }}({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ if eq .SwaggerType "integer" }}int{{ else }}float{{ end }}64({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.Maximum}}, {{.ExclusiveMaximum}}); err != nil {
+if err := validate.Maximum{{ if eq .SwaggerType "integer" }}Int{{ end }}({{ if .Path }}{{ .Path }}{{else}}propName{{end}}, {{ printf "%q" .Location }}, {{ if eq .SwaggerType "integer" }}int{{ else }}float{{ end }}64({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.Maximum}}, {{.ExclusiveMaximum}}); err != nil {
   return err
 }
 {{end}}
 {{if .MultipleOf}}
-if err := validate.MultipleOf({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, float64({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.MultipleOf}}); err != nil {
+if err := validate.MultipleOf({{ if .Path }}{{ .Path }}{{else}}propName{{end}}, {{ printf "%q" .Location }}, float64({{ if .IsNullable }}*{{ end }}{{.ValueExpression}}), {{.MultipleOf}}); err != nil {
   return err
 }
 {{end}}
 {{if .Enum}}
 // value enum
-if err := {{.ReceiverName}}.validate{{ pascalize .Name }}{{ pascalize .Suffix }}Enum({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression}}); err != nil {
+if err := {{.ReceiverName}}.validate{{ pascalize .Name }}{{ pascalize .Suffix }}Enum({{ if .Path }}{{ .Path }}{{else}}propName{{end}}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression}}); err != nil {
   return err
 }
 {{end}}
@@ -247,6 +247,18 @@ func ({{ .ReceiverName }} *{{ if .IsExported }}{{ pascalize .Name}}{{ else }}{{ 
 // Validate validates this {{ humanize .Name }}
 func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if .IsExported }}{{ pascalize .Name}}{{ else }}{{ .Name }}{{ end }}) Validate(formats strfmt.Registry) error {
   var res []error
+
+  {{ if .IsPrimitive }}
+    var propName string
+    pc, _, _, ok := goruntime.Caller(1)
+    details := goruntime.FuncForPC(pc)
+    if ok && details != nil {
+      tmpAry := strings.Split(details.Name(), ".")
+      tmpStr := tmpAry[len(tmpAry)-1]
+      propName = tmpStr[len("validate"):len(tmpStr)]
+    }
+  {{ end }}
+
   {{ range .AllOf }}
     {{ if or .Required .HasValidations }}
     {{if .IsPrimitive }}{{ template "primitivefieldvalidator" .}}

--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -70,7 +70,7 @@ if err := validate.UniqueItems({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ pr
 if err := {{.ReceiverName}}.validate{{ pascalize .Name }}Enum({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{.ValueExpression}}); err != nil {
   return err
 }
-{{end}}{{ if .Items }}{{ if or .Items.Required .Items.HasValidations .Items.IsBaseType }}
+{{end}}{{ if .Items }}{{ if or .Items.Required .Items.HasValidations .Items.IsBaseType .Items.IsAliased }}
 for {{.IndexVar}} := 0; {{.IndexVar}} < len({{.ValueExpression}}); {{.IndexVar}}++ {
 {{with .Items}}
   {{ if and .IsNullable (not .Required) }}


### PR DESCRIPTION
Go-swagger supports array type validation for the modals that uses direct definition, while if the modal definition is set by $ref (aliased), the validation logic are not generated in Swagger templates rendering, causing Rest server unable to prevent invalid rest calls.