### PR TITLE
fix 805-support-array-type-validation-for-aliased-definition

### DIFF
--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -70,7 +70,7 @@ if err := validate.UniqueItems({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ pr
 if err := {{.ReceiverName}}.validate{{ pascalize .Name }}Enum({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{.ValueExpression}}); err != nil {
   return err
 }
-{{end}}{{ if .Items }}{{ if or .Items.Required .Items.HasValidations .Items.IsBaseType }}
+{{end}}{{ if .Items }}{{ if or .Items.Required .Items.HasValidations .Items.IsBaseType .Items.IsAliased }}
 for {{.IndexVar}} := 0; {{.IndexVar}} < len({{.ValueExpression}}); {{.IndexVar}}++ {
 {{with .Items}}
   {{ if and .IsNullable (not .Required) }}


### PR DESCRIPTION
Problem:
Go-swagger supports array type validation for the modals that uses direct definition, while if the modal definition is set by $ref (aliased), the validation logic are not generated in Swagger templates rendering, causing Rest server unable to prevent invalid rest calls.

Fix:
By allowing `IsAliased` items to be rendered for type validation.