### PR TITLE
Fix issue

### DIFF
--- a/scan/schema.go
+++ b/scan/schema.go
@@ -92,6 +92,7 @@ func (sv schemaValidations) SetMinLength(val int64)    { sv.current.MinLength = 
 func (sv schemaValidations) SetMaxLength(val int64)    { sv.current.MaxLength = &val }
 func (sv schemaValidations) SetPattern(val string)     { sv.current.Pattern = val }
 func (sv schemaValidations) SetUnique(val bool)        { sv.current.UniqueItems = val }
+func (sv schemaValidations) SetDefault(val string)     { sv.current.Default = val }
 func (sv schemaValidations) SetEnum(val string) {
 	list := strings.Split(val, ",")
 	interfaceSlice := make([]interface{}, len(list))
@@ -100,7 +101,6 @@ func (sv schemaValidations) SetEnum(val string) {
 	}
 	sv.current.Enum = interfaceSlice
 }
-func (sv schemaValidations) SetDefault(val string) { sv.current.Default = val }
 
 func newSchemaAnnotationParser(goName string) *schemaAnnotationParser {
 	return &schemaAnnotationParser{GoName: goName, rx: rxModelOverride}

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -85,22 +85,22 @@ func (sv schemaValidations) SetMinimum(val float64, exclusive bool) {
 	sv.current.Minimum = &val
 	sv.current.ExclusiveMinimum = exclusive
 }
-func (sv schemaValidations) SetMultipleOf(val float64)  { sv.current.MultipleOf = &val }
-func (sv schemaValidations) SetMinItems(val int64)      { sv.current.MinItems = &val }
-func (sv schemaValidations) SetMaxItems(val int64)      { sv.current.MaxItems = &val }
-func (sv schemaValidations) SetMinLength(val int64)     { sv.current.MinLength = &val }
-func (sv schemaValidations) SetMaxLength(val int64)     { sv.current.MaxLength = &val }
-func (sv schemaValidations) SetPattern(val string)      { sv.current.Pattern = val }
-func (sv schemaValidations) SetUnique(val bool)         { sv.current.UniqueItems = val }
-func (sv schemaValidations) SetEnum(val string)         {
-    list := strings.Split(val, ",")
-    interfaceSlice := make([]interface{}, len(list))
-    for i, d := range list {
-        interfaceSlice[i] = d
-    }
-    sv.current.Enum = interfaceSlice
+func (sv schemaValidations) SetMultipleOf(val float64) { sv.current.MultipleOf = &val }
+func (sv schemaValidations) SetMinItems(val int64)     { sv.current.MinItems = &val }
+func (sv schemaValidations) SetMaxItems(val int64)     { sv.current.MaxItems = &val }
+func (sv schemaValidations) SetMinLength(val int64)    { sv.current.MinLength = &val }
+func (sv schemaValidations) SetMaxLength(val int64)    { sv.current.MaxLength = &val }
+func (sv schemaValidations) SetPattern(val string)     { sv.current.Pattern = val }
+func (sv schemaValidations) SetUnique(val bool)        { sv.current.UniqueItems = val }
+func (sv schemaValidations) SetEnum(val string) {
+	list := strings.Split(val, ",")
+	interfaceSlice := make([]interface{}, len(list))
+	for i, d := range list {
+		interfaceSlice[i] = d
+	}
+	sv.current.Enum = interfaceSlice
 }
-func (sv schemaValidations) SetDefault(val string)          { sv.current.Default = val }
+func (sv schemaValidations) SetDefault(val string) { sv.current.Default = val }
 
 func newSchemaAnnotationParser(goName string) *schemaAnnotationParser {
 	return &schemaAnnotationParser{GoName: goName, rx: rxModelOverride}
@@ -548,6 +548,7 @@ func (scp *schemaParser) parseInterfaceType(gofile *ast.File, bschema *spec.Sche
 			hasAllOf = true
 		}
 	}
+
 	if schema == nil {
 		schema = bschema
 	}
@@ -589,7 +590,7 @@ func (scp *schemaParser) parseInterfaceType(gofile *ast.File, bschema *spec.Sche
 		}
 
 	}
-	if schema != nil && hasAllOf {
+	if schema != nil && hasAllOf && len(schema.Properties) > 0 {
 		bschema.AllOf = append(bschema.AllOf, *schema)
 	}
 	for k := range schema.Properties {
@@ -729,8 +730,8 @@ func (scp *schemaParser) createParser(nm string, schema, ps *spec.Schema, fld *a
 			newSingleLineTagParser("minItems", &setMinItems{schemaValidations{ps}, rxf(rxMinItemsFmt, "")}),
 			newSingleLineTagParser("maxItems", &setMaxItems{schemaValidations{ps}, rxf(rxMaxItemsFmt, "")}),
 			newSingleLineTagParser("unique", &setUnique{schemaValidations{ps}, rxf(rxUniqueFmt, "")}),
-            newSingleLineTagParser("enum", &setEnum{schemaValidations{ps}, rxf(rxEnumFmt, "")}),
-            newSingleLineTagParser("default", &setDefault{schemaValidations{ps}, rxf(rxDefaultFmt, "")}),
+			newSingleLineTagParser("enum", &setEnum{schemaValidations{ps}, rxf(rxEnumFmt, "")}),
+			newSingleLineTagParser("default", &setDefault{schemaValidations{ps}, rxf(rxDefaultFmt, "")}),
 			newSingleLineTagParser("required", &setRequiredSchema{schema, nm}),
 			newSingleLineTagParser("readOnly", &setReadOnlySchema{ps}),
 			newSingleLineTagParser("discriminator", &setDiscriminator{schema, nm}),
@@ -749,8 +750,8 @@ func (scp *schemaParser) createParser(nm string, schema, ps *spec.Schema, fld *a
 				newSingleLineTagParser(fmt.Sprintf("items%dMinItems", level), &setMinItems{schemaValidations{items}, rxf(rxMinItemsFmt, itemsPrefix)}),
 				newSingleLineTagParser(fmt.Sprintf("items%dMaxItems", level), &setMaxItems{schemaValidations{items}, rxf(rxMaxItemsFmt, itemsPrefix)}),
 				newSingleLineTagParser(fmt.Sprintf("items%dUnique", level), &setUnique{schemaValidations{items}, rxf(rxUniqueFmt, itemsPrefix)}),
-                newSingleLineTagParser(fmt.Sprintf("items%dEnum", level), &setEnum{schemaValidations{items}, rxf(rxEnumFmt, itemsPrefix)}),
-                newSingleLineTagParser(fmt.Sprintf("items%dDefault", level), &setDefault{schemaValidations{items}, rxf(rxDefaultFmt, itemsPrefix)}),
+				newSingleLineTagParser(fmt.Sprintf("items%dEnum", level), &setEnum{schemaValidations{items}, rxf(rxEnumFmt, itemsPrefix)}),
+				newSingleLineTagParser(fmt.Sprintf("items%dDefault", level), &setDefault{schemaValidations{items}, rxf(rxDefaultFmt, itemsPrefix)}),
 			}
 
 		}


### PR DESCRIPTION
In case of composed interfaces 
```go
type InterfaceA interface{
	FuncA() bool
}

type InterfaceB interface{
	FuncB() bool
}

type InterfaceC interface{
	InterfaceA
	InterfaceB
}
```

swagger will generate following:
```json
{
  "InterfaceC": {
    "type": "object",
    "allOf": [
      {
        "type": "object",
        "properties": {
          "FuncA": {
            "type": "boolean"
          }
        }
      },
      {
        "type": "object",
        "properties": {
          "FuncB": {
            "type": "boolean"
          }
        }
      },
      {
        "type": "object",
        "allOf": [
          {
            "type": "object",
            "properties": {
              "FuncA": {
                "type": "boolean"
              }
            }
          },
          {
            "type": "object",
            "properties": {
              "FuncB": {
                "type": "boolean"
              }
            }
          }
        ]
      }
    ],
    "x-go-package": "....."
  }
}
```

also `fmt`