### PR TITLE
828-Support-default-value-for-model-property

### DIFF
--- a/generator/model.go
+++ b/generator/model.go
@@ -1208,6 +1208,7 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	sg.GenSchema.ReadOnly = sg.Schema.ReadOnly
 	sg.GenSchema.IncludeValidator = sg.IncludeValidator
 	sg.GenSchema.IncludeModel = sg.IncludeModel
+	sg.GenSchema.Default = sg.Schema.Default
 
 	var err error
 	returns, err := sg.shortCircuitNamedRef()

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -71,6 +71,7 @@ type GenSchema struct {
 	Parents                 []string
 	IncludeValidator        bool
 	IncludeModel            bool
+	Default                 interface{}
 }
 
 type sharedValidations struct {

--- a/generator/templates/schema.gotmpl
+++ b/generator/templates/schema.gotmpl
@@ -94,7 +94,7 @@ func unmarshal{{ pascalize .Name }}(data []byte, consumer runtime.Consumer) ({{ 
 func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(b []byte) error {
   type {{ pascalize .Name }}Alias {{ pascalize .Name }}
   var t {{ pascalize .Name }}Alias
-  if err := json.Unmarshal([]byte(`{{json .Default}}`), &t); err != nil {
+  if err := json.Unmarshal([]byte({{printf "%q" (json .Default)}}), &t); err != nil {
     return err
   }
   if err := json.Unmarshal(b, &t); err != nil {

--- a/generator/templates/schema.gotmpl
+++ b/generator/templates/schema.gotmpl
@@ -90,6 +90,19 @@ func unmarshal{{ pascalize .Name }}(data []byte, consumer runtime.Consumer) ({{ 
 
 }
 {{ else }}{{ if or .IsComplexObject .IsTuple .IsAdditionalProperties }}{{ if .Name }}type {{ if not .IsExported }}{{ .Name }}{{ else }}{{ pascalize .Name }}{{ end }} {{ end }}{{ template "schemaBody" . }}
+{{if .Default}}
+func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(b []byte) error {
+  type {{ pascalize .Name }}Alias {{ pascalize .Name }}
+  var t {{ pascalize .Name }}Alias
+  if err := json.Unmarshal([]byte(`{{json .Default}}`), &t); err != nil {
+    return err
+  }
+  if err := json.Unmarshal(b, &t); err != nil {
+    return err
+  }  
+  *{{.ReceiverName}} = {{ pascalize .Name }}(t)
+  return nil
+}{{end}}
 {{ else }}type {{ pascalize .Name }} {{ template "typeSchemaType" . }}
 {{ end -}}{{ if .IsSubType }}
 {{ range .AllOf }}


### PR DESCRIPTION
If there is another place able to pull the defaults without introducing a new `Default` field in `GenSchema` (and feeding into the templates), the following would be revised.