### PR TITLE
ensure constant client response body order

### DIFF
--- a/fixtures/bugs/846/swagger.yml
+++ b/fixtures/bugs/846/swagger.yml
@@ -1,0 +1,33 @@
+---
+swagger: '2.0'
+info:
+  version: 0.0.0
+  title: Test846 API
+  description: a simple API to test issue 846
+paths:
+  /:
+    get:
+      operationId: getFoo
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              Foo:
+                type: integer
+                format: int64
+        404:
+          description: NotFound
+          schema:
+            type: object
+            properties:
+              Message:
+                type: string
+        500:
+          description: Error
+          schema:
+            type: object
+            properties:
+              Message:
+                type: string

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -387,10 +387,11 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 		prin = iface
 	}
 
-	var extra []GenSchema
+	var extra GenSchemaList
 	for _, sch := range b.ExtraSchemas {
 		extra = append(extra, sch)
 	}
+	sort.Sort(extra)
 
 	swsp := resolver.Doc.Spec()
 	var extraSchemes []string


### PR DESCRIPTION
fixes #846

Also added a unit test to ensure the order of the Response & Body (payload).

Using a new swagger build with these changes, it now seems to appear that the order of generated objects is constant across sequential generations. Tested it for both the client and server of the EVE API Spec referenced in #846. Locally it seems to hold up, as it seemed to be only the body (extraSchemes) that were not sorted yet. Therefore I only added a unit-test to test the order of the body, as mentioned earlier.