### PR TITLE
Allow CodeGen to skip formatting

### DIFF
--- a/docs/use/template_layout.md
+++ b/docs/use/template_layout.md
@@ -34,6 +34,15 @@ contains | for use in conditions, returns true when the second argument is conta
 joinFilePath | joins the arguments as a file path, cross platform
 padSurround | surround an entry with a character n times before and m times after the entry
 
+## Template Attributes
+
+The following modifiers can be applied to a template to modify code-generation behaviour:
+
+Attribute | Type | Description
+----------|------|-------------
+skip_exists|boolean|Skip generating content for a file if the specified target file already exists. Use this for files the user needs to customise.
+skip_format|boolean|Skip formatting code from the template according to the standard golang rules. This may be useful if you have your own coding conventions that custom templates already adhere to, or if you are generating non-golang code.
+
 ## Server generation
 
 ```shell

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -286,6 +286,7 @@ type TemplateOpts struct {
 	Target     string `mapstructure:"target"`
 	FileName   string `mapstructure:"file_name"`
 	SkipExists bool   `mapstructure:"skip_exists"`
+	SkipFormat bool   `mapstructure:"skip_format"`
 }
 
 // SectionOpts allows for specifying options to customize the templates used for generation
@@ -504,10 +505,13 @@ func (g *GenOpts) write(t *TemplateOpts, data interface{}) error {
 		}
 	}
 
-	formatted, err := g.LanguageOpts.FormatContent(fname, content)
-	if err != nil {
-		formatted = content
-		err = fmt.Errorf("format %q failed: %v", t.Name, err)
+	// Conditionally format the code, unless the user wants to skip
+	formatted := content
+	if t.SkipFormat == false {
+		formatted, err = g.LanguageOpts.FormatContent(fname, content)
+		if err != nil {
+			err = fmt.Errorf("format %q failed: %v", t.Name, err)
+		}
 	}
 
 	writeerr := ioutil.WriteFile(filepath.Join(dir, fname), formatted, 0644)


### PR DESCRIPTION
As per #894 - allowing skipping of FormatContent behaviour when dealing with non-golang code output.