### PR TITLE
remove unused resolveSimpleType func

### DIFF
--- a/generator/types.go
+++ b/generator/types.go
@@ -209,32 +209,6 @@ func typeForHeader(header spec.Header) resolvedType {
 	return simpleResolvedType(header.Type, header.Format, header.Items)
 }
 
-//
-// func typeForParameter(param spec.Parameter) string {
-// 	return resolveSimpleType(param.Type, param.Format, param.Items)
-// }
-
-func resolveSimpleType(tn, fmt string, items *spec.Items) string {
-	if fmt != "" {
-		if tpe, ok := typeMapping[strings.Replace(fmt, "-", "", -1)]; ok {
-			return tpe
-		}
-	}
-
-	if tpe, ok := typeMapping[tn]; ok {
-		return tpe
-	}
-
-	if tn == "array" {
-		// TODO: Items can't be nil per spec, this should return an error
-		if items == nil {
-			return "[]interface{}"
-		}
-		return "[]" + resolveSimpleType(items.Type, items.Format, items.Items)
-	}
-	return tn
-}
-
 func newTypeResolver(pkg string, doc *loads.Document) *typeResolver {
 	resolver := typeResolver{ModelsPackage: pkg, Doc: doc}
 	resolver.KnownDefs = make(map[string]struct{}, 64)


### PR DESCRIPTION
fixes #875 

Original fix was actually resolving the TODO, but then I realized the function is no longer used, so I am proposing to delete it instead. Git History always has it in case you ever want to revive it again somewhere in the future.