### PR TITLE
Support x-go-name in response elements

### DIFF
--- a/fixtures/specs/response_name.json
+++ b/fixtures/specs/response_name.json
@@ -1,0 +1,28 @@
+{
+    "consumes": [
+        "application/json",
+        "application/x-www-form-urlencoded"
+    ],
+    "paths": {
+        "/testing": {
+            "put": {
+                "operationId": "putTesting",
+                "responses": {
+                    "200": {
+                        "description": "Success message",
+                        "x-go-name": "AlternateName"
+                    }
+                }
+            }
+        }
+    },
+    "produces": [
+        "application/json",
+        "application/json; charset=utf-8"
+    ],
+    "swagger": "2.0",
+    "info": {
+      "title": "test formats for form params",
+      "version": "0.0.0"
+    }
+}

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -354,8 +354,13 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	var successResponses []GenResponse
 	if operation.Responses != nil {
 		for _, v := range srs {
+			name, ok := v.Response.Extensions.GetString("x-go-name")
+			if !ok {
+				name = runtime.Statuses[v.Code]
+			}
+			name = swag.ToJSONName(b.Name + " " + name)
 			isSuccess := v.Code/100 == 2
-			gr, err := b.MakeResponse(receiver, swag.ToJSONName(b.Name+" "+runtime.Statuses[v.Code]), isSuccess, resolver, v.Code, v.Response)
+			gr, err := b.MakeResponse(receiver, name, isSuccess, resolver, v.Code, v.Response)
 			if err != nil {
 				return GenOperation{}, err
 			}

--- a/generator/response_test.go
+++ b/generator/response_test.go
@@ -379,7 +379,7 @@ func TestGenResponses_Issue776_SwaggerTemplate(t *testing.T) {
 
 func TestIssue846(t *testing.T) {
 	// do it 8 times, to ensure it's always in the same order
-	for i := 0 ; i < 8 ; i++ {
+	for i := 0; i < 8; i++ {
 		b, err := opBuilder("getFoo", "../fixtures/bugs/846/swagger.yml")
 		if assert.NoError(t, err) {
 			op, err := b.MakeOperation()
@@ -390,14 +390,14 @@ func TestIssue846(t *testing.T) {
 					ff, err := opts.LanguageOpts.FormatContent("do_empty_responses.go", buf.Bytes())
 					if assert.NoError(t, err) {
 						// sorted by code
-						assert.Regexp(t, "(?s)" +
-							"GetFooOK struct.+" +
-							"GetFooNotFound struct.+" +
+						assert.Regexp(t, "(?s)"+
+							"GetFooOK struct.+"+
+							"GetFooNotFound struct.+"+
 							"GetFooInternalServerError struct", string(ff))
 						// sorted by name
-						assert.Regexp(t, "(?s)" +
-							"GetFooInternalServerErrorBody struct.+" +
-							"GetFooNotFoundBody struct.+" +
+						assert.Regexp(t, "(?s)"+
+							"GetFooInternalServerErrorBody struct.+"+
+							"GetFooNotFoundBody struct.+"+
 							"GetFooOKBody struct", string(ff))
 					} else {
 						fmt.Println(buf.String())
@@ -426,6 +426,28 @@ func TestIssue881Deep(t *testing.T) {
 		if assert.NoError(t, err) {
 			var buf bytes.Buffer
 			assert.NoError(t, templates.MustGet("serverResponses").Execute(&buf, op))
+		}
+	}
+}
+
+func TestGenResponses_XGoName(t *testing.T) {
+	b, err := opBuilder("putTesting", "../fixtures/specs/response_name.json")
+	if assert.NoError(t, err) {
+		op, err := b.MakeOperation()
+		if assert.NoError(t, err) {
+			var buf bytes.Buffer
+			opts := opts()
+			if assert.NoError(t, templates.MustGet("serverResponses").Execute(&buf, op)) {
+				ff, err := opts.LanguageOpts.FormatContent("put_testing_responses.go", buf.Bytes())
+				if assert.NoError(t, err) {
+					assertInCode(t, "const PutTestingAlternateNameCode int =", string(ff))
+					assertInCode(t, "type PutTestingAlternateName struct {", string(ff))
+					assertInCode(t, "func NewPutTestingAlternateName() *PutTestingAlternateName {", string(ff))
+					assertInCode(t, "func (o *PutTestingAlternateName) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {", string(ff))
+				} else {
+					fmt.Println(buf.String())
+				}
+			}
 		}
 	}
 }

--- a/vendor/github.com/go-openapi/spec/response.go
+++ b/vendor/github.com/go-openapi/spec/response.go
@@ -35,10 +35,14 @@ type ResponseProps struct {
 type Response struct {
 	Refable
 	ResponseProps
+	VendorExtensible
 }
 
 // JSONLookup look up a value by the json property name
 func (p Response) JSONLookup(token string) (interface{}, error) {
+	if ex, ok := p.Extensions[token]; ok {
+		return &ex, nil
+	}
 	if token == "$ref" {
 		return &p.Ref, nil
 	}
@@ -54,6 +58,9 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &r.Refable); err != nil {
 		return err
 	}
+	if err := json.Unmarshal(data, &r.VendorExtensible); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -67,7 +74,11 @@ func (r Response) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return swag.ConcatJSON(b1, b2), nil
+	b3, err := json.Marshal(r.VendorExtensible)
+	if err != nil {
+		return nil, err
+	}
+	return swag.ConcatJSON(b1, b2, b3), nil
 }
 
 // NewResponse creates a new response instance

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -127,7 +127,7 @@
 			"importpath": "github.com/go-openapi/spec",
 			"repository": "https://github.com/go-openapi/spec",
 			"vcs": "git",
-			"revision": "f81e0f768713035fe232cd0d44a1c56e4eef1383",
+			"revision": "02fb9cd3430ed0581e0ceb4804d5d4b3cc702694",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
The Go name for response types is currently always derived from the HTTP
status code description. Add an optional vendor extension 'x-go-name'
to overwrite the name used for Go code generation.

Example:
```
paths:
  "/testing":
    put:
      responses:
        400:
          description: Missing element in request
          x-go-name: Missing
```
Will result in:
```
const PutTestingMissingCode int = 400

type PutTestingMissing struct {
}

func NewPutTestingMissing() *PutTestingMissing {
        return &PutTestingMissing{}
}
```