### PR TITLE
Remove no-op basePath assignment.

### DIFF
--- a/cmd/swagger/commands/serve.go
+++ b/cmd/swagger/commands/serve.go
@@ -48,9 +48,6 @@ func (s *ServeCmd) Execute(args []string) error {
 
 	basePath := s.BasePath
 	if basePath == "" {
-		basePath = s.BasePath
-	}
-	if basePath == "" {
 		basePath = "/"
 	}
 


### PR DESCRIPTION
The body of this `if` statement only reassigns the same value that was already assigned from; the value of `basePath` will still be the empty string afterwards, in all cases where the `if`-block actually executes.