### PR TITLE
Fix package lookup. Add ast.SelectorExpr

### DIFF
--- a/scan/parameters.go
+++ b/scan/parameters.go
@@ -400,6 +400,12 @@ func (pp *paramStructParser) parseStructType(gofile *ast.File, operation *spec.O
 								return nil, err
 							}
 							return otherTaggers, nil
+						case *ast.SelectorExpr:
+							otherTaggers, err := parseArrayTypes(iftpe.Sel, items.Items, level+1)
+							if err != nil {
+								return nil, err
+							}
+							return otherTaggers, nil
 						case *ast.Ident:
 							taggers := []tagParser{}
 							if iftpe.Obj == nil {

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -860,10 +860,15 @@ func (scp *schemaParser) packageForSelector(gofile *ast.File, expr ast.Expr) (*l
 					break
 				}
 			} else {
-				parts := strings.Split(pv, "/")
-				if len(parts) > 0 && parts[len(parts)-1] == pth.Name {
+				pkg := scp.program.Package(pv)
+				if pkg != nil {
 					selPath = pv
-					break
+				} else {
+					parts := strings.Split(pv, "/")
+					if len(parts) > 0 && parts[len(parts)-1] == pth.Name {
+						selPath = pv
+						break
+					}
 				}
 			}
 		}

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -861,8 +861,9 @@ func (scp *schemaParser) packageForSelector(gofile *ast.File, expr ast.Expr) (*l
 				}
 			} else {
 				pkg := scp.program.Package(pv)
-				if pkg != nil {
+				if pkg != nil && pth.Name == pkg.Pkg.Name() {
 					selPath = pv
+					break
 				} else {
 					parts := strings.Split(pv, "/")
 					if len(parts) > 0 && parts[len(parts)-1] == pth.Name {


### PR DESCRIPTION
1. Package lookup
for imports like `github.com/name/my-name-of-project` which has package name `name`
2. Added ast.SelectorType
```go
type Str struct {
    List []*pkg.Field
}
```