### PR TITLE
Add  in swagger:meta, security fix. Implementation of secure definitions

### DIFF
--- a/docs/generate/spec/meta.md
+++ b/docs/generate/spec/meta.md
@@ -31,6 +31,8 @@ Annotation | Format
 **Base path** | the default base path for this API
 **Contact** | the name of for the person to contact concerning the API eg. John Doe&nbsp;&lt;john@blogs.com&gt;&nbsp;http://john.blogs.com
 **License** | the name of the license followed by the URL of the license eg. MIT http://opensource.org/license/MIT
+**Security** | a dictionary of key: []string{scopes}
+**SecurityDefinitions** | list of supported authorization types https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject
 
 ##### Example:
 
@@ -62,6 +64,14 @@ Annotation | Format
 //     - application/json
 //     - application/xml
 //
+//     Security:
+//     - api_key:
+//
+//     SecurityDefinitions:
+//     - api_key:
+//          type: apiKey
+//          name: KEY
+//          in: header
 //
 // swagger:meta
 package classification

--- a/fixtures/goparsing/classification/doc.go
+++ b/fixtures/goparsing/classification/doc.go
@@ -39,6 +39,14 @@
 //     - application/json
 //     - application/xml
 //
+//     Security:
+//     - api_key:
+//
+//     SecurityDefinitions:
+//     - api_key:
+//          type: apiKey
+//          name: KEY
+//          in: header
 //
 // swagger:meta
 package classification

--- a/scan/meta.go
+++ b/scan/meta.go
@@ -57,6 +57,11 @@ func metaSecuritySetter(meta *spec.Swagger) func([]map[string][]string) {
 	return func(secDefs []map[string][]string) { meta.Security = secDefs }
 }
 
+func metaSecurityDefinitionsSetter(meta *spec.Swagger) func(spec.SecurityDefinitions) {
+	return func(secDefs spec.SecurityDefinitions) { meta.SecurityDefinitions = secDefs }
+}
+
+
 func newMetaParser(swspec *spec.Swagger) *sectionedParser {
 	sp := new(sectionedParser)
 	if swspec.Info == nil {
@@ -76,7 +81,8 @@ func newMetaParser(swspec *spec.Swagger) *sectionedParser {
 		newMultiLineTagParser("Consumes", newMultilineDropEmptyParser(rxConsumes, metaConsumesSetter(swspec))),
 		newMultiLineTagParser("Produces", newMultilineDropEmptyParser(rxProduces, metaProducesSetter(swspec))),
 		newSingleLineTagParser("Schemes", newSetSchemes(metaSchemeSetter(swspec))),
-		newSingleLineTagParser("SecurityDefinitions", newSetSecurityDefinitions(rxSecurity, metaSecuritySetter(swspec))),
+		newMultiLineTagParser("Security", newSetSecurity(rxSecuritySchemes, metaSecuritySetter(swspec))),
+		newMultiLineTagParser("SecurityDefinitions", newSetSecurityDefinitions(rxSecurity, metaSecurityDefinitionsSetter(swspec))),
 		newSingleLineTagParser("Version", &setMetaSingle{swspec, rxVersion, setInfoVersion}),
 		newSingleLineTagParser("Host", &setMetaSingle{swspec, rxHost, setSwaggerHost}),
 		newSingleLineTagParser("BasePath", &setMetaSingle{swspec, rxBasePath, setSwaggerBasePath}),

--- a/scan/meta.go
+++ b/scan/meta.go
@@ -61,7 +61,6 @@ func metaSecurityDefinitionsSetter(meta *spec.Swagger) func(spec.SecurityDefinit
 	return func(secDefs spec.SecurityDefinitions) { meta.SecurityDefinitions = secDefs }
 }
 
-
 func newMetaParser(swspec *spec.Swagger) *sectionedParser {
 	sp := new(sectionedParser)
 	if swspec.Info == nil {

--- a/scan/meta_test.go
+++ b/scan/meta_test.go
@@ -85,6 +85,15 @@ func verifyMeta(t testing.TB, doc *spec.Swagger) {
 	assert.EqualValues(t, []string{"application/json", "application/xml"}, doc.Consumes)
 	assert.EqualValues(t, []string{"application/json", "application/xml"}, doc.Produces)
 	assert.EqualValues(t, []string{"http", "https"}, doc.Schemes)
+	assert.EqualValues(t, []map[string][]string{{"api_key":{}}}, doc.Security)
+	expectedSecuritySchema := spec.SecurityScheme{
+		SecuritySchemeProps: spec.SecuritySchemeProps {
+			Type: "apiKey",
+			In: "header",
+			Name: "KEY",
+		},
+	}
+	assert.EqualValues(t, map[string]*spec.SecurityScheme{"api_key":&expectedSecuritySchema}, doc.SecurityDefinitions)
 	assert.Equal(t, "localhost", doc.Host)
 	assert.Equal(t, "/v2", doc.BasePath)
 }

--- a/scan/responses.go
+++ b/scan/responses.go
@@ -108,14 +108,14 @@ func (sv headerValidations) SetPattern(val string)          { sv.current.Pattern
 func (sv headerValidations) SetUnique(val bool)             { sv.current.UniqueItems = val }
 func (sv headerValidations) SetCollectionFormat(val string) { sv.current.CollectionFormat = val }
 func (sv headerValidations) SetEnum(val string) {
-    list := strings.Split(val, ",")
-    interfaceSlice := make([]interface{}, len(list))
-    for i, d := range list {
-        interfaceSlice[i] = d
-    }
-    sv.current.Enum = interfaceSlice
+	list := strings.Split(val, ",")
+	interfaceSlice := make([]interface{}, len(list))
+	for i, d := range list {
+		interfaceSlice[i] = d
+	}
+	sv.current.Enum = interfaceSlice
 }
-func (sv headerValidations) SetDefault(val string)          { sv.current.Default = val }
+func (sv headerValidations) SetDefault(val string) { sv.current.Default = val }
 
 func newResponseDecl(file *ast.File, decl *ast.GenDecl, ts *ast.TypeSpec) responseDecl {
 	var rd responseDecl
@@ -325,8 +325,8 @@ func (rp *responseParser) parseStructType(gofile *ast.File, response *spec.Respo
 					newSingleLineTagParser("minItems", &setMinItems{headerValidations{&ps}, rxf(rxMinItemsFmt, "")}),
 					newSingleLineTagParser("maxItems", &setMaxItems{headerValidations{&ps}, rxf(rxMaxItemsFmt, "")}),
 					newSingleLineTagParser("unique", &setUnique{headerValidations{&ps}, rxf(rxUniqueFmt, "")}),
-                    newSingleLineTagParser("enum", &setEnum{headerValidations{&ps}, rxf(rxEnumFmt, "")}),
-                    newSingleLineTagParser("default", &setDefault{headerValidations{&ps}, rxf(rxDefaultFmt, "")}),
+					newSingleLineTagParser("enum", &setEnum{headerValidations{&ps}, rxf(rxEnumFmt, "")}),
+					newSingleLineTagParser("default", &setDefault{headerValidations{&ps}, rxf(rxDefaultFmt, "")}),
 				}
 				itemsTaggers := func(items *spec.Items, level int) []tagParser {
 					// the expression is 1-index based not 0-index
@@ -343,8 +343,8 @@ func (rp *responseParser) parseStructType(gofile *ast.File, response *spec.Respo
 						newSingleLineTagParser(fmt.Sprintf("items%dMinItems", level), &setMinItems{itemsValidations{items}, rxf(rxMinItemsFmt, itemsPrefix)}),
 						newSingleLineTagParser(fmt.Sprintf("items%dMaxItems", level), &setMaxItems{itemsValidations{items}, rxf(rxMaxItemsFmt, itemsPrefix)}),
 						newSingleLineTagParser(fmt.Sprintf("items%dUnique", level), &setUnique{itemsValidations{items}, rxf(rxUniqueFmt, itemsPrefix)}),
-                        newSingleLineTagParser(fmt.Sprintf("items%dEnum", level), &setEnum{itemsValidations{items}, rxf(rxEnumFmt, itemsPrefix)}),
-                        newSingleLineTagParser(fmt.Sprintf("items%dDefault", level), &setDefault{itemsValidations{items}, rxf(rxDefaultFmt, itemsPrefix)}),
+						newSingleLineTagParser(fmt.Sprintf("items%dEnum", level), &setEnum{itemsValidations{items}, rxf(rxEnumFmt, itemsPrefix)}),
+						newSingleLineTagParser(fmt.Sprintf("items%dDefault", level), &setDefault{itemsValidations{items}, rxf(rxDefaultFmt, itemsPrefix)}),
 					}
 				}
 

--- a/scan/routes.go
+++ b/scan/routes.go
@@ -86,7 +86,7 @@ func (rp *routesParser) Parse(gofile *ast.File, target interface{}) error {
 			newMultiLineTagParser("Consumes", newMultilineDropEmptyParser(rxConsumes, opConsumesSetter(op))),
 			newMultiLineTagParser("Produces", newMultilineDropEmptyParser(rxProduces, opProducesSetter(op))),
 			newSingleLineTagParser("Schemes", newSetSchemes(opSchemeSetter(op))),
-			newMultiLineTagParser("Security", newSetSecurityDefinitions(rxSecuritySchemes, opSecurityDefsSetter(op))),
+			newMultiLineTagParser("Security", newSetSecurity(rxSecuritySchemes, opSecurityDefsSetter(op))),
 			newMultiLineTagParser("Responses", sr),
 		}
 		if err := sp.Parse(content.Remaining); err != nil {

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -561,9 +561,7 @@ func (ss *setSecurityDefinitions) Parse(lines []string) error {
 			continue
 		} else {
 			for _, p := range tp {
-				fmt.Println(p.Matches(lines[i]))
 				if p.Matches(lines[i]) {
-					fmt.Println(lines[i])
 					err := p.Parse([]string{lines[i]})
 					if err != nil {
 						return err
@@ -633,7 +631,6 @@ func (sf *setField) Parse(lines []string) error {
 	var value string
 	for _, line := range lines {
 		kv := strings.SplitN(line, ":", 2)
-		fmt.Println(kv)
 		if len(kv) > 1 {
 			value = strings.TrimSpace(kv[1])
 			break

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -500,7 +500,7 @@ func (ss *setSchemes) Parse(lines []string) error {
 	return nil
 }
 
-func newSetSecurityDefinitions(rx *regexp.Regexp, setter func([]map[string][]string)) *setSecurityDefinitions {
+func newSetSecurityDefinitions(rx *regexp.Regexp, setter func(spec.SecurityDefinitions)) *setSecurityDefinitions {
 	return &setSecurityDefinitions{
 		set: setter,
 		rx:  rx,
@@ -508,7 +508,7 @@ func newSetSecurityDefinitions(rx *regexp.Regexp, setter func([]map[string][]str
 }
 
 type setSecurityDefinitions struct {
-	set func([]map[string][]string)
+	set func(spec.SecurityDefinitions)
 	rx  *regexp.Regexp
 }
 
@@ -516,7 +516,152 @@ func (ss *setSecurityDefinitions) Matches(line string) bool {
 	return ss.rx.MatchString(line)
 }
 
+var (
+	rxSecuritySchemeType          = regexp.MustCompile("[Tt]ype\\p{Zs}*:")
+	rxSecuritySchemeName          = regexp.MustCompile("[Nn]ame\\p{Zs}*:")
+	rxSecuritySchemeIn            = regexp.MustCompile("[Ii]n\\p{Zs}*:")
+	rxSecuritySchemeFlow          = regexp.MustCompile("[Ff]low\\p{Zs}*:")
+	rxSecuritySchemeDescription   = regexp.MustCompile("[Dd]escription\\p{Zs}*:")
+	rxSecuritySchemeAuthorization = regexp.MustCompile("[Aa]uthorizationUrl\\p{Zs}*:")
+	rxSecuritySchemeToken         = regexp.MustCompile("[Tt]okenUrl\\p{Zs}*:")
+)
+
 func (ss *setSecurityDefinitions) Parse(lines []string) error {
+	if len(lines) == 0 || (len(lines) == 1 && len(lines[0]) == 0) {
+		return nil
+	}
+
+	result := spec.SecurityDefinitions{}
+	var scheme spec.SecurityScheme
+	var key string
+	var tp []tagParser
+	for i := 0; i < len(lines); i++ {
+		kv := strings.SplitN(lines[i], ":", 2)
+		if len(kv) <= 1 {
+			return fmt.Errorf("invalid format for securityDefinitions: %s", lines[i])
+		}
+
+		k, v := kv[0], strings.TrimSpace(kv[1])
+
+		if v == "" {
+			if key != "" {
+				result[key] = &scheme
+			}
+			scheme = spec.SecurityScheme{}
+			key = k
+			tp = []tagParser{
+				newSingleLineTagParser("type", newSetField(rxSecuritySchemeType, setSecuritySchemeType(&scheme))),
+				newSingleLineTagParser("name", newSetField(rxSecuritySchemeName, setSecuritySchemeName(&scheme))),
+				newSingleLineTagParser("in", newSetField(rxSecuritySchemeIn, setSecuritySchemeIn(&scheme))),
+				newSingleLineTagParser("flow", newSetField(rxSecuritySchemeFlow, setSecuritySchemeFlow(&scheme))),
+				newSingleLineTagParser("description", newSetField(rxSecuritySchemeDescription, setSecuritySchemeDescription(&scheme))),
+				newSingleLineTagParser("authorizationUrl", newSetField(rxSecuritySchemeAuthorization, setSecuritySchemeAuthorizationURL(&scheme))),
+				newSingleLineTagParser("tokenUrl", newSetField(rxSecuritySchemeToken, setSecuritySchemeTokenURL(&scheme))),
+			}
+			continue
+		} else {
+			for _, p := range tp {
+				fmt.Println(p.Matches(lines[i]))
+				if p.Matches(lines[i]) {
+					fmt.Println(lines[i])
+					err := p.Parse([]string{lines[i]})
+					if err != nil {
+						return err
+					}
+					break
+				}
+			}
+		}
+	}
+	if _, ok := result[key]; !ok && key != "" {
+		result[key] = &scheme
+	}
+
+	ss.set(result)
+	return nil
+}
+
+func setSecuritySchemeType(scheme *spec.SecurityScheme) func(string) {
+	return func(val string) { scheme.Type = val }
+}
+
+func setSecuritySchemeName(scheme *spec.SecurityScheme) func(string) {
+	return func(val string) { scheme.Name = val }
+}
+
+func setSecuritySchemeIn(scheme *spec.SecurityScheme) func(string) {
+	return func(val string) { scheme.In = val }
+}
+
+func setSecuritySchemeFlow(scheme *spec.SecurityScheme) func(string) {
+	return func(val string) { scheme.Flow = val }
+}
+
+func setSecuritySchemeDescription(scheme *spec.SecurityScheme) func(string) {
+	return func(val string) { scheme.Description = val }
+}
+
+func setSecuritySchemeAuthorizationURL(scheme *spec.SecurityScheme) func(string) {
+	return func(val string) { scheme.AuthorizationURL = val }
+}
+
+func setSecuritySchemeTokenURL(scheme *spec.SecurityScheme) func(string) {
+	return func(val string) { scheme.TokenURL = val }
+}
+
+func newSetField(rx *regexp.Regexp, setter func(string)) *setField {
+	return &setField{
+		rx:  rx,
+		set: setter,
+	}
+}
+
+type setField struct {
+	set func(string)
+	rx  *regexp.Regexp
+}
+
+func (sf *setField) Matches(line string) bool {
+	return sf.rx.MatchString(line)
+}
+
+func (sf *setField) Parse(lines []string) error {
+	if len(lines) == 0 || (len(lines) == 1 && len(lines[0]) == 0) {
+		return nil
+	}
+
+	var value string
+	for _, line := range lines {
+		kv := strings.SplitN(line, ":", 2)
+		fmt.Println(kv)
+		if len(kv) > 1 {
+			value = strings.TrimSpace(kv[1])
+			break
+		} else {
+			return fmt.Errorf("expecting `key: value`, got key only for string: %s", line)
+		}
+	}
+	sf.set(value)
+	return nil
+}
+
+func newSetSecurity(rx *regexp.Regexp, setter func([]map[string][]string)) *setSecurity {
+	return &setSecurity{
+		set: setter,
+		rx:  rx,
+	}
+}
+
+type setSecurity struct {
+	set func([]map[string][]string)
+	rx  *regexp.Regexp
+}
+
+func (ss *setSecurity) Matches(line string) bool {
+	return ss.rx.MatchString(line)
+}
+
+func (ss *setSecurity) Parse(lines []string) error {
 	if len(lines) == 0 || (len(lines) == 1 && len(lines[0]) == 0) {
 		return nil
 	}


### PR DESCRIPTION
this is fix for issue: #949 

- Security in swagger:meta - nothing has been changed there except I added this to meta
- SecurityDefinitions in swagger:meta new parser for securityDefinitions accepts following, documentation update required
```
SecureDefinitions:
- api_key:
    type: apiKey
    name: KEY
    in: header
```
Now generates the following:
```
  "securityDefinitions": {
    "api_key": {
      "type": "apiKey",
      "name": "UHUB_KEY",
      "in": "header"
    }
  },
```