### PR TITLE
Allow to set build tags for scanner

### DIFF
--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -29,6 +29,7 @@ import (
 // SpecFile command to generate a swagger spec from a go application
 type SpecFile struct {
 	BasePath   string         `long:"base-path" short:"b" description:"the base path to use" default:"."`
+	BuildTags  string         `long:"tags" short:"t" description:"build tags" default:""`
 	ScanModels bool           `long:"scan-models" short:"m" description:"includes models that were annotated with 'swagger:model'"`
 	Compact    bool           `long:"compact" description:"when present, doesn't prettify the the json"`
 	Output     flags.Filename `long:"output" short:"o" description:"the file to write to"`
@@ -46,6 +47,7 @@ func (s *SpecFile) Execute(args []string) error {
 	opts.BasePath = s.BasePath
 	opts.Input = input
 	opts.ScanModels = s.ScanModels
+	opts.BuildTags = s.BuildTags
 	swspec, err := scan.Application(opts)
 	if err != nil {
 		return err

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -19,20 +19,18 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+	"go/build"
 	goparser "go/parser"
 	"log"
 	"os"
 	"regexp"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
-
-	"golang.org/x/tools/go/loader"
-
 	"github.com/go-openapi/loads/fmts"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
-	"go/build"
+	"golang.org/x/tools/go/loader"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -32,6 +32,7 @@ import (
 	"github.com/go-openapi/loads/fmts"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
+	"go/build"
 )
 
 const (
@@ -148,6 +149,7 @@ type Opts struct {
 	BasePath   string
 	Input      *spec.Swagger
 	ScanModels bool
+	BuildTags  string
 }
 
 func safeConvert(str string) bool {
@@ -199,6 +201,10 @@ func newAppScanner(opts *Opts, includes, excludes packageFilters) (*appScanner, 
 	var ldr loader.Config
 	ldr.ParserMode = goparser.ParseComments
 	ldr.ImportWithTests(opts.BasePath)
+	if opts.BuildTags != "" {
+		ldr.Build = &build.Default
+		ldr.Build.BuildTags = strings.Split(opts.BuildTags, ",")
+	}
 	prog, err := ldr.Load()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When 2 files in the package have different build tags it cause an error that func/struct/whatever not found
```go 
// +build tag1

package something
```

```go 
// +build tag2

package something
```
usage: 
```
swagger generate spec -t 'tag1'
```