### PR TITLE
Add mixin feature that can merge swagger specs. Issue #1005

### DIFF
--- a/cmd/swagger/commands/mixin.go
+++ b/cmd/swagger/commands/mixin.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+
+	"github.com/go-openapi/analysis"
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/spec"
+)
+
+type MixinSpec struct {
+	ExpectedCollisionCount uint `short:"c" description:"expected # of rejected mixin paths, defs, etc due to existing key. Non-zero exit if does not match actual."`
+}
+
+// mixin provides functions to merge Swagger 2.0 specs into one spec
+//
+// Use cases include adding independently versioned metadata APIs to
+// application APIs for microservices.
+//
+// Typically, multiple APIs to the same service instance is not a
+// problem for client generation as you can create more than one
+// client to the service from the same calling process (one for each
+// API).  However, merging clients can improve clarity of client code
+// by having a single client to given service vs several.
+//
+// Server skeleton generation, ie generating the model & marshaling
+// code, http server instance etc. from Swagger, becomes easier with a
+// merged spec for some tools & target-languages.  Server code
+// generation tools that natively support hosting multiple specs in
+// one server process will not need this tool.
+func (c *MixinSpec) Execute(args []string) error {
+
+	if len(args) < 2 {
+		log.Fatalln("Nothing to do. Need some swagger files to merge.\nUSAGE: swagger mixin [-c <expected#Collisions>] <primary-swagger-file> <mixin-swagger-file>...")
+	}
+
+	log.Printf("args[0] = %v\n", args[0])
+	log.Printf("args[1:] = %v\n", args[1:])
+	collisions, err := MixinFiles(args[0], args[1:], os.Stdout)
+
+	for _, warn := range collisions {
+		log.Println(warn)
+	}
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if len(collisions) != int(c.ExpectedCollisionCount) {
+		if len(collisions) != 0 {
+			// use bash $? to get actual # collisions
+			// (but has to be non-zero)
+			os.Exit(int(len(collisions)))
+		}
+		os.Exit(254)
+	}
+	return nil
+}
+
+// MixinFiles is a convenience function for Mixin that reads the given
+// swagger files, adds the mixins to primary, calls
+// FixEmptyResponseDescriptions on the primary, and writes the primary
+// with mixins to the given writer in JSON.  Returns the warning
+// messages for collsions that occured during mixin process and any
+// error.
+func MixinFiles(primaryFile string, mixinFiles []string, w io.Writer) ([]string, error) {
+
+	primaryDoc, err := loads.Spec(primaryFile)
+	if err != nil {
+		return nil, err
+	}
+	primary := primaryDoc.Spec()
+
+	var mixins []*spec.Swagger
+	for _, mixinFile := range mixinFiles {
+		mixin, err := loads.Spec(mixinFile)
+		if err != nil {
+			return nil, err
+		}
+		mixins = append(mixins, mixin.Spec())
+	}
+
+	collisions := analysis.Mixin(primary, mixins...)
+	analysis.FixEmptyResponseDescriptions(primary)
+
+	bs, err := json.MarshalIndent(primary, "", "  ")
+	if err != nil {
+		return collisions, err
+	}
+
+	w.Write(bs)
+
+	return collisions, nil
+}

--- a/cmd/swagger/commands/mixin.go
+++ b/cmd/swagger/commands/mixin.go
@@ -11,11 +11,15 @@ import (
 	"github.com/go-openapi/spec"
 )
 
+// MixinSpec holds command line flag definitions specific to the mixin
+// command. The flags are defined using struct field tags with the
+// "github.com/jessevdk/go-flags" format.
 type MixinSpec struct {
 	ExpectedCollisionCount uint `short:"c" description:"expected # of rejected mixin paths, defs, etc due to existing key. Non-zero exit if does not match actual."`
 }
 
-// mixin provides functions to merge Swagger 2.0 specs into one spec
+// Execute runs the mixin command which merges Swagger 2.0 specs into
+// one spec
 //
 // Use cases include adding independently versioned metadata APIs to
 // application APIs for microservices.

--- a/cmd/swagger/swagger.go
+++ b/cmd/swagger/swagger.go
@@ -70,6 +70,11 @@ It aims to represent the contract of your API with a language agnostic descripti
 		log.Fatal(err)
 	}
 
+	_, err = parser.AddCommand("mixin", "merge swagger documents", "merge additional specs into first/primary spec by copying their paths and definitions", &commands.MixinSpec{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	genpar, err := parser.AddCommand("generate", "genererate go code", "generate go code for the swagger spec file", &commands.Generate{})
 	if err != nil {
 		log.Fatalln(err)

--- a/vendor/github.com/go-openapi/analysis/mixin.go
+++ b/vendor/github.com/go-openapi/analysis/mixin.go
@@ -1,0 +1,186 @@
+package analysis
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/spec"
+)
+
+// Mixin modifies the primary swagger spec by adding the paths and
+// definitions from the mixin specs. Top level parameters and
+// responses from the mixins are also carried over. Operation id
+// collisions are avoided by appending "Mixin<N>" but only if
+// needed. No other parts of primary are modified. Consider calling
+// FixEmptyResponseDescriptions() on the modified primary if you read
+// them from storage and they are valid to start with.
+//
+// Entries in "paths", "definitions", "parameters" and "responses" are
+// added to the primary in the order of the given mixins. If the entry
+// already exists in primary it is skipped with a warning message.
+//
+// The count of skipped entries (from collisions) is returned so any
+// deviation from the number expected can flag warning in your build
+// scripts. Carefully review the collisions before accepting them;
+// consider renaming things if possible.
+//
+// No normalization of any keys takes place (paths, type defs,
+// etc). Ensure they are canonical if your downstream tools do
+// key normalization of any form.
+func Mixin(primary *spec.Swagger, mixins ...*spec.Swagger) []string {
+	var skipped []string
+	opIds := getOpIds(primary)
+	if primary.Paths == nil {
+		primary.Paths = &spec.Paths{Paths: make(map[string]spec.PathItem)}
+	}
+	for i, m := range mixins {
+		for k, v := range m.Definitions {
+			// assume name collisions represent IDENTICAL type. careful.
+			if _, exists := primary.Definitions[k]; exists {
+				warn := fmt.Sprintf("definitions entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+				skipped = append(skipped, warn)
+				continue
+			}
+			primary.Definitions[k] = v
+		}
+		if m.Paths != nil {
+			for k, v := range m.Paths.Paths {
+				if _, exists := primary.Paths.Paths[k]; exists {
+					warn := fmt.Sprintf("paths entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+					skipped = append(skipped, warn)
+					continue
+				}
+
+				// Swagger requires that operationIds be
+				// unique within a spec. If we find a
+				// collision we append "Mixin0" to the
+				// operatoinId we are adding, where 0 is mixin
+				// index.  We assume that operationIds with
+				// all the proivded specs are already unique.
+				piops := pathItemOps(v)
+				for _, piop := range piops {
+					if opIds[piop.ID] {
+						piop.ID = fmt.Sprintf("%v%v%v", piop.ID, "Mixin", i)
+					}
+					opIds[piop.ID] = true
+				}
+				primary.Paths.Paths[k] = v
+			}
+		}
+		for k, v := range m.Parameters {
+			// could try to rename on conflict but would
+			// have to fix $refs in the mixin. Complain
+			// for now
+			if _, exists := primary.Parameters[k]; exists {
+				warn := fmt.Sprintf("top level parameters entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+				skipped = append(skipped, warn)
+				continue
+			}
+			primary.Parameters[k] = v
+		}
+		for k, v := range m.Responses {
+			// could try to rename on conflict but would
+			// have to fix $refs in the mixin. Complain
+			// for now
+			if _, exists := primary.Responses[k]; exists {
+				warn := fmt.Sprintf("top level responses entry '%v' already exists in primary or higher priority mixin, skipping\n", k)
+				skipped = append(skipped, warn)
+				continue
+			}
+			primary.Responses[k] = v
+		}
+	}
+	return skipped
+}
+
+// FixEmptyResponseDescriptions replaces empty ("") response
+// descriptions in the input with "(empty)" to ensure that the
+// resulting Swagger is stays valid.  The problem appears to arise
+// from reading in valid specs that have a explicit response
+// description of "" (valid, response.description is required), but
+// due to zero values being omitted upon re-serializing (omitempty) we
+// lose them unless we stick some chars in there.
+func FixEmptyResponseDescriptions(s *spec.Swagger) {
+	if s.Paths != nil {
+		for _, v := range s.Paths.Paths {
+			if v.Get != nil {
+				FixEmptyDescs(v.Get.Responses)
+			}
+			if v.Put != nil {
+				FixEmptyDescs(v.Put.Responses)
+			}
+			if v.Post != nil {
+				FixEmptyDescs(v.Post.Responses)
+			}
+			if v.Delete != nil {
+				FixEmptyDescs(v.Delete.Responses)
+			}
+			if v.Options != nil {
+				FixEmptyDescs(v.Options.Responses)
+			}
+			if v.Head != nil {
+				FixEmptyDescs(v.Head.Responses)
+			}
+			if v.Patch != nil {
+				FixEmptyDescs(v.Patch.Responses)
+			}
+		}
+	}
+	for k, v := range s.Responses {
+		FixEmptyDesc(&v)
+		s.Responses[k] = v
+	}
+}
+
+// FixEmptyDescs adds "(empty)" as the description for any Response in
+// the given Responses object that doesn't already have one.
+func FixEmptyDescs(rs *spec.Responses) {
+	FixEmptyDesc(rs.Default)
+	for k, v := range rs.StatusCodeResponses {
+		FixEmptyDesc(&v)
+		rs.StatusCodeResponses[k] = v
+	}
+}
+
+// FixEmptyDesc adds "(empty)" as the description to the given
+// Response object if it doesn't already have one and isn't a
+// ref. No-op on nil input.
+func FixEmptyDesc(rs *spec.Response) {
+	if rs == nil || rs.Description != "" || rs.Ref.Ref.GetURL() != nil {
+		return
+	}
+	rs.Description = "(empty)"
+}
+
+// getOpIds extracts all the paths.<path>.operationIds from the given
+// spec and returns them as the keys in a map with 'true' values.
+func getOpIds(s *spec.Swagger) map[string]bool {
+	rv := make(map[string]bool)
+	if s.Paths == nil {
+		return rv
+	}
+	for _, v := range s.Paths.Paths {
+		piops := pathItemOps(v)
+		for _, op := range piops {
+			rv[op.ID] = true
+		}
+	}
+	return rv
+}
+
+func pathItemOps(p spec.PathItem) []*spec.Operation {
+	var rv []*spec.Operation
+	rv = appendOp(rv, p.Get)
+	rv = appendOp(rv, p.Put)
+	rv = appendOp(rv, p.Post)
+	rv = appendOp(rv, p.Delete)
+	rv = appendOp(rv, p.Head)
+	rv = appendOp(rv, p.Patch)
+	return rv
+}
+
+func appendOp(ops []*spec.Operation, op *spec.Operation) []*spec.Operation {
+	if op == nil {
+		return ops
+	}
+	return append(ops, op)
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -71,7 +71,7 @@
 			"importpath": "github.com/go-openapi/analysis",
 			"repository": "https://github.com/go-openapi/analysis",
 			"vcs": "git",
-			"revision": "d5a75b7d751ca3f11ad5d93cfe97405f2c3f6a47",
+			"revision": "0473cb67199f68b8b7d90e641afd9e79ad36b851",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Also bumped vendored version of go-openapi/analysis with 'gvt update' for access to the new Mixin func.