### PR TITLE
Set field default depend on the type of property

### DIFF
--- a/fixtures/goparsing/classification/models/nomodel.go
+++ b/fixtures/goparsing/classification/models/nomodel.go
@@ -31,6 +31,7 @@ type NoModel struct {
 	// required: true
 	// minimum: > 10
 	// maximum: < 1000
+	// default: 11
 	ID int64 `json:"id"`
 
 	Ignored      string `json:"-"`
@@ -93,6 +94,7 @@ type NoModel struct {
 		// required: true
 		// minimum: > 10
 		// maximum: < 1000
+		// default: 11
 		ID int32 `json:"id"`
 
 		// The Pet to add to this NoModel items bucket.

--- a/fixtures/goparsing/classification/operations/noparams.go
+++ b/fixtures/goparsing/classification/operations/noparams.go
@@ -100,6 +100,7 @@ type NoParams struct {
 	// minimum: > 10
 	// maximum: < 1000
 	// in: path
+	// default: 1
 	ID int64 `json:"id"`
 
 	// The Score of this model
@@ -109,6 +110,7 @@ type NoParams struct {
 	// maximum: 45
 	// multiple of: 3
 	// in: query
+	// default: 2
 	Score int32 `json:"score"`
 
 	// Name of this no model instance
@@ -143,6 +145,7 @@ type NoParams struct {
 	// items.maxLength: 10
 	// items.pattern: \w+
 	// collection format: pipe
+	// items.default: bar
 	// in: query
 	FooSlice []string `json:"foo_slice"`
 
@@ -153,8 +156,8 @@ type NoParams struct {
 	// unique: true
 	// items.minItems: 4
 	// items.maxItems: 9
-    // items.enum: bar1,bar2,bar3
-    // items.default: bar2
+	// items.enum: bar1,bar2,bar3
+	// items.default: bar2
 	// items.items.minItems: 5
 	// items.items.maxItems: 8
 	// items.items.items.minLength: 3
@@ -174,6 +177,7 @@ type NoParams struct {
 		// required: true
 		// minimum: > 10
 		// maximum: < 1000
+		// default: 3
 		ID int32 `json:"id"`
 
 		// The Pet to add to this NoModel items bucket.

--- a/fixtures/goparsing/classification/operations/responses.go
+++ b/fixtures/goparsing/classification/operations/responses.go
@@ -32,10 +32,10 @@ type GenericError struct {
 // A ValidationError is an error that is used when the required input fails validation.
 // swagger:response validationError
 type ValidationError struct {
-    // in: header
-    // enum: foo,bar
-    // default: foo
-    Code int `json:"code"`
+	// in: header
+	// enum: foo,bar
+	// default: 400
+	Code int `json:"code"`
 
 	// The error message
 	// in: body
@@ -88,6 +88,7 @@ type SomeResponse struct {
 	//
 	// minimum: > 10
 	// maximum: < 1000
+	// default: 11
 	ID int64 `json:"id"`
 
 	// The Score of this model
@@ -96,6 +97,11 @@ type SomeResponse struct {
 	// maximum: 45
 	// multiple of: 3
 	Score int32 `json:"score"`
+
+	// Active state of the record
+	//
+	// default: true
+	Active bool `json:"active"`
 
 	// Name of this some response instance
 	//

--- a/scan/parameters.go
+++ b/scan/parameters.go
@@ -121,7 +121,7 @@ func (sv paramValidations) SetEnum(val string) {
 	}
 	sv.current.Enum = interfaceSlice
 }
-func (sv paramValidations) SetDefault(val string) { sv.current.Default = val }
+func (sv paramValidations) SetDefault(val interface{}) { sv.current.Default = val }
 
 type itemsValidations struct {
 	current *spec.Items
@@ -151,7 +151,7 @@ func (sv itemsValidations) SetEnum(val string) {
 	}
 	sv.current.Enum = interfaceSlice
 }
-func (sv itemsValidations) SetDefault(val string) { sv.current.Default = val }
+func (sv itemsValidations) SetDefault(val interface{}) { sv.current.Default = val }
 
 type paramDecl struct {
 	File         *ast.File
@@ -362,7 +362,7 @@ func (pp *paramStructParser) parseStructType(gofile *ast.File, operation *spec.O
 						newSingleLineTagParser("maxItems", &setMaxItems{paramValidations{&ps}, rxf(rxMaxItemsFmt, "")}),
 						newSingleLineTagParser("unique", &setUnique{paramValidations{&ps}, rxf(rxUniqueFmt, "")}),
 						newSingleLineTagParser("enum", &setEnum{paramValidations{&ps}, rxf(rxEnumFmt, "")}),
-						newSingleLineTagParser("default", &setDefault{paramValidations{&ps}, rxf(rxDefaultFmt, "")}),
+						newSingleLineTagParser("default", &setDefault{&ps.SimpleSchema, paramValidations{&ps}, rxf(rxDefaultFmt, "")}),
 						newSingleLineTagParser("required", &setRequiredParam{&ps}),
 					}
 
@@ -382,7 +382,7 @@ func (pp *paramStructParser) parseStructType(gofile *ast.File, operation *spec.O
 							newSingleLineTagParser(fmt.Sprintf("items%dMaxItems", level), &setMaxItems{itemsValidations{items}, rxf(rxMaxItemsFmt, itemsPrefix)}),
 							newSingleLineTagParser(fmt.Sprintf("items%dUnique", level), &setUnique{itemsValidations{items}, rxf(rxUniqueFmt, itemsPrefix)}),
 							newSingleLineTagParser(fmt.Sprintf("items%dEnum", level), &setEnum{itemsValidations{items}, rxf(rxEnumFmt, itemsPrefix)}),
-							newSingleLineTagParser(fmt.Sprintf("items%dDefault", level), &setDefault{itemsValidations{items}, rxf(rxDefaultFmt, itemsPrefix)}),
+							newSingleLineTagParser(fmt.Sprintf("items%dDefault", level), &setDefault{&items.SimpleSchema, itemsValidations{items}, rxf(rxDefaultFmt, itemsPrefix)}),
 						}
 					}
 

--- a/scan/parameters_test.go
+++ b/scan/parameters_test.go
@@ -145,6 +145,7 @@ func TestParamsParser(t *testing.T) {
 			assert.True(t, param.ExclusiveMaximum)
 			assert.EqualValues(t, 10, *param.Minimum)
 			assert.True(t, param.ExclusiveMinimum)
+			assert.Equal(t, 1, param.Default, "%s default value is incorrect", param.Name)
 
 		case "score":
 			assert.Equal(t, "The Score of this model", param.Description)
@@ -157,6 +158,7 @@ func TestParamsParser(t *testing.T) {
 			assert.False(t, param.ExclusiveMaximum)
 			assert.EqualValues(t, 3, *param.Minimum)
 			assert.False(t, param.ExclusiveMinimum)
+			assert.Equal(t, 2, param.Default, "%s default value is incorrect", param.Name)
 
 		case "x-hdr-name":
 			assert.Equal(t, "Name of this no model instance", param.Description)
@@ -193,13 +195,13 @@ func TestParamsParser(t *testing.T) {
 			assert.False(t, param.Required)
 			assert.True(t, param.UniqueItems)
 			assert.Equal(t, "pipe", param.CollectionFormat)
-			assert.NotNil(t, param.Items, "foo_slice should have had an items property")
 			assert.EqualValues(t, 3, *param.MinItems, "'foo_slice' should have had 3 min items")
 			assert.EqualValues(t, 10, *param.MaxItems, "'foo_slice' should have had 10 max items")
 			itprop := param.Items
 			assert.EqualValues(t, 3, *itprop.MinLength, "'foo_slice.items.minLength' should have been 3")
 			assert.EqualValues(t, 10, *itprop.MaxLength, "'foo_slice.items.maxLength' should have been 10")
 			assert.EqualValues(t, "\\w+", itprop.Pattern, "'foo_slice.items.pattern' should have \\w+")
+			assert.EqualValues(t, "bar", itprop.Default, "'foo_slice.items.default' should have bar default value")
 
 		case "items":
 			assert.Equal(t, "Items", param.Extensions["x-go-name"])
@@ -221,6 +223,7 @@ func TestParamsParser(t *testing.T) {
 			assert.NotNil(t, iprop.Minimum)
 			assert.EqualValues(t, 10, *iprop.Minimum)
 			assert.True(t, iprop.ExclusiveMinimum, "'id' should have had an exclusive minimum")
+			assert.Equal(t, 3, iprop.Default, "Items.ID default value is incorrect")
 
 			assertRef(t, itprop, "pet", "Pet", "#/definitions/pet")
 			iprop, ok = itprop.Properties["pet"]

--- a/scan/responses.go
+++ b/scan/responses.go
@@ -115,7 +115,7 @@ func (sv headerValidations) SetEnum(val string) {
 	}
 	sv.current.Enum = interfaceSlice
 }
-func (sv headerValidations) SetDefault(val string) { sv.current.Default = val }
+func (sv headerValidations) SetDefault(val interface{}) { sv.current.Default = val }
 
 func newResponseDecl(file *ast.File, decl *ast.GenDecl, ts *ast.TypeSpec) responseDecl {
 	var rd responseDecl
@@ -326,7 +326,7 @@ func (rp *responseParser) parseStructType(gofile *ast.File, response *spec.Respo
 					newSingleLineTagParser("maxItems", &setMaxItems{headerValidations{&ps}, rxf(rxMaxItemsFmt, "")}),
 					newSingleLineTagParser("unique", &setUnique{headerValidations{&ps}, rxf(rxUniqueFmt, "")}),
 					newSingleLineTagParser("enum", &setEnum{headerValidations{&ps}, rxf(rxEnumFmt, "")}),
-					newSingleLineTagParser("default", &setDefault{headerValidations{&ps}, rxf(rxDefaultFmt, "")}),
+					newSingleLineTagParser("default", &setDefault{&ps.SimpleSchema, headerValidations{&ps}, rxf(rxDefaultFmt, "")}),
 				}
 				itemsTaggers := func(items *spec.Items, level int) []tagParser {
 					// the expression is 1-index based not 0-index
@@ -344,7 +344,7 @@ func (rp *responseParser) parseStructType(gofile *ast.File, response *spec.Respo
 						newSingleLineTagParser(fmt.Sprintf("items%dMaxItems", level), &setMaxItems{itemsValidations{items}, rxf(rxMaxItemsFmt, itemsPrefix)}),
 						newSingleLineTagParser(fmt.Sprintf("items%dUnique", level), &setUnique{itemsValidations{items}, rxf(rxUniqueFmt, itemsPrefix)}),
 						newSingleLineTagParser(fmt.Sprintf("items%dEnum", level), &setEnum{itemsValidations{items}, rxf(rxEnumFmt, itemsPrefix)}),
-						newSingleLineTagParser(fmt.Sprintf("items%dDefault", level), &setDefault{itemsValidations{items}, rxf(rxDefaultFmt, itemsPrefix)}),
+						newSingleLineTagParser(fmt.Sprintf("items%dDefault", level), &setDefault{&items.SimpleSchema, itemsValidations{items}, rxf(rxDefaultFmt, itemsPrefix)}),
 					}
 				}
 

--- a/scan/responses_test.go
+++ b/scan/responses_test.go
@@ -64,7 +64,7 @@ func TestParseResponses(t *testing.T) {
 			assert.Equal(t, "string", header.Type)
 			assert.Equal(t, "", header.Format)
 		default:
-			assert.Fail(t, "unkown header: "+k)
+			assert.Fail(t, "unknown header: "+k)
 		}
 	}
 
@@ -96,7 +96,7 @@ func TestParseResponses(t *testing.T) {
 
 	res, ok := responses["someResponse"]
 	assert.True(t, ok)
-	assert.Len(t, res.Headers, 6)
+	assert.Len(t, res.Headers, 7)
 
 	for k, header := range res.Headers {
 		switch k {
@@ -109,6 +109,7 @@ func TestParseResponses(t *testing.T) {
 			assert.True(t, header.ExclusiveMaximum)
 			assert.EqualValues(t, 10, *header.Minimum)
 			assert.True(t, header.ExclusiveMinimum)
+			assert.Equal(t, 11, header.Default, "ID default value is incorrect")
 
 		case "score":
 			assert.Equal(t, "The Score of this model", header.Description)
@@ -127,6 +128,11 @@ func TestParseResponses(t *testing.T) {
 			assert.EqualValues(t, 4, *header.MinLength)
 			assert.EqualValues(t, 50, *header.MaxLength)
 			assert.Equal(t, "[A-Za-z0-9-.]*", header.Pattern)
+
+		case "active":
+			assert.Equal(t, "Active state of the record", header.Description)
+			assert.Equal(t, "boolean", header.Type)
+			assert.Equal(t, true, header.Default)
 
 		case "created":
 			assert.Equal(t, "Created holds the time when this entry was created", header.Description)

--- a/scan/schema_test.go
+++ b/scan/schema_test.go
@@ -41,6 +41,7 @@ func TestSchemaParser(t *testing.T) {
 	assert.NotNil(t, prop.Minimum)
 	assert.EqualValues(t, 10, *prop.Minimum)
 	assert.True(t, prop.ExclusiveMinimum, "'id' should have had an exclusive minimum")
+	assert.Equal(t, 11, prop.Default, "ID default value is incorrect")
 
 	assertProperty(t, &schema, "string", "NoNameOmitEmpty", "", "")
 	prop, ok = schema.Properties["NoNameOmitEmpty"]
@@ -128,6 +129,7 @@ func TestSchemaParser(t *testing.T) {
 	assert.NotNil(t, iprop.Minimum)
 	assert.EqualValues(t, 10, *iprop.Minimum)
 	assert.True(t, iprop.ExclusiveMinimum, "'id' should have had an exclusive minimum")
+	assert.Equal(t, 11, iprop.Default, "ID default value is incorrect")
 
 	assertRef(t, itprop, "pet", "Pet", "#/definitions/pet")
 	iprop, ok = itprop.Properties["pet"]


### PR DESCRIPTION
Validator is not allow to have field type `integer` and content of `default` other than `integer`
Example which will fail validation:
```go
type  Resp struct {
 // default: bar
 Field int
}
```
should be:
```go
type  Resp struct {
 // default: 0
 Field int
}
```