### PR TITLE
Add easyjson:json annotation for generated types

### DIFF
--- a/generator/templates/model.gotmpl
+++ b/generator/templates/model.gotmpl
@@ -7,6 +7,7 @@
       // {{ pascalize .Name }} {{ template "docstring" . }}
       {{- if not .IsBaseType }}
 // swagger:model {{ .Name }}
+// easyjson:json
       {{- else }}
 // swagger:discriminator {{ .Name }} {{ .DiscriminatorField }}
       {{- end }}
@@ -20,6 +21,7 @@
 {{ if .IncludeModel }}// {{ pascalize .Name }} {{ template "docstring" . }}
   {{- if not .IsBaseType }}
 // swagger:model {{ .Name }}
+// easyjson:json
   {{- else }}
 // swagger:discriminator {{ .Name }} {{ .DiscriminatorField }}
   {{- end }}


### PR DESCRIPTION
Currect swagger code is support easyjson serialization, but don't mark generated types as `easyjson:json`.

This issue can partically workarounded by `easyjson -all`, but unfortunatelly this command ignore array types like:
```
// swagger:model Posts
type Posts []*Post
```

As result you can't use easyjson serialization with swagger model like:
```
swagger: '2.0'
paths:
  /posts/{thread_id}/profile:
    get:
      parameters:
      - name: thread_id
        in: path
        required: true
        type: number
      responses:
        200:
          schema:
            $ref: '#/definitions/Posts'
definitions:
  Post:
    type: object
    ...
  Posts:
    type: array
    items:
      $ref: '#/definitions/Post'
```