### PR TITLE
Use filepath.Rel to determine template name

### DIFF
--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -240,10 +240,11 @@ func (t *Repository) LoadDir(templatePath string) error {
 	err := filepath.Walk(templatePath, func(path string, info os.FileInfo, err error) error {
 
 		if strings.HasSuffix(path, ".gotmpl") {
-			assetName := strings.TrimPrefix(path, templatePath)
-			if data, e := ioutil.ReadFile(path); e == nil {
-				if ee := t.AddFile(assetName, string(data)); ee != nil {
-					log.Fatal(ee)
+			if assetName, e := filepath.Rel(templatePath, path); e == nil {
+				if data, e := ioutil.ReadFile(path); e == nil {
+					if ee := t.AddFile(assetName, string(data)); ee != nil {
+						log.Fatal(ee)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
`templatePath` may start with `./`, but the `path` argument of `filepath.WalkFunc` does not start with `./`.