### PR TITLE
add support for strfmt.ObjectId

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,4 @@ For a V1 I want to have this feature set completed:
   - [x] duration
   - [x] password
   - [x] custom string formats
+  - [x] BSON ObjectId

--- a/generator/typeresolver_test.go
+++ b/generator/typeresolver_test.go
@@ -59,6 +59,7 @@ var schTypeVals = []struct{ Type, Format, Expected string }{
 	{"string", "hexcolor", "strfmt.HexColor"},
 	{"string", "rgbcolor", "strfmt.RGBColor"},
 	{"string", "duration", "strfmt.Duration"},
+	{"string", "ObjectId", "strfmt.ObjectId"},
 	{"string", "password", "strfmt.Password"},
 	{"file", "", "runtime.File"},
 }

--- a/generator/types.go
+++ b/generator/types.go
@@ -134,6 +134,7 @@ var typeMapping = map[string]string{
 	"rgbcolor":   "strfmt.RGBColor",
 	"duration":   "strfmt.Duration",
 	"password":   "strfmt.Password",
+	"ObjectId":   "strfmt.ObjectId",
 	"binary":     "io.ReadCloser",
 	"char":       "rune",
 	"int":        "int64",
@@ -785,6 +786,7 @@ var customFormatters = map[string]struct{}{
 	"strfmt.RGBColor":   struct{}{},
 	"strfmt.Base64":     struct{}{},
 	"strfmt.Duration":   struct{}{},
+	"strfmt.ObjectID":   struct{}{},
 	"io.ReadCloser":     struct{}{},
 	"io.Writer":         struct{}{},
 }


### PR DESCRIPTION
mgo compatibility was added to strfmt in https://github.com/go-openapi/strfmt/pull/12

This adds the`strfmt.ObjectId` type to the type resolver.

Signed-off-by: Matt Tucker <matt.tucker@microsoft.com>

Fixes #884 