### PR TITLE
Copying missing "existing-models" option

### DIFF
--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -71,6 +71,7 @@ func (c *Client) Execute(args []string) error {
 		IncludeSupport:    true,
 		TemplateDir:       string(c.TemplateDir),
 		DumpData:          c.DumpData,
+		ExistingModels:    c.ExistingModels,
 	}
 
 	if err := opts.EnsureDefaults(true); err != nil {


### PR DESCRIPTION
Can now generate clients using existing-models that have been generated
in another package.