### PR TITLE
Issue # 1059 : import's are incorrectly generated if $GOPATH is on a symlink. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ playground
 # Sublime files
 *.sublime-*
 
+# Vscode files
+.vscode/*
 cmd/swagger/swagger.json.bak
 tags
 

--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -102,14 +102,17 @@ func (c *Client) Execute(args []string) error {
 		return err
 	}
 
-	var basepath,rp string
+	var basepath,rp,targetAbs string
 
 	basepath,err = filepath.Abs(".")
 	if err != nil {
 		return err
 	}
-
-	rp, err = filepath.Rel(basepath, opts.Target)
+	targetAbs,err = filepath.Abs(opts.Target)
+	if err != nil {
+		return err
+	}
+		rp, err = filepath.Rel(basepath, targetAbs)
 	if err != nil {
 		return err
 	}

--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -102,7 +102,14 @@ func (c *Client) Execute(args []string) error {
 		return err
 	}
 
-	rp, err := filepath.Rel(".", opts.Target)
+	var basepath,rp string
+
+	basepath,err = filepath.Abs(".")
+	if err != nil {
+		return err
+	}
+
+	rp, err = filepath.Rel(basepath, opts.Target)
 	if err != nil {
 		return err
 	}

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -91,7 +91,17 @@ func (m *Model) Execute(args []string) error {
 		return err
 	}
 
-	rp, err := filepath.Rel(".", opts.Target)
+	var basepath,rp,targetAbs string
+
+	basepath,err = filepath.Abs(".")
+	if err != nil {
+		return err
+	}
+	targetAbs,err = filepath.Abs(opts.Target)
+	if err != nil {
+		return err
+	}
+	rp, err = filepath.Rel(basepath, targetAbs)
 	if err != nil {
 		return err
 	}

--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -81,7 +81,17 @@ func (o *Operation) Execute(args []string) error {
 		return err
 	}
 
-	rp, err := filepath.Rel(".", opts.Target)
+	var basepath,rp,targetAbs string
+
+	basepath,err = filepath.Abs(".")
+	if err != nil {
+		return err
+	}
+	targetAbs,err = filepath.Abs(opts.Target)
+	if err != nil {
+		return err
+	}
+	rp, err = filepath.Rel(basepath, targetAbs)
 	if err != nil {
 		return err
 	}

--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -118,14 +118,17 @@ func (s *Server) Execute(args []string) error {
 	if e := generator.GenerateServer(s.Name, s.Models, s.Operations, opts); e != nil {
 		return e
 	}
-	var basepath, rp string
+	var basepath,rp,targetAbs string
 
 	basepath,err = filepath.Abs(".")
 	if err != nil {
 		return err
 	}
-
-	rp, err = filepath.Rel(basepath, opts.Target)
+	targetAbs,err = filepath.Abs(opts.Target)
+	if err != nil {
+		return err
+	}
+	rp, err = filepath.Rel(basepath, targetAbs)
 	if err != nil {
 		return err
 	}

--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -118,8 +118,14 @@ func (s *Server) Execute(args []string) error {
 	if e := generator.GenerateServer(s.Name, s.Models, s.Operations, opts); e != nil {
 		return e
 	}
+	var basepath, rp string
 
-	rp, err := filepath.Rel(".", opts.Target)
+	basepath,err = filepath.Abs(".")
+	if err != nil {
+		return err
+	}
+
+	rp, err = filepath.Rel(basepath, opts.Target)
 	if err != nil {
 		return err
 	}

--- a/cmd/swagger/commands/generate/support.go
+++ b/cmd/swagger/commands/generate/support.go
@@ -52,7 +52,17 @@ func (s *Support) Execute(args []string) error {
 		return err
 	}
 
-	rp, err := filepath.Rel(".", opts.Target)
+	var basepath,rp,targetAbs string
+	var err error
+	basepath,err = filepath.Abs(".")
+	if err != nil {
+		return err
+	}
+	targetAbs,err = filepath.Abs(opts.Target)
+	if err != nil {
+		return err
+	}
+	rp, err = filepath.Rel(basepath, targetAbs)
 	if err != nil {
 		return err
 	}

--- a/generator/support.go
+++ b/generator/support.go
@@ -173,7 +173,7 @@ func checkPrefixAndFetchRelativePath(childpath string, parentpath string) (bool,
 	}
 
 	return false, ""
-	
+
 
 }
 

--- a/generator/support.go
+++ b/generator/support.go
@@ -170,9 +170,10 @@ func checkPrefixAndFetchRelativePath(childpath string, parentpath string) (bool,
 			log.Fatalln(err)
 		}
 		return true, pth
-	} else {
-		return false, ""
 	}
+
+	return false, ""
+	
 
 }
 

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	goruntime "runtime"
 	"path/filepath"
+	"strings"
 )
 
 var checkprefixandfetchrelativepathtests = []struct {
@@ -47,13 +48,14 @@ var checkbaseimporttest = []struct {
 
 }
 
+
 func TestCheckPrefixFetchRelPath(t *testing.T) {
 
 	for _,item := range checkprefixandfetchrelativepathtests {
 		actualok, actualpath := checkPrefixAndFetchRelativePath(item.childpath, item.parentpath)
 
 		if goruntime.GOOS == "windows" {
-			item.path = filepath.Clean(item.path)
+			item.path = strings.Replace(item.path, "/", "\\", -1)
 		}
 
 		if actualok != item.ok {
@@ -97,8 +99,7 @@ func TestBaseImport(t *testing.T) {
 		actualpath := baseImport(item.targetpath)
 
 		if goruntime.GOOS == "windows" {
-			actualpath = filepath.Clean(actualpath)
-			item.expectedpath = filepath.Clean(item.expectedpath)
+			item.expectedpath = strings.Replace(item.expectedpath, "/", "\\", -1)
 		}
 
 		if actualpath != item.expectedpath {

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -3,6 +3,8 @@ package generator
 import (
 	"testing"
 	"os"
+	goruntime "runtime"
+	"path/filepath"
 )
 
 var checkprefixandfetchrelativepathtests = []struct {
@@ -49,6 +51,11 @@ func TestCheckPrefixFetchRelPath(t *testing.T) {
 
 	for _,item := range checkprefixandfetchrelativepathtests {
 		actualok, actualpath := checkPrefixAndFetchRelativePath(item.childpath, item.parentpath)
+
+		if goruntime.GOOS == "windows" {
+			actualpath = filepath.Clean(actualpath)
+		}
+
 		if actualok != item.ok {
 			t.Errorf("checkPrefixAndFetchRelativePath(%s, %s): expected %v, actual %v", item.childpath, item.parentpath, item.ok, actualok)
 		} else if actualpath != item.path {
@@ -88,6 +95,11 @@ func TestBaseImport(t *testing.T) {
 
 		// Test
 		actualpath := baseImport(item.targetpath)
+
+		if goruntime.GOOS == "windows" {
+			actualpath = filepath.Clean(actualpath)
+			item.expectedpath = filepath.Clean(item.expectedpath)
+		}
 
 		if actualpath != item.expectedpath {
 			t.Errorf("baseImport(%s): expected %s, actual %s", item.targetpath, item.expectedpath, actualpath)

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -1,17 +1,17 @@
 package generator
 
 import (
-	"testing"
 	"os"
 	goruntime "runtime"
 	"strings"
+	"testing"
 )
 
 var checkprefixandfetchrelativepathtests = []struct {
 	childpath  string
 	parentpath string
-	ok bool
-	path string
+	ok         bool
+	path       string
 }{
 	// Positive
 	{"/", "/", true, "."},
@@ -23,34 +23,31 @@ var checkprefixandfetchrelativepathtests = []struct {
 	{"/User/Gopher", "/User/SomethingElse", false, ""},
 	{"/var", "/etc", false, ""},
 	{"/mnt/dev3", "/mnt/dev3/dir", false, ""},
-
-
-
 }
 
+var tempdir = os.TempDir()
+
 var checkbaseimporttest = []struct {
-	path  []string
-	gopath string
-	targetpath string
-	symlinksrc string
-	symlinkdest string  // symlink is the last dir in targetpath
+	path         []string
+	gopath       string
+	targetpath   string
+	symlinksrc   string
+	symlinkdest  string // symlink is the last dir in targetpath
 	expectedpath string
 }{
 	// No sym link. Positive Test Case
-	{[]string {"/tmp/root/go/src/github.com/go-swagger",}, "/tmp/root/go/", "/tmp/root/go/src/github.com/go-swagger", "", "", "github.com/go-swagger"},
+	{[]string{tempdir + "/root/go/src/github.com/go-swagger"}, tempdir + "/root/go/", tempdir + "/root/go/src/github.com/go-swagger", "", "", "github.com/go-swagger"},
 	// Symlink points inside GOPATH
-	{[]string {"/tmp/root/go/src/github.com/go-swagger",}, "/tmp/root/go/", "/tmp/root/symlink", "/tmp/root/symlink", "/tmp/root/go/src/", "."},
+	{[]string{tempdir + "/root/go/src/github.com/go-swagger"}, tempdir + "/root/go/", tempdir + "/root/symlink", tempdir + "/root/symlink", tempdir + "/root/go/src/", "."},
 	// Symlink points inside GOPATH
-	{[]string {"/tmp/root/go/src/github.com/go-swagger",}, "/tmp/root/go/", "/tmp/root/symlink", "/tmp/root/symlink", "/tmp/root/go/src/github.com", "github.com"},
+	{[]string{tempdir + "/root/go/src/github.com/go-swagger"}, tempdir + "/root/go/", tempdir + "/root/symlink", tempdir + "/root/symlink", tempdir + "/root/go/src/github.com", "github.com"},
 	// Symlink point outside GOPATH : Targets Case 1: in baseImport implementation.
-	{[]string {"/tmp/root/go/src/github.com/go-swagger","/tmp/root/gopher/go/"}, "/tmp/root/go/", "/tmp/root/go/src/github.com/gopher", "/tmp/root/go/src/github.com/gopher", "/tmp/root/gopher/go", "github.com/gopher"},
-
+	{[]string{tempdir + "/root/go/src/github.com/go-swagger", tempdir + "/root/gopher/go/"}, tempdir + "/root/go/", tempdir + "/root/go/src/github.com/gopher", tempdir + "/root/go/src/github.com/gopher", tempdir + "/root/gopher/go", "github.com/gopher"},
 }
-
 
 func TestCheckPrefixFetchRelPath(t *testing.T) {
 
-	for _,item := range checkprefixandfetchrelativepathtests {
+	for _, item := range checkprefixandfetchrelativepathtests {
 		actualok, actualpath := checkPrefixAndFetchRelativePath(item.childpath, item.parentpath)
 
 		if goruntime.GOOS == "windows" {
@@ -79,12 +76,12 @@ func TestBaseImport(t *testing.T) {
 
 	oldgopath := os.Getenv("GOPATH")
 	defer os.Setenv("GOPATH", oldgopath)
-	defer os.RemoveAll("/tmp/root")
+	defer os.RemoveAll(tempdir + "/root")
 
-	for _,item := range checkbaseimporttest {
+	for _, item := range checkbaseimporttest {
 
 		// Create Paths
-		for _,paths := range item.path {
+		for _, paths := range item.path {
 			os.MkdirAll(paths, 0777)
 		}
 
@@ -105,7 +102,7 @@ func TestBaseImport(t *testing.T) {
 			t.Errorf("baseImport(%s): expected %s, actual %s", item.targetpath, item.expectedpath, actualpath)
 		}
 
-		os.RemoveAll("/tmp/root")
+		os.RemoveAll(tempdir + "/root")
 
 	}
 

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"os"
 	goruntime "runtime"
-	"path/filepath"
 	"strings"
 )
 

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -1,0 +1,100 @@
+package generator
+
+import (
+	"testing"
+	"os"
+)
+
+var checkprefixandfetchrelativepathtests = []struct {
+	childpath  string
+	parentpath string
+	ok bool
+	path string
+}{
+	// Positive
+	{"/", "/", true, "."},
+	{"/User/Gopher", "/", true, "User/Gopher"},
+	{"/User/Gopher/Go", "/User/Gopher/Go", true, "."},
+	{"/User/../User/Gopher", "/", true, "User/Gopher"},
+	// Negative cases
+	{"/", "/var", false, ""},
+	{"/User/Gopher", "/User/SomethingElse", false, ""},
+	{"/var", "/etc", false, ""},
+	{"/mnt/dev3", "/mnt/dev3/dir", false, ""},
+
+
+
+}
+
+var checkbaseimporttest = []struct {
+	path  []string
+	gopath string
+	targetpath string
+	symlinksrc string
+	symlinkdest string  // symlink is the last dir in targetpath
+	expectedpath string
+}{
+	// No sym link. Positive Test Case
+	{[]string {"/tmp/root/go/src/github.com/go-swagger",}, "/tmp/root/go/", "/tmp/root/go/src/github.com/go-swagger", "", "", "github.com/go-swagger"},
+	// Symlink points inside GOPATH
+	{[]string {"/tmp/root/go/src/github.com/go-swagger",}, "/tmp/root/go/", "/tmp/root/symlink", "/tmp/root/symlink", "/tmp/root/go/src/", "."},
+	// Symlink points inside GOPATH
+	{[]string {"/tmp/root/go/src/github.com/go-swagger",}, "/tmp/root/go/", "/tmp/root/symlink", "/tmp/root/symlink", "/tmp/root/go/src/github.com", "github.com"},
+	// Symlink point outside GOPATH : Targets Case 1: in baseImport implementation.
+	{[]string {"/tmp/root/go/src/github.com/go-swagger","/tmp/root/gopher/go/"}, "/tmp/root/go/", "/tmp/root/go/src/github.com/gopher", "/tmp/root/go/src/github.com/gopher", "/tmp/root/gopher/go", "github.com/gopher"},
+
+}
+
+func TestCheckPrefixFetchRelPath(t *testing.T) {
+
+	for _,item := range checkprefixandfetchrelativepathtests {
+		actualok, actualpath := checkPrefixAndFetchRelativePath(item.childpath, item.parentpath)
+		if actualok != item.ok {
+			t.Errorf("checkPrefixAndFetchRelativePath(%s, %s): expected %v, actual %v", item.childpath, item.parentpath, item.ok, actualok)
+		} else if actualpath != item.path {
+			t.Errorf("checkPrefixAndFetchRelativePath(%s, %s): expected %s, actual %s", item.childpath, item.parentpath, item.path, actualpath)
+		} else {
+			continue
+		}
+	}
+
+}
+
+func TestBaseImport(t *testing.T) {
+
+	// 1. Create a root folder /tmp/root
+	// 2. Simulate scenario
+	//	2.a No Symlink
+	//	2.b Symlink from outside of GOPATH to inside
+	//  2.c Symlink from inside of GOPATH to outside.
+	// 3. Check results.
+
+	oldgopath := os.Getenv("GOPATH")
+	defer os.Setenv("GOPATH", oldgopath)
+	defer os.RemoveAll("/tmp/root")
+
+	for _,item := range checkbaseimporttest {
+
+		// Create Paths
+		for _,paths := range item.path {
+			os.MkdirAll(paths, 0777)
+		}
+
+		// Change GOPATH
+		os.Setenv("GOPATH", item.gopath)
+
+		// Create Symlink
+		os.Symlink(item.symlinkdest, item.symlinksrc)
+
+		// Test
+		actualpath := baseImport(item.targetpath)
+
+		if actualpath != item.expectedpath {
+			t.Errorf("baseImport(%s): expected %s, actual %s", item.targetpath, item.expectedpath, actualpath)
+		}
+
+		os.RemoveAll("/tmp/root")
+
+	}
+
+}

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -53,7 +53,7 @@ func TestCheckPrefixFetchRelPath(t *testing.T) {
 		actualok, actualpath := checkPrefixAndFetchRelativePath(item.childpath, item.parentpath)
 
 		if goruntime.GOOS == "windows" {
-			actualpath = filepath.Clean(actualpath)
+			item.path = filepath.Clean(item.path)
 		}
 
 		if actualok != item.ok {


### PR DESCRIPTION
Corrected Path generation for Base Imports.

baseImport function now  
 - make paths symlink free  
 - checks all GOPATH  
 - corrected bug in linux environment run of function.

fixes #1059 


