### PR TITLE
Generate models that have x-go-type

### DIFF
--- a/cmd/swagger/commands/generate/model_test.go
+++ b/cmd/swagger/commands/generate/model_test.go
@@ -13,7 +13,7 @@ import (
 func TestGenerateModel(t *testing.T) {
 	specs := []string{
 		"billforward.discriminators.yml",
-		"bitbucket.json",
+		"existing-model.yml",
 		"instagram.yml",
 		"shipyard.yml",
 		"sodabooth.json",
@@ -36,6 +36,7 @@ func TestGenerateModel(t *testing.T) {
 			flags.Parse(m)
 			m.Spec = flags.Filename(path)
 			m.Target = flags.Filename(generated)
+			m.NoValidator = true
 
 			if err := m.Execute([]string{}); err != nil {
 				t.Error(err)


### PR DESCRIPTION
Models with `x-go-type` cause a panic when generating corresponding files
This patch corrects that
```
sh-3.2$ git rev-parse HEAD ; go run cmd/swagger/swagger.go generate model -f fixtures/codegen/existing-model.yml
3962c9253776ac7c1332321fb391292e13149658
2017/09/07 18:24:41 rendering 1 templates for model JsonWebKeySet
2017/09/07 18:24:41 name field JsonWebKeySet
2017/09/07 18:24:41 package field models
2017/09/07 18:24:41 creating "json_web_key_set.go" in "models" as definition
2017/09/07 18:24:41 generated model JsonWebKeySet
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x156da30]

goroutine 1 [running]:
github.com/go-swagger/go-swagger/generator.(*GenOpts).renderDefinition(0xc4201f03c0, 0x0, 0x0, 0x0)
        /Users/josh/go/src/github.com/go-swagger/go-swagger/generator/shared.go:588 +0xa0
github.com/go-swagger/go-swagger/generator.(*definitionGenerator).generateModel(0xc420bb99b0, 0x0, 0xc4204a8d3a, 0x6)
        /Users/josh/go/src/github.com/go-swagger/go-swagger/generator/model.go:129 +0x3c
github.com/go-swagger/go-swagger/generator.(*definitionGenerator).Generate(0xc420bb99b0, 0x2, 0x2)
        /Users/josh/go/src/github.com/go-swagger/go-swagger/generator/model.go:119 +0x1da
github.com/go-swagger/go-swagger/generator.GenerateDefinition(0xc4208fed80, 0x2, 0x2, 0xc4201f03c0, 0x0, 0x1)
        /Users/josh/go/src/github.com/go-swagger/go-swagger/generator/model.go:89 +0x462
github.com/go-swagger/go-swagger/cmd/swagger/commands/generate.(*Model).Execute(0xc42019e0c0, 0xc4200630c0, 0x0, 0x4, 0xc42019e0c0, 0x1)
        /Users/josh/go/src/github.com/go-swagger/go-swagger/cmd/swagger/commands/generate/model.go:90 +0x2ba
github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags.(*Parser).ParseArgs(0xc4207ab380, 0xc420010150, 0x4, 0x4, 0x1012878, 0xc42008ca20, 0xc420221900, 0xc42016f101, 0xc4208aba10)
        /Users/josh/go/src/github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags/parser.go:316 +0x841
github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags.(*Parser).Parse(0xc4207ab380, 0x6, 0x1791eb1, 0x6, 0x0, 0x17d8fc9)
        /Users/josh/go/src/github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags/parser.go:186 +0x71
main.main()
        /Users/josh/go/src/github.com/go-swagger/go-swagger/cmd/swagger/swagger.go:105 +0xd63
exit status 2
sh-3.2$
sh-3.2$
sh-3.2$
sh-3.2$
sh-3.2$ git checkout model-go-extension
Switched to branch 'model-go-extension'
sh-3.2$ git rev-parse HEAD ; go run cmd/swagger/swagger.go generate model -f fixtures/codegen/existing-model.yml
b9d371459a2ad9404e209aa0d813a73fe1a7b194
2017/09/07 18:25:03 rendering 1 templates for model JsonWebKeySet
2017/09/07 18:25:03 name field JsonWebKeySet
2017/09/07 18:25:03 package field models
2017/09/07 18:25:03 creating "json_web_key_set.go" in "models" as definition
2017/09/07 18:25:03 generated model JsonWebKeySet
Generation completed!

For this generation to compile you need to have some packages in your GOPATH:

  * github.com/go-openapi/runtime

You can get these now with: go get -u -f ./...
```