### PR TITLE
Expands spec before generation correctly

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -101,7 +101,7 @@
   branch = "master"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  revision = "8a82927c942c94794a5cd8b8b50ce2f48a955c0c"
+  revision = "901ab082554d18fd6a99cc3a4bde6469e58d4cf6"
 
 [[projects]]
   branch = "master"

--- a/fixtures/bugs/890/path/health_check.yaml
+++ b/fixtures/bugs/890/path/health_check.yaml
@@ -1,0 +1,5 @@
+get:
+  summary: Health Check
+  responses:
+    200:
+      description: Server OK

--- a/fixtures/bugs/890/swagger.yaml
+++ b/fixtures/bugs/890/swagger.yaml
@@ -1,0 +1,18 @@
+swagger: '2.0'
+info:
+  title: Some API
+  description: Some API
+  version: "1.0.0"
+
+host: someapi.com
+
+schemes:
+  - https
+
+basePath: /v1/
+
+produces:
+  - application/json
+paths:
+  /health_check:
+    $ref: ./path/health_check.yaml

--- a/generator/client.go
+++ b/generator/client.go
@@ -51,17 +51,8 @@ func GenerateClient(name string, modelNames, operationIDs []string, opts *GenOpt
 		return err
 	}
 
-	// Validate if needed
-	if opts.ValidateSpec {
-		if err = validateSpec(opts.Spec, specDoc); err != nil {
-			return err
-		}
-		// Restore spec to original
-		opts.Spec, specDoc, err = loadSpec(opts.Spec)
-		if err != nil {
-			return err
-		}
-	}
+	// Validate and Expand. specDoc is in/out param.
+	validateAndExpandSpec(opts, specDoc)
 
 	analyzed := analysis.New(specDoc.Spec())
 
@@ -69,7 +60,12 @@ func GenerateClient(name string, modelNames, operationIDs []string, opts *GenOpt
 	if err != nil {
 		return err
 	}
+
 	operations := gatherOperations(analyzed, operationIDs)
+
+	if len(operations) == 0 {
+		return errors.New("no operations were selected")
+	}
 
 	defaultScheme := opts.DefaultScheme
 	if defaultScheme == "" {

--- a/generator/client.go
+++ b/generator/client.go
@@ -52,7 +52,10 @@ func GenerateClient(name string, modelNames, operationIDs []string, opts *GenOpt
 	}
 
 	// Validate and Expand. specDoc is in/out param.
-	validateAndExpandSpec(opts, specDoc)
+	specDoc,err = validateAndFlattenSpec(opts, specDoc)
+	if err != nil {
+		return err
+	}
 
 	analyzed := analysis.New(specDoc.Spec())
 

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
+
 )
 
 type respSort struct {
@@ -71,9 +72,16 @@ func GenerateServerOperation(operationNames []string, opts *GenOpts) error {
 	if err != nil {
 		return err
 	}
+
+	// Validate and Expand. specDoc is in/out param.
+	validateAndExpandSpec(opts, specDoc)
+
 	analyzed := analysis.New(specDoc.Spec())
 
 	ops := gatherOperations(analyzed, operationNames)
+	if len(ops) == 0 {
+		return errors.New("no operations were selected")
+	}
 
 	for operationName, opRef := range ops {
 		method, path, operation := opRef.Method, opRef.Path, opRef.Op

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -74,7 +74,10 @@ func GenerateServerOperation(operationNames []string, opts *GenOpts) error {
 	}
 
 	// Validate and Expand. specDoc is in/out param.
-	validateAndExpandSpec(opts, specDoc)
+	specDoc,err = validateAndFlattenSpec(opts, specDoc)
+	if err != nil {
+		return err
+	}
 
 	analyzed := analysis.New(specDoc.Spec())
 
@@ -299,7 +302,9 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	if Debug {
 		log.Printf("[%s %s] parsing operation (id: %q)", b.Method, b.Path, b.Operation.ID)
 	}
-	resolver := newTypeResolver(b.ModelsPackage, b.Doc.ResetDefinitions())
+	// @eleanorrigby : letting the comment be. Commented in response to issue#890
+	// Post-flattening of spec we no longer need to reset defs for spec or use original spec in any case.
+	resolver := newTypeResolver(b.ModelsPackage, b.Doc/*.ResetDefinitions()*/)
 	receiver := "o"
 
 	operation := b.Operation

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -150,7 +150,7 @@ func TestMakeResponse_WithAllOfSchema(t *testing.T) {
 				if assert.NotEmpty(t, body.Properties) {
 					prop := body.Properties[0]
 					assert.Equal(t, "data", prop.Name)
-					assert.Equal(t, "[]*DataItems0", prop.GoType)
+					assert.Equal(t, "[]*models.DataItems0", prop.GoType)
 				}
 				items := b.ExtraSchemas["DataItems0"]
 				if assert.NotEmpty(t, items.AllOf) {
@@ -218,7 +218,7 @@ func TestRenderOperation_InstagramSearch(t *testing.T) {
 				if assert.NoError(t, err) {
 					res := string(ff)
 					// fmt.Println(res)
-					assertInCode(t, "Data []*DataItems0 `json:\"data\"`", res)
+					assertInCode(t, "Data []*models.DataItems0 `json:\"data\"`", res)
 					assertInCode(t, "models.Media", res)
 				} else {
 					fmt.Println(buf.String())

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -534,3 +534,116 @@ func TestGenClient_Issue733(t *testing.T) {
 		}
 	}
 }
+
+func TestGenServerIssue890_ValidationTrue(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stderr)
+	dr, _ := os.Getwd()
+	opts := &GenOpts{
+		Spec:              filepath.FromSlash("../fixtures/bugs/890/swagger.yaml"),
+		IncludeModel:      true,
+		IncludeValidator:  true,
+		IncludeHandler:    true,
+		IncludeParameters: true,
+		IncludeResponses:  true,
+		IncludeMain:       true,
+		ValidateSpec:			 true,
+		APIPackage:        "restapi",
+		ModelPackage:      "model",
+		ServerPackage:     "server",
+		ClientPackage:     "client",
+		Target:            dr,
+	}
+
+	//Testing Server Generation
+	err := opts.EnsureDefaults(true)
+	assert.NoError(t, err)
+	appGen, err := newAppGenerator("JsonRefOperation", nil, nil, opts)
+	if assert.NoError(t, err) {
+		op, err := appGen.makeCodegenApp()
+		if assert.NoError(t, err) {
+			buf := bytes.NewBuffer(nil)
+			err := templates.MustGet("serverOperation").Execute(buf, op.Operations[0])
+			if assert.NoError(t, err) {
+				filecontent, err := appGen.GenOpts.LanguageOpts.FormatContent("operation.go", buf.Bytes())
+				if assert.NoError(t, err) {
+					res := string(filecontent)
+					assertInCode(t, "GetHealthCheck", res)
+				} else {
+					fmt.Println(buf.String())
+				}
+			}
+		}
+	}
+}
+
+
+func TestGenClientIssue890_ValidationTrue(t *testing.T) {
+	defer func() {
+		dr, _ := os.Getwd()
+		os.RemoveAll(dr+"/restapi/")
+	}()
+	opts := testGenOpts()
+	opts.Spec = "../fixtures/bugs/890/swagger.yaml"
+	opts.ValidateSpec = true
+	// Testing this is enough as there is only one operation which is specified as $ref.
+	// If this doesn't get resolved then there will be an error definitely.
+	assert.NoError(t, GenerateClient("foo", nil, nil, &opts))
+}
+
+
+func TestGenServerIssue890_ValidationFalse(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stderr)
+	dr, _ := os.Getwd()
+	opts := &GenOpts{
+		Spec:              filepath.FromSlash("../fixtures/bugs/890/swagger.yaml"),
+		IncludeModel:      true,
+		IncludeValidator:  true,
+		IncludeHandler:    true,
+		IncludeParameters: true,
+		IncludeResponses:  true,
+		IncludeMain:       true,
+		ValidateSpec:			 false,
+		APIPackage:        "restapi",
+		ModelPackage:      "model",
+		ServerPackage:     "server",
+		ClientPackage:     "client",
+		Target:            dr,
+	}
+
+	//Testing Server Generation
+	err := opts.EnsureDefaults(true)
+	assert.NoError(t, err)
+	appGen, err := newAppGenerator("JsonRefOperation", nil, nil, opts)
+	if assert.NoError(t, err) {
+		op, err := appGen.makeCodegenApp()
+		if assert.NoError(t, err) {
+			buf := bytes.NewBuffer(nil)
+			err := templates.MustGet("serverOperation").Execute(buf, op.Operations[0])
+			if assert.NoError(t, err) {
+				filecontent, err := appGen.GenOpts.LanguageOpts.FormatContent("operation.go", buf.Bytes())
+				if assert.NoError(t, err) {
+					res := string(filecontent)
+					assertInCode(t, "GetHealthCheck", res)
+				} else {
+					fmt.Println(buf.String())
+				}
+			}
+		}
+	}
+}
+
+
+func TestGenClientIssue890_ValidationFalse(t *testing.T) {
+	defer func() {
+		dr, _ := os.Getwd()
+		os.RemoveAll(dr+"/restapi/")
+	}()
+	opts := testGenOpts()
+	opts.Spec = "../fixtures/bugs/890/swagger.yaml"
+	opts.ValidateSpec = false
+	// Testing this is enough as there is only one operation which is specified as $ref.
+	// If this doesn't get resolved then there will be an error definitely.
+	assert.NoError(t, GenerateClient("foo", nil, nil, &opts))
+}

--- a/generator/response_test.go
+++ b/generator/response_test.go
@@ -138,7 +138,7 @@ func TestInlinedSchemaResponses(t *testing.T) {
 							}
 						}
 						assert.Len(t, b.ExtraSchemas, 1)
-						assert.Equal(t, "[]*SuccessBodyItems0", res.Schema.GoType)
+						assert.Equal(t, "[]*models.SuccessBodyItems0", res.Schema.GoType)
 					}
 				}
 			}

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -770,3 +770,25 @@ func pruneEmpty(in []string) (out []string) {
 func trimBOM(in string) string {
 	return strings.Trim(in, "\xef\xbb\xbf")
 }
+
+func validateAndExpandSpec(opts *GenOpts, specDoc *loads.Document) error {
+
+	// Validate if needed
+	if opts.ValidateSpec {
+		if err := validateSpec(opts.Spec, specDoc); err != nil {
+			return err
+		} else {
+			return nil
+		}
+	}
+
+	// If no validation then just expand and return
+	exp, err := specDoc.Expanded()
+	if err != nil {
+			return err
+	}
+
+	*specDoc = *exp
+
+	return nil
+}

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -777,9 +777,8 @@ func validateAndExpandSpec(opts *GenOpts, specDoc *loads.Document) error {
 	if opts.ValidateSpec {
 		if err := validateSpec(opts.Spec, specDoc); err != nil {
 			return err
-		} else {
-			return nil
 		}
+		return nil
 	}
 
 	// If no validation then just expand and return

--- a/generator/support.go
+++ b/generator/support.go
@@ -75,17 +75,8 @@ func newAppGenerator(name string, modelNames, operationIDs []string, opts *GenOp
 		return nil, err
 	}
 
-	// Validate if needed
-	if opts.ValidateSpec {
-		if err = validateSpec(opts.Spec, specDoc); err != nil {
-			return nil, err
-		}
-		// Restore spec to original
-		opts.Spec, specDoc, err = loadSpec(opts.Spec)
-		if err != nil {
-			return nil, err
-		}
-	}
+	// Validate and Expand. specDoc is in/out param.
+	validateAndExpandSpec(opts, specDoc)
 
 	analyzed := analysis.New(specDoc.Spec())
 

--- a/generator/support.go
+++ b/generator/support.go
@@ -76,7 +76,10 @@ func newAppGenerator(name string, modelNames, operationIDs []string, opts *GenOp
 	}
 
 	// Validate and Expand. specDoc is in/out param.
-	validateAndExpandSpec(opts, specDoc)
+	specDoc,err = validateAndFlattenSpec(opts, specDoc)
+	if err != nil {
+		return nil,err
+	}
 
 	analyzed := analysis.New(specDoc.Spec())
 

--- a/generator/types.go
+++ b/generator/types.go
@@ -213,7 +213,7 @@ func typeForHeader(header spec.Header) resolvedType {
 func newTypeResolver(pkg string, doc *loads.Document) *typeResolver {
 	resolver := typeResolver{ModelsPackage: pkg, Doc: doc}
 	resolver.KnownDefs = make(map[string]struct{}, 64)
-	for k, sch := range doc.OrigSpec().Definitions {
+	for k, sch := range doc.Spec().Definitions {
 		tpe, _, _ := knownDefGoType(k, sch, nil)
 		resolver.KnownDefs[tpe] = struct{}{}
 	}

--- a/vendor/github.com/go-openapi/validate/spec.go
+++ b/vendor/github.com/go-openapi/validate/spec.go
@@ -48,10 +48,12 @@ import (
 // 	- every default value that is specified must validate against the schema for that property
 // 	- items property is required for all schemas/definitions of type `array`
 func Spec(doc *loads.Document, formats strfmt.Registry) error {
-	errs, _ /*warns*/ := NewSpecValidator(doc.Schema(), formats).Validate(doc)
+   newSpecValidator := NewSpecValidator(doc.Schema(), formats)
+   errs, _ /*warns*/ := newSpecValidator.Validate(doc)
 	if errs.HasErrors() {
 		return errors.CompositeValidationError(errs.Errors...)
 	}
+   *doc = *(newSpecValidator.expanded)
 	return nil
 }
 


### PR DESCRIPTION
Adds support for expansion in abscence of validation.
Updates Vendor dependency package 'validate' which returns
expanded spec.
Minor refactoring for code reusability.

#890 