### PR TITLE
Add skip-flatten flag to generate server, client and operation

### DIFF
--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	SkipOperations  bool     `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
 	DumpData        bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
 	SkipValidation  bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
+	SkipFlattening  bool     `long:"skip-flatten" description:"skips flattening of spec prior to generation"`
 }
 
 // Execute runs this command
@@ -82,6 +83,7 @@ func (c *Client) Execute(args []string) error {
 		IncludeParameters: !c.SkipOperations,
 		IncludeResponses:  !c.SkipOperations,
 		ValidateSpec:      !c.SkipValidation,
+		FlattenSpec:			 !c.SkipFlattening,
 		Tags:              c.Tags,
 		IncludeSupport:    true,
 		TemplateDir:       string(c.TemplateDir),

--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -36,6 +36,8 @@ type Operation struct {
 	NoValidator   bool     `long:"skip-validator" description:"when present will not generate a model validator"`
 	NoURLBuilder  bool     `long:"skip-url-builder" description:"when present will not generate a URL builder"`
 	DumpData      bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
+	SkipFlattening  bool     `long:"skip-flatten" description:"skips flattening of spec prior to generation"`
+	SkipValidation  bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
 }
 
 // Execute generates a model file
@@ -67,6 +69,8 @@ func (o *Operation) Execute(args []string) error {
 		IncludeValidator:  !o.NoValidator,
 		IncludeURLBuilder: !o.NoURLBuilder,
 		Tags:              o.Tags,
+		FlattenSpec:			 !o.SkipFlattening,
+		ValidateSpec:      !o.SkipValidation,
 	}
 
 	if err = opts.EnsureDefaults(false); err != nil {

--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -43,6 +43,7 @@ type Server struct {
 	FlagStrategy      string   `long:"flag-strategy" description:"the strategy to provide flags for the server" default:"go-flags" choice:"go-flags" choice:"pflag"`
 	CompatibilityMode string   `long:"compatibility-mode" description:"the compatibility mode for the tls server" default:"modern" choice:"modern" choice:"intermediate"`
 	SkipValidation    bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
+	SkipFlattening  bool     `long:"skip-flatten" description:"skips flattening of spec prior to generation"`
 }
 
 // Execute runs this command
@@ -93,6 +94,7 @@ func (s *Server) Execute(args []string) error {
 		IncludeMain:       !s.ExcludeMain,
 		IncludeSupport:    !s.SkipSupport,
 		ValidateSpec:      !s.SkipValidation,
+		FlattenSpec:			 !s.SkipFlattening,
 		ExcludeSpec:       s.ExcludeSpec,
 		TemplateDir:       string(s.TemplateDir),
 		WithContext:       s.WithContext,

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -535,7 +535,7 @@ func TestGenClient_Issue733(t *testing.T) {
 	}
 }
 
-func TestGenServerIssue890_ValidationTrue(t *testing.T) {
+func TestGenServerIssue890_ValidationTrueFlatteningTrue(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)
 	dr, _ := os.Getwd()
@@ -548,6 +548,7 @@ func TestGenServerIssue890_ValidationTrue(t *testing.T) {
 		IncludeResponses:  true,
 		IncludeMain:       true,
 		ValidateSpec:			 true,
+		FlattenSpec:			 true,
 		APIPackage:        "restapi",
 		ModelPackage:      "model",
 		ServerPackage:     "server",
@@ -577,8 +578,7 @@ func TestGenServerIssue890_ValidationTrue(t *testing.T) {
 	}
 }
 
-
-func TestGenClientIssue890_ValidationTrue(t *testing.T) {
+func TestGenClientIssue890_ValidationTrueFlatteningTrue(t *testing.T) {
 	defer func() {
 		dr, _ := os.Getwd()
 		os.RemoveAll(dr+"/restapi/")
@@ -586,13 +586,13 @@ func TestGenClientIssue890_ValidationTrue(t *testing.T) {
 	opts := testGenOpts()
 	opts.Spec = "../fixtures/bugs/890/swagger.yaml"
 	opts.ValidateSpec = true
+	opts.FlattenSpec = true
 	// Testing this is enough as there is only one operation which is specified as $ref.
 	// If this doesn't get resolved then there will be an error definitely.
 	assert.NoError(t, GenerateClient("foo", nil, nil, &opts))
 }
 
-
-func TestGenServerIssue890_ValidationFalse(t *testing.T) {
+func TestGenServerIssue890_ValidationFalseFlattenTrue(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)
 	dr, _ := os.Getwd()
@@ -605,6 +605,7 @@ func TestGenServerIssue890_ValidationFalse(t *testing.T) {
 		IncludeResponses:  true,
 		IncludeMain:       true,
 		ValidateSpec:			 false,
+		FlattenSpec:			 true,
 		APIPackage:        "restapi",
 		ModelPackage:      "model",
 		ServerPackage:     "server",
@@ -634,8 +635,7 @@ func TestGenServerIssue890_ValidationFalse(t *testing.T) {
 	}
 }
 
-
-func TestGenClientIssue890_ValidationFalse(t *testing.T) {
+func TestGenClientIssue890_ValidationFalseFlatteningTrue(t *testing.T) {
 	defer func() {
 		dr, _ := os.Getwd()
 		os.RemoveAll(dr+"/restapi/")
@@ -643,7 +643,92 @@ func TestGenClientIssue890_ValidationFalse(t *testing.T) {
 	opts := testGenOpts()
 	opts.Spec = "../fixtures/bugs/890/swagger.yaml"
 	opts.ValidateSpec = false
+	opts.FlattenSpec = true
 	// Testing this is enough as there is only one operation which is specified as $ref.
 	// If this doesn't get resolved then there will be an error definitely.
 	assert.NoError(t, GenerateClient("foo", nil, nil, &opts))
+}
+
+func TestGenServerIssue890_ValidationFalseFlattenFalse(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stderr)
+	dr, _ := os.Getwd()
+	opts := &GenOpts{
+		Spec:              filepath.FromSlash("../fixtures/bugs/890/swagger.yaml"),
+		IncludeModel:      true,
+		IncludeValidator:  true,
+		IncludeHandler:    true,
+		IncludeParameters: true,
+		IncludeResponses:  true,
+		IncludeMain:       true,
+		ValidateSpec:			 false,
+		FlattenSpec:       false,
+		APIPackage:        "restapi",
+		ModelPackage:      "model",
+		ServerPackage:     "server",
+		ClientPackage:     "client",
+		Target:            dr,
+	}
+
+	//Testing Server Generation
+	err := opts.EnsureDefaults(true)
+	assert.NoError(t, err)
+	_, err = newAppGenerator("JsonRefOperation", nil, nil, opts)
+	assert.Error(t, err)
+}
+
+func TestGenClientIssue890_ValidationFalseFlattenFalse(t *testing.T) {
+	defer func() {
+		dr, _ := os.Getwd()
+		os.RemoveAll(dr+"/restapi/")
+	}()
+	opts := testGenOpts()
+	opts.Spec = "../fixtures/bugs/890/swagger.yaml"
+	opts.ValidateSpec = false
+	opts.FlattenSpec = false
+	// Testing this is enough as there is only one operation which is specified as $ref.
+	// If this doesn't get resolved then there will be an error definitely.
+	assert.Error(t, GenerateClient("foo", nil, nil, &opts))
+}
+
+func TestGenServerIssue890_ValidationTrueFlattenFalse(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stderr)
+	dr, _ := os.Getwd()
+	opts := &GenOpts{
+		Spec:              filepath.FromSlash("../fixtures/bugs/890/swagger.yaml"),
+		IncludeModel:      true,
+		IncludeValidator:  true,
+		IncludeHandler:    true,
+		IncludeParameters: true,
+		IncludeResponses:  true,
+		IncludeMain:       true,
+		ValidateSpec:			 true,
+		FlattenSpec:       false,
+		APIPackage:        "restapi",
+		ModelPackage:      "model",
+		ServerPackage:     "server",
+		ClientPackage:     "client",
+		Target:            dr,
+	}
+
+	//Testing Server Generation
+	err := opts.EnsureDefaults(true)
+	assert.NoError(t, err)
+	_, err = newAppGenerator("JsonRefOperation", nil, nil, opts)
+	assert.Error(t, err)
+}
+
+func TestGenClientIssue890_ValidationTrueFlattenFalse(t *testing.T) {
+	defer func() {
+		dr, _ := os.Getwd()
+		os.RemoveAll(dr+"/restapi/")
+	}()
+	opts := testGenOpts()
+	opts.Spec = "../fixtures/bugs/890/swagger.yaml"
+	opts.ValidateSpec = true
+	opts.FlattenSpec = false
+	// Testing this is enough as there is only one operation which is specified as $ref.
+	// If this doesn't get resolved then there will be an error definitely.
+	assert.Error(t, GenerateClient("foo", nil, nil, &opts))
 }

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -311,6 +311,7 @@ type GenOpts struct {
 	DumpData          bool
 	WithContext       bool
 	ValidateSpec      bool
+	FlattenSpec				bool
 	defaultsEnsured   bool
 
 	Spec              string
@@ -782,19 +783,20 @@ func validateAndFlattenSpec(opts *GenOpts, specDoc *loads.Document) (*loads.Docu
 		}
 	}
 
-
 	// Restore spec to original
 	opts.Spec, specDoc, err = loadSpec(opts.Spec)
 	if err != nil {
-		return nil,err
+		return nil, err
 	}
 
-	flattenOpts := analysis.FlattenOpts{
-		BasePath: specDoc.SpecFilePath(),
-		Spec:     analysis.New(specDoc.Spec()),
+	// Flatten if needed
+	if opts.FlattenSpec {
+		flattenOpts := analysis.FlattenOpts{
+			BasePath: specDoc.SpecFilePath(),
+			Spec:     analysis.New(specDoc.Spec()),
+		}
+		err = analysis.Flatten(flattenOpts)
 	}
-
-	err = analysis.Flatten(flattenOpts)
 
 	return specDoc,nil
 }


### PR DESCRIPTION
Adds `--skip-flatten` flag to `swagger   ##generate` command for skipping the flattening of spec before generation



#1172 
 