### PR TITLE
Support adding Vendor Extensions to Infos

### DIFF
--- a/fixtures/goparsing/classification/doc.go
+++ b/fixtures/goparsing/classification/doc.go
@@ -48,6 +48,15 @@
 //       - name: obj
 //         value: field
 //
+//     InfoExtensions:
+//     x-info-value: value
+//     x-info-array:
+//       - value1
+//       - value2
+//     x-info-array-obj:
+//       - name: obj
+//         value: field
+//
 //     Security:
 //     - api_key:
 //

--- a/scan/meta_test.go
+++ b/scan/meta_test.go
@@ -119,10 +119,24 @@ func verifyMeta(t testing.TB, doc *spec.Swagger) {
 		},
 		"x-meta-value": "value",
 	}
+	expectedInfoExtensions := spec.Extensions{
+		"x-info-array": []interface{}{
+			"value1",
+			"value2",
+		},
+		"x-info-array-obj": []interface{}{
+			map[string]interface{}{
+				"name":  "obj",
+				"value": "field",
+			},
+		},
+		"x-info-value": "value",
+	}
 	assert.NotNil(t, doc.SecurityDefinitions["api_key"])
 	assert.NotNil(t, doc.SecurityDefinitions["oauth2"])
 	assert.EqualValues(t, spec.SecurityDefinitions{"api_key": &expectedSecuritySchemaKey, "oauth2": &expectedSecuritySchemaOAuth}, doc.SecurityDefinitions)
 	assert.EqualValues(t, expectedExtensions, doc.Extensions)
+	assert.EqualValues(t, expectedInfoExtensions, doc.Info.Extensions)
 	assert.Equal(t, "localhost", doc.Host)
 	assert.Equal(t, "/v2", doc.BasePath)
 

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -117,6 +117,7 @@ var (
 	rxContact         = regexp.MustCompile(`[Cc]ontact\p{Zs}*-?(?:[Ii]info\p{Zs}*)?:\p{Zs}*(.+)$`)
 	rxTOS             = regexp.MustCompile(`[Tt](:?erms)?\p{Zs}*-?[Oo]f?\p{Zs}*-?[Ss](?:ervice)?\p{Zs}*:`)
 	rxExtensions      = regexp.MustCompile(`[Ee]xtensions\p{Zs}*:`)
+	rxInfoExtensions  = regexp.MustCompile(`[In]nfo\p{Zs}*[Ee]xtensions:`)
 )
 
 // Many thanks go to https://github.com/yvasiyarov/swagger


### PR DESCRIPTION
Hello,

This is a PR allowing the addition of Vendor Extensions to the info object.
This is useful for ReDoc, to add a logo on the documentation pages, as an example.

Feel free to tell me if anything should be changed !