### PR TITLE
1299-fix-unit-test-verbosity

### DIFF
--- a/generator/build_test.go
+++ b/generator/build_test.go
@@ -1,17 +1,26 @@
 package generator_test
 
 import (
+	"bytes"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/go-swagger/go-swagger/cmd/swagger/commands/generate"
 	flags "github.com/jessevdk/go-flags"
 )
 
 func TestGenerateAndBuild(t *testing.T) {
+	defer func() {
+		log.SetOutput(os.Stdout)
+	}()
+
 	cases := map[string]struct {
 		spec string
 	}{
@@ -24,6 +33,9 @@ func TestGenerateAndBuild(t *testing.T) {
 	}
 
 	for name, cas := range cases {
+		var captureLog bytes.Buffer
+		log.SetOutput(&captureLog)
+
 		t.Run(name, func(t *testing.T) {
 			spec := filepath.FromSlash(cas.spec)
 
@@ -37,6 +49,9 @@ func TestGenerateAndBuild(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Execute()=%s", err)
 			}
+
+			//fmt.Println(captureLog.String())
+			assert.Contains(t, strings.ToLower(captureLog.String()), "generation completed")
 
 			packages := filepath.Join(generated, "...")
 

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -1994,7 +1994,7 @@ func TestGenModel_Issue981(t *testing.T) {
 				ct, err := opts.LanguageOpts.FormatContent("user.go", buf.Bytes())
 				if assert.NoError(t, err) {
 					res := string(ct)
-					fmt.Println(res)
+					//fmt.Println(res)
 					assertInCode(t, "FirstName string `json:\"first_name,omitempty\"`", res)
 					assertInCode(t, "LastName string `json:\"last_name,omitempty\"`", res)
 					assertInCode(t, "if swag.IsZero(m.Type)", res)
@@ -2024,7 +2024,7 @@ func TestGenModel_Issue774(t *testing.T) {
 				ff, err := opts.LanguageOpts.FormatContent("Foo.go", buf.Bytes())
 				if assert.NoError(t, err) {
 					res := string(ff)
-					fmt.Println(res)
+					//fmt.Println(res)
 					assertInCode(t, "HasOmitEmptyFalse []string `json:\"hasOmitEmptyFalse\"`", res)
 					assertInCode(t, "HasOmitEmptyTrue []string `json:\"hasOmitEmptyTrue,omitempty\"`", res)
 					assertInCode(t, "NoOmitEmpty []string `json:\"noOmitEmpty\"`", res)

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -579,7 +579,9 @@ func TestGenServerIssue890_ValidationTrueFlatteningTrue(t *testing.T) {
 }
 
 func TestGenClientIssue890_ValidationTrueFlatteningTrue(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
 	defer func() {
+		log.SetOutput(os.Stdout)
 		dr, _ := os.Getwd()
 		os.RemoveAll(filepath.Join(filepath.FromSlash(dr), "restapi"))
 	}()
@@ -636,7 +638,9 @@ func TestGenServerIssue890_ValidationFalseFlattenTrue(t *testing.T) {
 }
 
 func TestGenClientIssue890_ValidationFalseFlatteningTrue(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
 	defer func() {
+		log.SetOutput(os.Stdout)
 		dr, _ := os.Getwd()
 		os.RemoveAll(filepath.Join(filepath.FromSlash(dr), "restapi"))
 	}()
@@ -720,7 +724,9 @@ func TestGenServerIssue890_ValidationTrueFlattenFalse(t *testing.T) {
 }
 
 func TestGenClientIssue890_ValidationTrueFlattenFalse(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
 	defer func() {
+		log.SetOutput(os.Stdout)
 		dr, _ := os.Getwd()
 		os.RemoveAll(filepath.Join(filepath.FromSlash(dr), "restapi"))
 	}()

--- a/generator/parameter_test.go
+++ b/generator/parameter_test.go
@@ -17,6 +17,9 @@ package generator
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/go-openapi/spec"
@@ -875,6 +878,11 @@ func TestGenParameter_Issue1010_Server(t *testing.T) {
 }
 
 func TestGenParameter_Issue710(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer func() {
+		log.SetOutput(os.Stdout)
+	}()
+
 	assert := assert.New(t)
 
 	gen, err := opBuilder("createTask", "../fixtures/codegen/todolist.allparams.yml")
@@ -899,7 +907,11 @@ func TestGenParameter_Issue710(t *testing.T) {
 
 func TestGenParameter_Issue776_LocalFileRef(t *testing.T) {
 	spec.Debug = true
-	defer func() { spec.Debug = false }()
+	log.SetOutput(ioutil.Discard)
+	defer func() {
+		spec.Debug = false
+		log.SetOutput(os.Stdout)
+	}()
 	b, err := opBuilder("GetItem", "../fixtures/bugs/776/param.yaml")
 	if assert.NoError(t, err) {
 		op, err := b.MakeOperation()

--- a/generator/response_test.go
+++ b/generator/response_test.go
@@ -17,6 +17,9 @@ package generator
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/go-openapi/spec"
@@ -331,7 +334,11 @@ func TestGenResponses_Issue718_Required(t *testing.T) {
 
 func TestGenResponses_Issue776_Spec(t *testing.T) {
 	spec.Debug = true
-	defer func() { spec.Debug = false }()
+	log.SetOutput(ioutil.Discard)
+	defer func() {
+		log.SetOutput(os.Stdout)
+		spec.Debug = false
+	}()
 
 	b, err := opBuilder("GetItem", "../fixtures/bugs/776/spec.yaml")
 	if assert.NoError(t, err) {
@@ -363,7 +370,11 @@ func TestGenResponses_Issue776_Spec(t *testing.T) {
 
 func TestGenResponses_Issue776_SwaggerTemplate(t *testing.T) {
 	spec.Debug = true
-	defer func() { spec.Debug = false }()
+	log.SetOutput(ioutil.Discard)
+	defer func() {
+		log.SetOutput(os.Stdout)
+		spec.Debug = false
+	}()
 
 	b, err := opBuilder("getHealthy", "../fixtures/bugs/776/swagger-template.yml")
 	if assert.NoError(t, err) {

--- a/scan/scanner_test.go
+++ b/scan/scanner_test.go
@@ -19,6 +19,7 @@ import (
 	"go/ast"
 	goparser "go/parser"
 	"log"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -841,7 +842,10 @@ func verifyBoolean(t *testing.T, matcher *regexp.Regexp, names, names2 []string)
 	if len(names2) > 0 {
 		nm2 = " " + names2[0]
 	}
-	fmt.Printf("tested %d %s%s combinations\n", cnt, names[0], nm2)
+	var Debug = os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != ""
+	if Debug {
+		fmt.Printf("tested %d %s%s combinations\n", cnt, names[0], nm2)
+	}
 }
 
 func verifyIntegerMinMaxManyWords(t *testing.T, matcher *regexp.Regexp, name1 string, words []string) {
@@ -888,7 +892,11 @@ func verifyIntegerMinMaxManyWords(t *testing.T, matcher *regexp.Regexp, name1 st
 	if len(words) > 0 {
 		nm2 = " " + words[0]
 	}
-	fmt.Printf("tested %d %s%s combinations\n", cnt, name1, nm2)
+	var Debug = os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != ""
+	if Debug {
+		fmt.Printf("tested %d %s%s combinations\n", cnt, name1, nm2)
+
+	}
 }
 
 func verifyNumeric2Words(t *testing.T, matcher *regexp.Regexp, name1, name2 string) {
@@ -937,7 +945,10 @@ func verifyNumeric2Words(t *testing.T, matcher *regexp.Regexp, name1, name2 stri
 			}
 		}
 	}
-	fmt.Printf("tested %d %s %s combinations\n", cnt, name1, name2)
+	var Debug = os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != ""
+	if Debug {
+		fmt.Printf("tested %d %s %s combinations\n", cnt, name1, name2)
+	}
 }
 
 func verifyMinMax(t *testing.T, matcher *regexp.Regexp, name string, operators []string) {
@@ -975,7 +986,10 @@ func verifyMinMax(t *testing.T, matcher *regexp.Regexp, name string, operators [
 			}
 		}
 	}
-	fmt.Printf("tested %d %s combinations\n", cnt, name)
+	var Debug = os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != ""
+	if Debug {
+		fmt.Printf("tested %d %s combinations\n", cnt, name)
+	}
 }
 
 func verifySwaggerOneArgSwaggerTag(t *testing.T, matcher *regexp.Regexp, prefixes, validParams, invalidParams []string) {


### PR DESCRIPTION
Minor change in order to better get the essentials when running CI checks.