### PR TITLE
1171. Add fixture

### DIFF
--- a/cmd/swagger/commands/validate_test.go
+++ b/cmd/swagger/commands/validate_test.go
@@ -22,3 +22,15 @@ func TestCmd_Validate_Issue1238(t *testing.T) {
 		assert.Contains(t, result.Error(), "definitions.RRSets in body must be of type array")
 	}
 }
+
+// Test proper validation: missing items in array error
+func TestCmd_Validate_Issue1171(t *testing.T) {
+	v := ValidateSpec{}
+	base := filepath.FromSlash("../../../")
+	specDoc := filepath.Join(base, "fixtures", "bugs", "1171", "swagger.yaml")
+	result := v.Execute([]string{specDoc})
+	if assert.Error(t, result) {
+		assert.Contains(t, result.Error(), "is invalid against swagger specification 2.0")
+		assert.Contains(t, result.Error(), "items in definitions.Zones is required")
+	}
+}

--- a/fixtures/bugs/1171/swagger.yaml
+++ b/fixtures/bugs/1171/swagger.yaml
@@ -1,0 +1,66 @@
+# In this one we make sure arrays without items are detected by validation
+# Conversely, objects with items are detected with fixture for issue #1238
+swagger: '2.0'
+info:
+  title: issue-1171
+  version: 0.0.1
+  license:
+    name: MIT
+host: localhost:8081
+basePath: /api/v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  '/servers/{server_id}/zones':
+    get:
+      operationId: listZones
+      tags:
+        - zones
+      parameters:
+        - name: server_id
+          in: path
+          required: true
+          type: string
+      responses:
+        '200':
+          description: An array of Zones
+          schema:
+            $ref: '#/definitions/Zones'
+
+  '/servers/{server_id}/zones/{zone_id}':
+    get:
+      operationId: listZone
+      tags:
+        - zones
+      parameters:
+        - name: server_id
+          in: path
+          required: true
+          type: string
+        - name: zone_id
+          type: string
+          in: path
+          required: true
+      responses:
+        '200':
+          description: A Zone
+          schema:
+            $ref: '#/definitions/Zone'
+
+
+definitions:
+  Zones:
+    type: array
+    properties:
+      name:
+        type: string
+
+  Zone:
+    type: array
+    items:
+      name:
+        type: string


### PR DESCRIPTION
Issue#1171 has been much embroiled...
There are basically 2 cases mentionned:
- object with an items property : covered with fixture for issue#1238 (more or less a duplicate of #1171, only clearer)
- items missing in array. This case specifically covered by the present fixture.

Together with issue#1238, both cases discussed are covered by UT (new exerciser for cmd/swagger/validate).