### PR TITLE
move language specific baseImport check to LanguageOpts #1312

### DIFF
--- a/generator/client.go
+++ b/generator/client.go
@@ -127,10 +127,10 @@ func (c *clientGenerator) Generate() error {
 	if app.Name == "" {
 		app.Name = "APIClient"
 	}
-
+	baseImport := c.GenOpts.LanguageOpts.baseImport(c.Target)
 	app.DefaultImports = []string{c.GenOpts.ExistingModels}
 	if c.GenOpts.ExistingModels == "" {
-		app.DefaultImports = []string{filepath.ToSlash(filepath.Join(baseImport(c.Target), c.ModelsPackage))}
+		app.DefaultImports = []string{filepath.ToSlash(filepath.Join(baseImport, c.ModelsPackage))}
 	}
 	if err != nil {
 		return err
@@ -185,7 +185,7 @@ func (c *clientGenerator) Generate() error {
 				}
 				// })
 			}
-			app.DefaultImports = append(app.DefaultImports, filepath.ToSlash(filepath.Join(baseImport(c.Target), c.ClientPackage, opGroup.Name)))
+			app.DefaultImports = append(app.DefaultImports, filepath.ToSlash(filepath.Join(baseImport, c.ClientPackage, opGroup.Name)))
 
 			// wg.Do(func() {
 			if err := c.GenOpts.renderOperationGroup(&opGroup); err != nil {

--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -15,6 +15,8 @@
 package generator
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,4 +27,19 @@ func TestClient_InvalidSpec(t *testing.T) {
 	opts.Spec = "../fixtures/bugs/825/swagger.yml"
 	opts.ValidateSpec = true
 	assert.Error(t, GenerateClient("foo", nil, nil, &opts))
+}
+
+func TestClient_BaseImportDisabled(t *testing.T) {
+	targetdir, err := ioutil.TempDir(os.TempDir(), "swagger_nogo")
+	if err != nil {
+		t.Fatalf("Failed to create a test target directory: %v", err)
+	}
+	defer func() {
+		os.RemoveAll(targetdir)
+	}()
+	opts := testGenOpts()
+	opts.Target = targetdir
+	opts.Spec = "../fixtures/petstores/petstore.json"
+	opts.LanguageOpts.BaseImportFunc = nil
+	assert.NoError(t, GenerateClient("foo", nil, nil, &opts))
 }

--- a/generator/config.go
+++ b/generator/config.go
@@ -16,7 +16,9 @@ type LanguageDefinition struct {
 // ConfigureOpts for generation
 func (d *LanguageDefinition) ConfigureOpts(opts *GenOpts) error {
 	opts.Sections = d.Layout
-	opts.LanguageOpts = GoLangOpts()
+	if opts.LanguageOpts == nil {
+		opts.LanguageOpts = GoLangOpts()
+	}
 	return nil
 }
 

--- a/generator/model.go
+++ b/generator/model.go
@@ -278,7 +278,7 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 	return &GenDefinition{
 		GenCommon: GenCommon{
 			Copyright:        opts.Copyright,
-			TargetImportPath: filepath.ToSlash(baseImport(opts.Target)),
+			TargetImportPath: filepath.ToSlash(opts.LanguageOpts.baseImport(opts.Target)),
 		},
 		Package:        opts.LanguageOpts.MangleName(filepath.Base(pkg), "definitions"),
 		GenSchema:      pg.GenSchema,

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -213,7 +213,7 @@ func (o *operationGenerator) Generate() error {
 
 	bldr.DefaultImports = []string{o.GenOpts.ExistingModels}
 	if o.GenOpts.ExistingModels == "" {
-		bldr.DefaultImports = []string{filepath.ToSlash(filepath.Join(baseImport(o.Base), o.ModelsPackage))}
+		bldr.DefaultImports = []string{filepath.ToSlash(filepath.Join(o.GenOpts.LanguageOpts.baseImport(o.Base), o.ModelsPackage))}
 	}
 
 	bldr.APIPackage = bldr.RootAPIPackage
@@ -465,7 +465,7 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	return GenOperation{
 		GenCommon: GenCommon{
 			Copyright:        b.GenOpts.Copyright,
-			TargetImportPath: filepath.ToSlash(baseImport(b.GenOpts.Target)),
+			TargetImportPath: filepath.ToSlash(b.GenOpts.LanguageOpts.baseImport(b.GenOpts.Target)),
 		},
 		Package:              b.APIPackage,
 		RootPackage:          b.RootAPIPackage,

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	goruntime "runtime"
 	"sort"
 	"strings"
 	"text/template"
@@ -43,6 +44,7 @@ import (
 // LanguageOpts to describe a language to the code generator
 type LanguageOpts struct {
 	ReservedWords    []string
+	BaseImportFunc   func(string) string
 	reservedWordsSet map[string]struct{}
 	initialized      bool
 	formatFunc       func(string, []byte) ([]byte, error)
@@ -84,6 +86,13 @@ func (l *LanguageOpts) FormatContent(name string, content []byte) ([]byte, error
 	return content, nil
 }
 
+func (l *LanguageOpts) baseImport(tgt string) string {
+	if l.BaseImportFunc != nil {
+		return l.BaseImportFunc(tgt)
+	}
+	return ""
+}
+
 var golang = GoLangOpts()
 
 // GoLangOpts for rendering items as golang code
@@ -103,6 +112,90 @@ func GoLangOpts() *LanguageOpts {
 		opts.Fragment = true
 		opts.Comments = true
 		return imports.Process(ffn, content, opts)
+	}
+	opts.BaseImportFunc = func(tgt string) string {
+		// On Windows, filepath.Abs("") behaves differently than on Unix.
+		// Windows: yields an error, since Abs() does not know the volume.
+		// UNIX: returns current working directory
+		if tgt == "" {
+			tgt = "."
+		}
+		tgtAbsPath, err := filepath.Abs(tgt)
+		if err != nil {
+			log.Fatalf("could not evaluate base import path with target \"%s\": %v", tgt, err)
+		}
+		var tgtAbsPathExtended string
+		tgtAbsPathExtended, err = filepath.EvalSymlinks(tgtAbsPath)
+		if err != nil {
+			log.Fatalf("could not evaluate base import path with target \"%s\" (with symlink resolution): %v", tgtAbsPath, err)
+		}
+
+		gopath := os.Getenv("GOPATH")
+		if gopath == "" {
+			gopath = filepath.Join(os.Getenv("HOME"), "go")
+		}
+
+		var pth string
+		for _, gp := range filepath.SplitList(gopath) {
+			// EvalSymLinks also calls the Clean
+			gopathExtended, err := filepath.EvalSymlinks(gp)
+			if err != nil {
+				log.Fatalln(err)
+			}
+			gopathExtended = filepath.Join(gopathExtended, "src")
+			gp = filepath.Join(gp, "src")
+
+			// Windows (local) file systems - NTFS, as well as FAT and variants
+			// are case insensitive.
+			if goruntime.GOOS == "windows" {
+				tgtAbsPath = strings.ToLower(tgtAbsPath)
+				tgtAbsPathExtended = strings.ToLower(tgtAbsPathExtended)
+				gopathExtended = strings.ToLower(gopathExtended)
+				gp = strings.ToLower(gp)
+			}
+
+			// At this stage we have expanded and unexpanded target path. GOPATH is fully expanded.
+			// Expanded means symlink free.
+			// We compare both types of targetpath<s> with gopath.
+			// If any one of them coincides with gopath , it is imperative that
+			// target path lies inside gopath. How?
+			// 		- Case 1: Irrespective of symlinks paths coincide. Both non-expanded paths.
+			// 		- Case 2: Symlink in target path points to location inside GOPATH. (Expanded Target Path)
+			//    - Case 3: Symlink in target path points to directory outside GOPATH (Unexpanded target path)
+
+			// Case 1: - Do nothing case. If non-expanded paths match just genrate base import path as if
+			//				   there are no symlinks.
+
+			// Case 2: - Symlink in target path points to location inside GOPATH. (Expanded Target Path)
+			//					 First if will fail. Second if will succeed.
+
+			// Case 3: - Symlink in target path points to directory outside GOPATH (Unexpanded target path)
+			// 					 First if will succeed and break.
+
+			//compares non expanded path for both
+			if ok, relativepath := checkPrefixAndFetchRelativePath(tgtAbsPath, gp); ok {
+				pth = relativepath
+				break
+			}
+
+			// Compares non-expanded target path
+			if ok, relativepath := checkPrefixAndFetchRelativePath(tgtAbsPath, gopathExtended); ok {
+				pth = relativepath
+				break
+			}
+
+			// Compares expanded target path.
+			if ok, relativepath := checkPrefixAndFetchRelativePath(tgtAbsPathExtended, gopathExtended); ok {
+				pth = relativepath
+				break
+			}
+
+		}
+
+		if pth == "" {
+			log.Fatalln("target must reside inside a location in the $GOPATH/src")
+		}
+		return pth
 	}
 	opts.Init()
 	return opts

--- a/generator/support.go
+++ b/generator/support.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	goruntime "runtime"
 	"sort"
 	"strings"
 
@@ -180,91 +179,6 @@ func checkPrefixAndFetchRelativePath(childpath string, parentpath string) (bool,
 
 }
 
-func baseImport(tgt string) string {
-	// On Windows, filepath.Abs("") behaves differently than on Unix.
-	// Windows: yields an error, since Abs() does not know the volume.
-	// UNIX: returns current working directory
-	if tgt == "" {
-		tgt = "."
-	}
-	tgtAbsPath, err := filepath.Abs(tgt)
-	if err != nil {
-		log.Fatalf("could not evaluate base import path with target \"%s\": %v", tgt, err)
-	}
-	var tgtAbsPathExtended string
-	tgtAbsPathExtended, err = filepath.EvalSymlinks(tgtAbsPath)
-	if err != nil {
-		log.Fatalf("could not evaluate base import path with target \"%s\" (with symlink resolution): %v", tgtAbsPath, err)
-	}
-
-	gopath := os.Getenv("GOPATH")
-	if gopath == "" {
-		gopath = filepath.Join(os.Getenv("HOME"), "go")
-	}
-
-	var pth string
-	for _, gp := range filepath.SplitList(gopath) {
-		// EvalSymLinks also calls the Clean
-		gopathExtended, err := filepath.EvalSymlinks(gp)
-		if err != nil {
-			log.Fatalln(err)
-		}
-		gopathExtended = filepath.Join(gopathExtended, "src")
-		gp = filepath.Join(gp, "src")
-
-		// Windows (local) file systems - NTFS, as well as FAT and variants
-		// are case insensitive.
-		if goruntime.GOOS == "windows" {
-			tgtAbsPath = strings.ToLower(tgtAbsPath)
-			tgtAbsPathExtended = strings.ToLower(tgtAbsPathExtended)
-			gopathExtended = strings.ToLower(gopathExtended)
-			gp = strings.ToLower(gp)
-		}
-
-		// At this stage we have expanded and unexpanded target path. GOPATH is fully expanded.
-		// Expanded means symlink free.
-		// We compare both types of targetpath<s> with gopath.
-		// If any one of them coincides with gopath , it is imperative that
-		// target path lies inside gopath. How?
-		// 		- Case 1: Irrespective of symlinks paths coincide. Both non-expanded paths.
-		// 		- Case 2: Symlink in target path points to location inside GOPATH. (Expanded Target Path)
-		//    - Case 3: Symlink in target path points to directory outside GOPATH (Unexpanded target path)
-
-		// Case 1: - Do nothing case. If non-expanded paths match just genrate base import path as if
-		//				   there are no symlinks.
-
-		// Case 2: - Symlink in target path points to location inside GOPATH. (Expanded Target Path)
-		//					 First if will fail. Second if will succeed.
-
-		// Case 3: - Symlink in target path points to directory outside GOPATH (Unexpanded target path)
-		// 					 First if will succeed and break.
-
-		//compares non expanded path for both
-		if ok, relativepath := checkPrefixAndFetchRelativePath(tgtAbsPath, gp); ok {
-			pth = relativepath
-			break
-		}
-
-		// Compares non-expanded target path
-		if ok, relativepath := checkPrefixAndFetchRelativePath(tgtAbsPath, gopathExtended); ok {
-			pth = relativepath
-			break
-		}
-
-		// Compares expanded target path.
-		if ok, relativepath := checkPrefixAndFetchRelativePath(tgtAbsPathExtended, gopathExtended); ok {
-			pth = relativepath
-			break
-		}
-
-	}
-
-	if pth == "" {
-		log.Fatalln("target must reside inside a location in the $GOPATH/src")
-	}
-	return pth
-}
-
 func (a *appGenerator) Generate() error {
 
 	app, err := a.makeCodegenApp()
@@ -352,11 +266,11 @@ func (a *appGenerator) GenerateSupport(ap *GenApp) error {
 		}
 		app = &ca
 	}
-
-	importPath := filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage, a.APIPackage))
+	baseImport := a.GenOpts.LanguageOpts.baseImport(a.Target)
+	importPath := filepath.ToSlash(filepath.Join(baseImport, a.ServerPackage, a.APIPackage))
 	app.DefaultImports = append(
 		app.DefaultImports,
-		filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage)),
+		filepath.ToSlash(filepath.Join(baseImport, a.ServerPackage)),
 		importPath,
 	)
 
@@ -599,11 +513,12 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 		prin = "interface{}"
 	}
 	security := a.makeSecuritySchemes()
+	baseImport := a.GenOpts.LanguageOpts.baseImport(a.Target)
 
 	var genMods []GenDefinition
 	importPath := a.GenOpts.ExistingModels
 	if a.GenOpts.ExistingModels == "" {
-		importPath = filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ModelsPackage))
+		importPath = filepath.ToSlash(filepath.Join(baseImport, a.ModelsPackage))
 	}
 
 	defaultImports = append(defaultImports, importPath)
@@ -682,7 +597,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 
 	}
 	for k := range tns {
-		importPath := filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage, a.APIPackage, swag.ToFileName(k)))
+		importPath := filepath.ToSlash(filepath.Join(baseImport, a.ServerPackage, a.APIPackage, swag.ToFileName(k)))
 		defaultImports = append(defaultImports, importPath)
 	}
 	sort.Sort(genOps)
@@ -702,20 +617,20 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 		opGroup := GenOperationGroup{
 			GenCommon: GenCommon{
 				Copyright:        a.GenOpts.Copyright,
-				TargetImportPath: filepath.ToSlash(baseImport(a.Target)),
+				TargetImportPath: filepath.ToSlash(baseImport),
 			},
 			Name:           k,
 			Operations:     v,
-			DefaultImports: []string{filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ModelsPackage))},
+			DefaultImports: []string{filepath.ToSlash(filepath.Join(baseImport, a.ModelsPackage))},
 			RootPackage:    a.APIPackage,
 			WithContext:    a.GenOpts != nil && a.GenOpts.WithContext,
 		}
 		opGroups = append(opGroups, opGroup)
 		var importPath string
 		if k == a.APIPackage {
-			importPath = filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage, a.APIPackage))
+			importPath = filepath.ToSlash(filepath.Join(baseImport, a.ServerPackage, a.APIPackage))
 		} else {
-			importPath = filepath.ToSlash(filepath.Join(baseImport(a.Target), a.ServerPackage, a.APIPackage, k))
+			importPath = filepath.ToSlash(filepath.Join(baseImport, a.ServerPackage, a.APIPackage, k))
 		}
 		defaultImports = append(defaultImports, importPath)
 	}
@@ -745,7 +660,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 	return GenApp{
 		GenCommon: GenCommon{
 			Copyright:        a.GenOpts.Copyright,
-			TargetImportPath: filepath.ToSlash(baseImport(a.Target)),
+			TargetImportPath: filepath.ToSlash(baseImport),
 		},
 		APIPackage:          a.ServerPackage,
 		Package:             a.Package,

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -95,7 +95,7 @@ func TestBaseImport(t *testing.T) {
 			if err := os.Symlink(item.symlinkdest, item.symlinksrc); err == nil {
 
 				// Test
-				actualpath := baseImport(item.targetpath)
+				actualpath := golang.baseImport(item.targetpath)
 
 				if goruntime.GOOS == "windows" {
 					item.expectedpath = strings.Replace(item.expectedpath, "/", "\\", -1)


### PR DESCRIPTION
Hi,
I moved the go specific baseImport code into the new function attached to LanguageOpts so that this code can be customized.

@casualjim Please let me know if this fits to what you are thinking about.

Thanks,
aki

fixes #1312 