### PR TITLE
Add shutdown handling of graceful server on calls to Server.Shutdown

### DIFF
--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -157,6 +157,7 @@ func NewServer(api *{{ .Package }}.{{ pascalize .Name }}API) *Server {
 	s.TLSWriteTimeout = tlsWriteTimeout{{ if .ExcludeSpec }}
   s.Spec = specFile
   {{ end }}{{ end }}
+	s.shutdown = make(chan struct{})
 	s.api = api
 	return s
 }
@@ -206,7 +207,9 @@ type Server struct {
 	{{ if .ExcludeSpec }}Spec {{ if .UsePFlags }}string{{ else }}flags.Filename `long:"spec" description:"the swagger specification to serve"`{{ end }}{{ end }}
 	api               *{{ .Package }}.{{ pascalize .Name }}API
 	handler           http.Handler
-	hasListeners bool
+	hasListeners      bool
+	shutdown          chan struct{}
+	shuttingDown      bool
 }
 
 // Logf logs message either via defined user logger or via system one if no user logger is defined.
@@ -286,7 +289,7 @@ func (s *Server) Serve() (err error) {
 
 		configureServer(domainSocket, "unix", string(s.SocketPath))
 
-		wg.Add(1)
+		wg.Add(2)
 		s.Logf("Serving {{ humanize .Name }} at unix://%s", s.SocketPath)
 		go func(l net.Listener){
 		  defer wg.Done()
@@ -295,6 +298,7 @@ func (s *Server) Serve() (err error) {
 		  }
 		  s.Logf("Stopped serving {{ humanize .Name }} at unix://%s", s.SocketPath)
 		}(s.domainSocketL)
+		go s.handleShutdown(&wg, domainSocket)
 	}
 
 	if s.hasScheme(schemeHTTP) {
@@ -317,7 +321,7 @@ func (s *Server) Serve() (err error) {
 
 		configureServer(httpServer, "http", s.httpServerL.Addr().String())
 
-		wg.Add(1)
+		wg.Add(2)
 		s.Logf("Serving {{ humanize .Name }} at http://%s", s.httpServerL.Addr())
 		go func(l net.Listener) {
 			defer wg.Done()
@@ -326,6 +330,7 @@ func (s *Server) Serve() (err error) {
 			}
 			s.Logf("Stopped serving {{ humanize .Name }} at http://%s", l.Addr())
 		}(s.httpServerL)
+		go s.handleShutdown(&wg, httpServer)
 	}
 
 	if s.hasScheme(schemeHTTPS) {
@@ -402,7 +407,7 @@ func (s *Server) Serve() (err error) {
 
 		configureServer(httpsServer, "https", s.httpsServerL.Addr().String())
 
-		wg.Add(1)
+		wg.Add(2)
 		s.Logf("Serving {{ humanize .Name }} at https://%s", s.httpsServerL.Addr())
 		go func(l net.Listener) {
 			defer wg.Done()
@@ -411,6 +416,7 @@ func (s *Server) Serve() (err error) {
 			}
 			s.Logf("Stopped serving {{ humanize .Name }} at https://%s", l.Addr())
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
+		go s.handleShutdown(&wg, httpsServer)
   }
 
   wg.Wait()
@@ -490,8 +496,30 @@ func (s *Server) Listen() error {
 
 // Shutdown server and clean up resources
 func (s *Server) Shutdown() error {
-	s.api.ServerShutdown()
+	if s.shuttingDown {
+		s.Logf("already shutting down")
+		return nil
+	}
+	s.shutdown <- struct{}{}
 	return nil
+}
+
+func (s *Server) handleShutdown(wg *sync.WaitGroup, server *graceful.Server) {
+	defer wg.Done()
+	for {
+		select {
+		case <-s.shutdown:
+			s.shuttingDown = true
+			server.Stop(s.CleanupTimeout)
+			<-server.StopChan()
+			s.api.ServerShutdown()
+			return
+		case <-server.StopChan():
+			s.shuttingDown = true
+			s.api.ServerShutdown()
+			return
+		}
+	}
 }
 
 // GetHandler returns a handler useful for testing


### PR DESCRIPTION
Fixes #1316 (https://github.com/go-swagger/go-swagger/issues/1316)

This change implements proper shutdown handling when calling `Server.Shutdown`. On calls to the method the graceful server is signalled to shutdown and the method blocks until shutdown have completed.