### PR TITLE
case sensitive import path on Windows

### DIFF
--- a/generator/shared.go
+++ b/generator/shared.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	goruntime "runtime"
 	"sort"
 	"strings"
 	"text/template"
@@ -144,15 +143,6 @@ func GoLangOpts() *LanguageOpts {
 			}
 			gopathExtended = filepath.Join(gopathExtended, "src")
 			gp = filepath.Join(gp, "src")
-
-			// Windows (local) file systems - NTFS, as well as FAT and variants
-			// are case insensitive.
-			if goruntime.GOOS == "windows" {
-				tgtAbsPath = strings.ToLower(tgtAbsPath)
-				tgtAbsPathExtended = strings.ToLower(tgtAbsPathExtended)
-				gopathExtended = strings.ToLower(gopathExtended)
-				gp = strings.ToLower(gp)
-			}
 
 			// At this stage we have expanded and unexpanded target path. GOPATH is fully expanded.
 			// Expanded means symlink free.

--- a/generator/support.go
+++ b/generator/support.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	goruntime "runtime"
 	"sort"
 	"strings"
 
@@ -169,8 +170,15 @@ type appGenerator struct {
 // 2. If they do return child path  relative to parent path.
 // 3. Everything else return false
 func checkPrefixAndFetchRelativePath(childpath string, parentpath string) (bool, string) {
+	// Windows (local) file systems - NTFS, as well as FAT and variants
+	// are case insensitive.
+	cp, pp := childpath, parentpath
+	if goruntime.GOOS == "windows" {
+		cp = strings.ToLower(cp)
+		pp = strings.ToLower(pp)
+	}
 
-	if strings.HasPrefix(childpath, parentpath) {
+	if strings.HasPrefix(cp, pp) {
 		pth, err := filepath.Rel(parentpath, childpath)
 		if err != nil {
 			log.Fatalln(err)


### PR DESCRIPTION
Generated codes on Windows by go-swagger can't be compiled when the package path has case sensitive name.

For example, the name of pacakge is `github.com/FooBar/awesome`, go-swagger generate codes which have `"github.com/foobar/awesome/xxx"` or so in import paths on Windows.  It causes compilation errors because golang compiler checks import paths by case sensitive.

This PR modifies `checkPrefixAndFetchRelativePath()` function to compare two paths by case insensitive on Windows, but create relative path by case sensitive.