### PR TITLE
Edit the todo tutorial for grammar and clarity

### DIFF
--- a/docs/tutorial/todo-list.md
+++ b/docs/tutorial/todo-list.md
@@ -1,23 +1,24 @@
 # Todo List Tutorial
 
-This example walks you through a hypothetical project that is building a todo list.
-It specifically uses a todo list because it's a super well-understood application and hopefully this allows you to focus entirely on the new concepts. This example builds a server and then a client.
+This example walks you through a hypothetical project, building a todo list.
+
+It uses a todo list because this is well-understood application, so you can focus on the go-swagger pieces. In this example we build a server and a client.
 
 <!--more-->
 
-When you start an application most likely you think about the functionality it supports.
+To create your application start with `swagger init`:
 
 ```
 swagger init spec \
-  --title "A To Do list application" \
-  --description "The product of a tutorial on goswagger.io" \
+  --title "A Todo list application" \
+  --description "From the todo list tutorial on goswagger.io" \
   --version 1.0.0 \
   --scheme http \
   --consumes application/io.goswagger.examples.todo-list.v1+json \
   --produces application/io.goswagger.examples.todo-list.v1+json
 ```
 
-You can get started with a swagger.yml like this:
+This gives you a skeleton `swagger.yml` file:
 
 ```yaml
 ---
@@ -25,8 +26,8 @@ consumes:
 - application/io.goswagger.examples.todo-list.v1+json
 definitions: {}
 info:
-  description: The product of a tutorial on goswagger.io
-  title: A To Do list application
+  description: From the todo list tutorial on goswagger.io
+  title: A Todo list application
   version: 1.0.0
 paths: {}
 produces:
@@ -36,7 +37,7 @@ schemes:
 swagger: "2.0"
 ```
 
-This doesn't do much but it would validate in the swagger validator step.
+This doesn't do much but it does pass validation:
 
 ```
 ± ~/go/src/github.com/go-swagger/go-swagger/examples/tutorials/todo-list
@@ -44,7 +45,7 @@ git:(master) ✗ ? » swagger validate ./swagger.yml
 The swagger spec at "./swagger.yml" is valid against swagger specification 2.0
 ```
 
-So now you have an empty but valid specification document, time to get to declaring some models and endpoints for the API. You'll probably need a model to represent a todo item, you can define that in the definitions.
+Now that you have an empty but valid specification document, it's time to declare some models and endpoints for the API. You'll need a model to represent a todo item, so you can define that in the definitions section:
 
 ```yaml
 ---
@@ -65,10 +66,11 @@ definitions:
         type: boolean
 ```
 
-In this model definition we say that the model `item` is an _object_ with a required property `description`. This item model has 3 properties: id, description and completed. The `id` property is an int64 value and is marked as _readOnly_, so that means that it will be provided by the API server and it will be ignored when the item is created.
-This document also says that the description must be at least 1 char long, this will result in a string property that's [not a pointer](/use/schemas.md#nullability).
+In this model definition we say that the model `item` is an _object_ with a required property `description`. This item model has 3 properties: `id`, `description`, and `completed`. The `id` property is an int64 value and is marked as _readOnly_, meaning that it will be provided by the API server and it will be ignored when the item is created.
 
-At this moment there is enough to get some actual code generated, but let's wait with that and continue defining the rest of the API so that the code generation later on will be more useful. Now you have a model so you probably want to add some endpoints to list the todo's.
+This document also says that the description must be at least 1 char long, which results in a string property that's [not a pointer](/use/schemas.md#nullability).
+
+At this moment you have enough so that actual code could be generated, but let's continue defining the rest of the API so that the code generation will be more useful. Now that you have a model so you can add some endpoints to list the todo's:
 
 ```yaml
 ---
@@ -86,9 +88,9 @@ paths:
               $ref: "#/definitions/item"
 ```
 
-This snippet of yaml defines a `GET /` operation, and tags it with _todos_. Tagging things is nice because tools do all kinds of fancy things with tags. Tags help UI's group endpoints appropriately, code generators might turn them into 'controllers'. Furthermore there is a response defined with a generic description, about what's in the response. Be aware that some generators think a field like that is a good thing to put in the http status message. And then of course the response defines also the return type of that endpoint. In this case the endpoint will be returning a list of todo items, so the schema is an _array_ and the array will contain items that look like the item definition you declared earlier.
+This snippet of yaml defines a `GET /` operation and tags it with _todos_. Tagging things is useful for many tools, for example helping UI tools group endpoints appropriately. Code generators might turn them into 'controllers'. There is also a response defined with a generic description about the response content. Note that some generators will put the description into the http status message. The response also defines endpoint's return type. In this case the endpoint returns a list of todo items, so the schema is an _array_ and the array will contain `item` objects, which you defined previously.
 
-But wait a minute, what if there are 100's of todo items, will we just return all of them for everybody?  It might be best to add a since and limit param here. The ids will have ordered for a since param to work but you're in control of that so that's fine.
+But wait a minute, what if there are 100's of todo items, will we just return all of them for everybody?  It would be good to add a `since` and `limit` param here. The ids will have to be ordered for a `since` param to work but you're in control of that so that's fine.
 
 ```yaml
 ---
@@ -116,11 +118,11 @@ paths:
               $ref: "#/definitions/item"
 ```
 
-With this new version of the operation YAML, there are query params now for the values and they define defaults so people can leave them off and the API will still function as intended.
+With this new version of the operation you now have query params. These parameters have defaults so users can leave them off and the API will still function as intended.
 
-However  this definition is extremely optimistic and only defines a response for the "happy path". It's very likely that the API will need to return some form of error messages too. So that means you probably have to define a model for the error messages as well as at least one more response definition to cover both the bodies in you contract.
+However, this definition is extremely optimistic and only defines a response for the "happy path". It's very likely that the API will need to return errors too. That means you have to define a model errors, as well as at least one more response definition to cover the error response.
 
-The error definition might look like this:
+The error definition looks like this:
 
 ```yaml
 ---
@@ -137,7 +139,7 @@ definitions:
         type: string
 ```
 
-For the extra response you can use the default response, because after all every successful response from your API is defying the odds.
+For the error response you can use the default response, on the assumption that every successful response from your API is defying the odds.
 
 ```yaml
 ---
@@ -169,18 +171,18 @@ paths:
             $ref: "#/definitions/error"
 ```
 
-At this point you've got your first endpoint defined completely. To improve the strength of this contract you could define responses for each of the status codes and perhaps return a different error message. In this case the status code will be provided in the error message, and can easily be different from the HTTP status codes, who typically only give you a hint of what went wrong.
+At this point you've defined your first endpoint completely. To improve the strength of this contract you could define responses for each of the status codes and perhaps return different error messages for different statuses. For now, the status code will be provided in the error message.
 
-Perhaps validate the specification again, having a valid swagger document, is important when using the code generation, there are quite a few factors that contribute to rendering the models for a specification. An invalid swagger document makes it so that the generated code will have unpredictable behavior.
+Try validating the specification again with `swagger validate ./swagger.yml` to ensure that code generation will work as expected. Generating code from an invalid specification leads to unpredictable results.
 
-So the completed spec should look like this:
+Your completed spec should look like this:
 
 ```yaml
 ---
 swagger: "2.0"
 info:
-  description: The product of a tutorial on goswagger.io
-  title: A To Do list application
+  description: From the todo list tutorial on goswagger.io
+  title: A Todo list application
   version: 1.0.0
 consumes:
 - application/io.goswagger.examples.todo-list.v1+json
@@ -241,85 +243,163 @@ definitions:
         type: string
 ```
 
-Once you generate a server for this you'll see the following directory listing:
+When you generate a server for this spec you'll see the following output:
 
 ```
 ± ~/go/src/github.com/go-swagger/go-swagger/examples/tutorials/todo-list/server-1
 git:(master) ✗ !? » swagger generate server -A todo-list -f ./swagger.yml
-2016/02/15 12:32:40 building a plan for generation
-2016/02/15 12:32:40 planning definitions
-2016/02/15 12:32:40 planning operations
-2016/02/15 12:32:40 grouping operations into packages
-2016/02/15 12:32:40 planning meta data and facades
-2016/02/15 12:32:40 rendering 2 models
-2016/02/15 12:32:40 rendered model template: error
-2016/02/15 12:32:40 rendered model template: item
-2016/02/15 12:32:40 rendered handler template: todos.Get
-2016/02/15 12:32:40 generated handler todos.Get
-2016/02/15 12:32:40 rendered parameters template: todos.GetParameters
-2016/02/15 12:32:40 generated parameters todos.GetParameters
-2016/02/15 12:32:40 rendered responses template: todos.GetResponses
-2016/02/15 12:32:40 generated responses todos.GetResponses
-2016/02/15 12:32:40 rendered builder template: operations.TodoList
-2016/02/15 12:32:40 rendered embedded Swagger JSON template: server.TodoList
-2016/02/15 12:32:40 rendered configure api template: operations.ConfigureTodoList
-2016/02/15 12:32:40 rendered doc template: operations.TodoList
-2016/02/15 12:32:40 rendered main template: server.TodoList
+2018/01/06 11:49:16 building a plan for generation
+2018/01/06 11:49:16 planning definitions
+2018/01/06 11:49:16 planning operations
+2018/01/06 11:49:16 grouping operations into packages
+2018/01/06 11:49:16 planning meta data and facades
+2018/01/06 11:49:16 rendering 3 models
+2018/01/06 11:49:16 rendering 1 templates for model getOKBody
+2018/01/06 11:49:16 name field getOKBody
+2018/01/06 11:49:16 package field models
+2018/01/06 11:49:16 creating generated file "get_okbody.go" in "models" as definition
+2018/01/06 11:49:16 executed template asset:model
+2018/01/06 11:49:16 rendering 1 templates for model item
+2018/01/06 11:49:16 name field item
+2018/01/06 11:49:16 package field models
+2018/01/06 11:49:16 creating generated file "item.go" in "models" as definition
+2018/01/06 11:49:16 executed template asset:model
+2018/01/06 11:49:16 rendering 1 templates for model error
+2018/01/06 11:49:16 name field error
+2018/01/06 11:49:16 package field models
+2018/01/06 11:49:16 creating generated file "error.go" in "models" as definition
+2018/01/06 11:49:16 executed template asset:model
+2018/01/06 11:49:16 rendering 1 operation groups (tags)
+2018/01/06 11:49:16 rendering 1 operations for todos
+2018/01/06 11:49:16 rendering 4 templates for operation todo-list
+2018/01/06 11:49:16 name field Get
+2018/01/06 11:49:16 package field todos
+2018/01/06 11:49:16 creating generated file "get_parameters.go" in "restapi/operations/todos" as parameters
+2018/01/06 11:49:16 executed template asset:serverParameter
+2018/01/06 11:49:16 name field Get
+2018/01/06 11:49:16 package field todos
+2018/01/06 11:49:16 creating generated file "get_urlbuilder.go" in "restapi/operations/todos" as urlbuilder
+2018/01/06 11:49:16 executed template asset:serverUrlbuilder
+2018/01/06 11:49:16 name field Get
+2018/01/06 11:49:16 package field todos
+2018/01/06 11:49:16 creating generated file "get_responses.go" in "restapi/operations/todos" as responses
+2018/01/06 11:49:16 executed template asset:serverResponses
+2018/01/06 11:49:16 name field Get
+2018/01/06 11:49:16 package field todos
+2018/01/06 11:49:16 creating generated file "get.go" in "restapi/operations/todos" as handler
+2018/01/06 11:49:16 executed template asset:serverOperation
+2018/01/06 11:49:16 rendering 0 templates for operation group todo-list
+2018/01/06 11:49:16 rendering support
+2018/01/06 11:49:16 rendering 6 templates for application TodoList
+2018/01/06 11:49:16 name field TodoList
+2018/01/06 11:49:16 package field operations
+2018/01/06 11:49:16 creating generated file "configure_todo_list.go" in "restapi" as configure
+2018/01/06 11:49:16 executed template asset:serverConfigureapi
+2018/01/06 11:49:16 name field TodoList
+2018/01/06 11:49:16 package field operations
+2018/01/06 11:49:16 creating generated file "main.go" in "cmd/todo-list-server" as main
+2018/01/06 11:49:16 executed template asset:serverMain
+2018/01/06 11:49:16 name field TodoList
+2018/01/06 11:49:16 package field operations
+2018/01/06 11:49:16 creating generated file "embedded_spec.go" in "restapi" as embedded_spec
+2018/01/06 11:49:16 executed template asset:swaggerJsonEmbed
+2018/01/06 11:49:16 name field TodoList
+2018/01/06 11:49:16 package field operations
+2018/01/06 11:49:16 creating generated file "server.go" in "restapi" as server
+2018/01/06 11:49:16 executed template asset:serverServer
+2018/01/06 11:49:16 name field TodoList
+2018/01/06 11:49:16 package field operations
+2018/01/06 11:49:16 creating generated file "todo_list_api.go" in "restapi/operations" as builder
+2018/01/06 11:49:16 executed template asset:serverBuilder
+2018/01/06 11:49:16 name field TodoList
+2018/01/06 11:49:16 package field operations
+2018/01/06 11:49:16 creating generated file "doc.go" in "restapi" as doc
+2018/01/06 11:49:16 executed template asset:serverDoc
+2018/01/06 11:49:16 Generation completed!
+
+For this generation to compile you need to have some packages in your GOPATH:
+
+  * github.com/go-openapi/runtime
+  * github.com/tylerb/graceful
+  * github.com/jessevdk/go-flags
 
 ± ~/go/src/github.com/go-swagger/go-swagger/examples/tutorials/todo-list/server-1
 git:(master) ✗ !? » tree
 .
 ├── cmd
 │   └── todo-list-server
-│       ├── configure_todo_list.go
-│       ├── doc.go
-│       ├── embedded_spec.go
 │       └── main.go
 ├── models
 │   ├── error.go
+│   ├── get_okbody.go
 │   └── item.go
 ├── restapi
-│   └── operations
-│       ├── todo_list_api.go
-│       └── todos
-│           ├── get.go
-│           ├── get_parameters.go
-│           └── get_responses.go
+│   ├── configure_todo_list.go
+│   ├── doc.go
+│   ├── embedded_spec.go
+│   ├── operations
+│   │   ├── todo_list_api.go
+│   │   └── todos
+│   │       ├── get.go
+│   │       ├── get_parameters.go
+│   │       ├── get_responses.go
+│   │       └── get_urlbuilder.go
+│   └── server.go
 └── swagger.yml
 
-6 directories, 11 files
+6 directories, 14 files
 ```
 
-In this file tree you notice that there is a cmd/todo-list-server generated. The swagger generator adds -server to the application name (provided to the generated command through the -A argument).
+In this file tree you see that there is a `cmd/todo-list-server` directory. The swagger generator adds "-server" to the application name that you gave via the `-A` argument.
 
-The second major section in this tree is the models package. This package contains go representations for both the definitions from the swagger spec document.
+The next section in this tree is the `models` package. This package contains go representations for all item definitions in the swagger spec document.
 
-And then the last major section is restapi. Within restapi there is the code that is generated based on the information from the paths property in the swagger specification. The go swagger generator uses the tags to group the operations into packages.
+The last section is `restapi`. The `restapi` package is generated based on the `paths` property in the swagger specification. The go swagger generator uses tags to group the operations into packages.
 
-We skipped over naming operations, you have the ability to name the operations by giving operations an ID in the specification document. For example for the operation definition with `operationId: findTodos`, the following tree would be generated:
+You can also name operation by specifying an `operationId` in the specification for a path:
+
+
+```yaml
+---
+paths:
+  /:
+    get:
+      tags:
+        - todos
+      operationId: find_todos
+      ...
+```
+
+These `operationId` values are used to name the generated files:
 
 ```
 .
 ├── cmd
 │   └── todo-list-server
-│       ├── configure_todo_list.go
-│       ├── doc.go
-│       ├── embedded_spec.go
 │       └── main.go
 ├── models
 │   ├── error.go
+│   ├── find_todos_okbody.go
+│   ├── get_okbody.go
 │   └── item.go
 ├── restapi
-│   └── operations
-│       ├── todo_list_api.go
-│       └── todos
-│           ├── find_todos.go
-│           ├── find_todos_parameters.go
-│           └── find_todos_responses.go
+│   ├── configure_todo_list.go
+│   ├── doc.go
+│   ├── embedded_spec.go
+│   ├── operations
+│   │   ├── todo_list_api.go
+│   │   └── todos
+│   │       ├── find_todos.go
+│   │       ├── find_todos_parameters.go
+│   │       ├── find_todos_responses.go
+│   │       └── find_todos_urlbuilder.go
+│   └── server.go
 └── swagger.yml
 ```
 
-At this point you're able to start the server, but let's first see what --help gives you. To make this happen you can first install the binary and then run it.
+You can see that the files under `restapi/operations/todos` now use the `operationId` as part of the generated file names.
+
+At this point can start the server, but first let's see what `--help` gives you. First install the server binary and then run it:
 
 ```
 ± ~/go/src/.../examples/tutorials/todo-list/server-1
@@ -329,24 +409,43 @@ At this point you're able to start the server, but let's first see what --help g
 Usage:
   todo-list-server [OPTIONS]
 
-The product of a tutorial on goswagger.io
+From the todo list tutorial on goswagger.io
 
 Application Options:
-      --host= the IP to listen on (default: localhost) [$HOST]
-      --port= the port to listen on for insecure connections, defaults to a random value [$PORT]
+      --scheme=            the listeners to enable, this can be repeated and defaults to the schemes in the swagger spec
+      --cleanup-timeout=   grace period for which to wait before shutting down the server (default: 10s)
+      --max-header-size=   controls the maximum number of bytes the server will read parsing the request header's keys and values, including the
+                           request line. It does not limit the size of the request body. (default: 1MiB)
+      --socket-path=       the unix socket to listen on (default: /var/run/todo-list.sock)
+      --host=              the IP to listen on (default: localhost) [$HOST]
+      --port=              the port to listen on for insecure connections, defaults to a random value [$PORT]
+      --listen-limit=      limit the number of outstanding requests
+      --keep-alive=        sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)
+                           (default: 3m)
+      --read-timeout=      maximum duration before timing out read of the request (default: 30s)
+      --write-timeout=     maximum duration before timing out write of the response (default: 60s)
+      --tls-host=          the IP to listen on for tls, when not specified it's the same as --host [$TLS_HOST]
+      --tls-port=          the port to listen on for secure connections, defaults to a random value [$TLS_PORT]
+      --tls-certificate=   the certificate to use for secure connections [$TLS_CERTIFICATE]
+      --tls-key=           the private key to use for secure conections [$TLS_PRIVATE_KEY]
+      --tls-ca=            the certificate authority file to be used with mutual tls auth [$TLS_CA_CERTIFICATE]
+      --tls-listen-limit=  limit the number of outstanding requests
+      --tls-keep-alive=    sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)
+      --tls-read-timeout=  maximum duration before timing out read of the request
+      --tls-write-timeout= maximum duration before timing out write of the response
 
 Help Options:
-  -h, --help  Show this help message
+  -h, --help               Show this help message
 ```
 
-As you can see your application can be run straightaway and it will use a random port value by default. This might not be what you want so you can configure a port with an argument or through an environment variable. Those env vars are chosen because many platforms (like heroku) use those to configure the apps they are running.
+If you run your application now it will start on a random port by default. This might not be what you want, so you can configure a port through a command line argument or a `PORT` env var.
 
 ```
 git:(master) ✗ !? » todo-list-server
 serving todo list at http://127.0.0.1:64637
 ```
 
-And you can curl it:
+You can use `curl` to check your API:
 
 ```
 git:(master) ✗ !? » curl -i http://127.0.0.1:64637/
@@ -360,9 +459,9 @@ Content-Length: 57
 "operation todos.FindTodos has not yet been implemented"
 ```
 
-So immediately after generating, the API has limited usability, but this can serve as a sanity check. Your API will need more endpoints besides listing todo items. Because this tutorial highlights design first, we know we will need a few other things. In addition to listing the todo items the API will need a means to add a new todo item, update the description of one and mark a todo item as completed.
+As you can see, the generated API isn't very usable yet, but we know it runs and does something. To make it useful you'll need to implement the actual logic behind those endpoints. And you'll also want to add some more endpoints, like adding a new todo item and updating an existing item to change its description or mark it completed.
 
-For adding a todo item you probably want to define a POST operation, for our purposes that might look like this:
+To supporting  adding a todo item you should define a `POST` operation:
 
 ```yaml
 ---
@@ -388,7 +487,9 @@ paths:
             $ref: "#/definitions/error"
 ```
 
-So in this YAML snippet there is one new thing: you're defining that your API has a POST body and that that should be the item model defined earlier. Earlier the item schema was defined with a _readOnly_ id, so that means it doesn't need to be included in the POST body. But the response to the POST request will include an id property. The next operation to define is the DELETE operation, where you delete a todo item from the list.
+This snippet has something new. You see that the parameters are defined using a `schema` that references our exist item model. Remember that we defined this object's `id` key as _readOnly_, so it will not be accepted as part of the `POST` body.
+
+Next you can define a `DELETE` to remove a todo item from the list:
 
 ```yaml
 ---
@@ -413,7 +514,9 @@ paths:
             $ref: "#/definitions/error"
 ```
 
-The new concept in the DELETE method is that this time around you're defining a path parameter. When you delete an item you need to provide an ID. This is typically done in the path of a resource, and that's how this operation will know which todo item to delete. Once you've deleted something you can't really return its data anymore, so the success response in this case is `204 No Content`. At this point all you still require is a means to update an item, which combines everything you've just learnt.
+This time you're you're defining a parameter that is part of the `path`. This operation will look in the URI templated path for an id. Since there's nothing to return after a delete, the success response  is `204 No Content`.
+
+Finally, you need to define a way to update an existing item:
 
 ```yaml
 ---
@@ -446,16 +549,18 @@ paths:
       # elided for brevity
 ```
 
-For updates there are 2 approaches that people typically take: PUT indicates replace the entity, PATCH indicates only update the fields provided in the request. In this case the "brute force" approach of replacing an entire entity is taken. Another thing you see here is that because the id path parameter is shared between both the put and the delete method, there is an opportunity to DRY the operation definition up a bit. So the path parameter moved to the common parameters section for the path.
+There are two approaches typically taken for updates. A `PUT` indicates that the entire entity is being replaced, and a `PATCH` indicates that only the fields provided in the request should be updated. In the above example, you can see that the `PUT` "brute force" approach is being used.
 
-At this point you should have a completed specification for the todo list API.
+Another thing to note is that because the `/{id}` path is shared for both `DELETE` and `PUT`, they can share a `parameters` definition.
+
+At this point you should have a complete specification for the todo list API:
 
 ```yaml
 ---
 swagger: "2.0"
 info:
-  description: The product of a tutorial on goswagger.io
-  title: A To Do list application
+  description: From the todo list tutorial on goswagger.io
+  title: A Todo list application
   version: 1.0.0
 consumes:
 - application/io.goswagger.examples.todo-list.v1+json
@@ -572,7 +677,7 @@ definitions:
         type: string
 ```
 
-Again this is a good time to sanity check, and run the validator.
+This is a good time to sanity check and by validating the schema:
 
 ```
 ± ~/go/src/github.com/go-swagger/go-swagger/examples/tutorials/todo-list/server-2
@@ -580,7 +685,7 @@ git:(master) ✗ !? » swagger validate ./swagger.yml
 The swagger spec at "./swagger.yml" is valid against swagger specification 2.0
 ```
 
-You're ready to generate the API and start filling out some of the blanks.
+Now you're ready to generate the API and start filling in the actual operations:
 
 ```
 git:(master) ✗ !? » swagger generate server -A TodoList -f ./swagger.yml
@@ -591,38 +696,45 @@ git:(master) ✗ !? » tree
 .
 ├── cmd
 │   └── todo-list-server
-│       ├── configure_todo_list.go
-│       ├── doc.go
-│       ├── embedded_spec.go
 │       └── main.go
 ├── models
 │   ├── error.go
+│   ├── find_todos_okbody.go
 │   └── item.go
 ├── restapi
-│   └── operations
-│       ├── todo_list_api.go
-│       └── todos
-│           ├── add_one.go
-│           ├── add_one_parameters.go
-│           ├── add_one_responses.go
-│           ├── destroy_one.go
-│           ├── destroy_one_parameters.go
-│           ├── destroy_one_responses.go
-│           ├── find_todos.go
-│           ├── find_todos_parameters.go
-│           ├── find_todos_responses.go
-│           ├── update_one.go
-│           ├── update_one_parameters.go
-│           └── update_one_responses.go
+│   ├── configure_todo_list.go
+│   ├── doc.go
+│   ├── embedded_spec.go
+│   ├── operations
+│   │   ├── todo_list_api.go
+│   │   └── todos
+│   │       ├── add_one.go
+│   │       ├── add_one_parameters.go
+│   │       ├── add_one_responses.go
+│   │       ├── add_one_urlbuilder.go
+│   │       ├── destroy_one.go
+│   │       ├── destroy_one_parameters.go
+│   │       ├── destroy_one_responses.go
+│   │       ├── destroy_one_urlbuilder.go
+│   │       ├── find_todos.go
+│   │       ├── find_todos_parameters.go
+│   │       ├── find_todos_responses.go
+│   │       ├── find_todos_urlbuilder.go
+│   │       ├── update_one.go
+│   │       ├── update_one_parameters.go
+│   │       ├── update_one_responses.go
+│   │       └── update_one_urlbuilder.go
+│   └── server.go
 └── swagger.yml
 
-6 directories, 20 files
+6 directories, 26 files
 ```
 
-When you want to add functionality to your application, like adding your own code to the generated code, the place to do that is in the `configure_todo_list.go` file. The configure_todo_list file is safe to edit, it won't get overwritten in regeneration passes, to override the file you'd have to delete it yourself and regenerate.
+To implement the core of your application you start by editing `restapi/configure_todo_list.go`. This file is safe to edit. Its content will not be overwritten if you run `swagger generate` again the future.
 
-A good first implementation of the todo list api, can be one where everything is stored in a map. This should show that everything works, without the complications of dealing with a database yet.
-For this you'll need to track the state for an incrementing id and a structure to store items in.
+The simplest way to implement this application is to simply store all the todo items in a golang `map`. This provides a simple way to move forward without bringing in complications like a database or files.
+
+To do this you'll need a map and a counter to track the last assigned id:
 
 ```go
 // the variables we need throughout our implementation
@@ -639,9 +751,11 @@ api.TodosDestroyOneHandler = todos.DestroyOneHandlerFunc(func(params todos.Destr
 })
 ```
 
-After deleting the item from the store, there is a responder that needs to be created. The code generator has generated responders for each response you defined in the the swagger specification. The other 3 handler implementations are pretty similar to this one, they are provided in the [source for this tutorial](https://github.com/go-swagger/go-swagger/blob/master/examples/tutorials/todo-list/server-complete/restapi/configure_todo_list.go).
+After deleting the item from the store, you need to provide a response. The code generator created responders for each response you defined in the the swagger specification, and you can see how one of those is being used in the example above.
 
-You're all set now, with a spiffy new todo list api implemented, lets see if it actually works.
+The other 3 handler implementations are similar to this one. They are provided in the [source for this tutorial](https://github.com/go-swagger/go-swagger/blob/master/examples/tutorials/todo-list/server-complete/restapi/configure_todo_list.go).
+
+So assuming you go ahead and implement the remainder of the endpoints, you're all set to test it out:
 
 ```
 » curl -i localhost:8765


### PR DESCRIPTION
Mostly this consisted of going through the tutorial and editing for English
grammar as well as trying to trim down the word count. The text was a bit more
verbose than it needed to be, which I think made it harder to follow.

I also made a few other changes:

* Wrapped more things in backticks to highlight technical terms, code
  snippets, etc.

* Updated output examples to match the current state of go-swagger (notably
  the generate files have changed a bit).