### PR TITLE
1348 Add generation of validate on MAC format

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ build_script:
   - echo %GOPATH%
 
 test_script:
-  - ps: go test -race -v $(go list ./... | sls -n "vendor|fixtures|examples")
+  - ps: go test -timeout 20m -race -v $(go list ./... | sls -n "vendor|fixtures|examples")
 
 #artifacts:
 #  - path: '%GOPATH%\bin\*.exe'

--- a/fixtures/bugs/1348/fixture-1348.yaml
+++ b/fixtures/bugs/1348/fixture-1348.yaml
@@ -1,0 +1,43 @@
+swagger: '2.0'
+info:
+  title: fixture for issue#1348
+  version: '1.0.0'
+host: localhost
+basePath: /
+produces:
+  - application/json
+schemes:
+  - http
+paths:
+  /optional:
+    get:
+      operationId: getOptional
+      parameters:
+      - name: option1
+        in: query
+        type: string
+        format: mac
+        required: false
+      - name: option2
+        in: body
+        required: false
+        schema:
+          $ref: '#/definitions/ContainerConfig'
+      responses:
+        200:
+          description: simple type
+          schema:
+            type: string
+            format: mac
+        default:
+          description: option
+          schema:
+            $ref: '#/definitions/ContainerConfig'
+definitions:
+  ContainerConfig:
+    type: object
+    required: [config1]
+    properties:
+      config1:
+        type: string
+        format: mac

--- a/generator/debug.go
+++ b/generator/debug.go
@@ -1,0 +1,34 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// Debug when the env var DEBUG or SWAGGER_DEBUG is not empty
+// the generators will be very noisy about what they are doing
+var Debug = os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != ""
+
+func logDebug(frmt string, args ...interface{}) {
+	if Debug {
+		_, file, pos, _ := runtime.Caller(2)
+		log.Printf("%s:%d: %s", filepath.Base(file), pos, fmt.Sprintf(frmt, args...))
+	}
+}

--- a/generator/doc.go
+++ b/generator/doc.go
@@ -12,39 +12,62 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*Package generator provides the code generation library for go-swagger
+/*Package generator provides the code generation library for go-swagger.
+
+Generating data types
 
 The general idea is that you should rarely see interface{} in the generated code.
 You get a complete representation of a swagger document in somewhat idiomatic go.
 
-To do so there is set of mapping patterns that are applied to a spec to go types:
+To do so, there is a set of mapping patterns that are applied,
+to map a Swagger specfication to go types:
 
-   defintion of primitive => type alias/name
-   defintion of array => type alias/name
-   definition of map => type alias/name
-   definition of object with properties => struct
-   definition of ref => type alias/name
-   object with only additional properties => map[string]T
-   object with additional properties and properties => custom serializer
-   schema with schema array in items => tuple (struct with properties, custom serializer)
-   schema with all of => struct
-     * all of schema with ref => embedded value
-     * all of schema with properties => properties are included in struct
-     * adding an all of schema with just "x-isnullable": true or "x-nullable": true turns
-     the schema into a pointer when there are only other extension properties provided
+   definition of primitive   => type alias/name
+   definition of array       => type alias/name
+   definition of map         => type alias/name
 
-A property on a definition is a pointer when:
+   definition of object
+   with properties           => struct
+   definition of $ref        => type alias/name
 
-    it is a object schema (struct)
+   object with only
+   additional properties     => map[string]T
+
+   object with additional
+   properties and properties => custom serializer
+
+   schema with schema array
+   in items                  => tuple (struct with properties, custom serializer)
+
+   schema with all of        => struct
+
+     * allOf schema with $ref        => embedded value
+     * allOf schema with properties  => properties are included in struct
+     * adding an allOf schema with just "x-isnullable": true or
+	   "x-nullable": true turns the schema into a pointer when
+	   there are only other extension properties provided
+
+NOTE: anyOf and oneOf JSON-schema constructs are not supported by Swagger 2.0
+
+A property on a definition is a pointer when any one of the following conditions is met:
+
+    it is an object schema (struct)
     it has x-nullable or x-isnullable as vendor extension
-    it is a primitive where the zero value is valid but would fail validation otherwise
-      strings minLength > 0 or required results in non-pointer
-      numbers min > 0, max < 0 and min < max
+    it is a primitive where the zero value is valid but would fail validation
+	otherwise strings minLength > 0 or required results in non-pointer
+    numbers min > 0, max < 0 and min < max
 
-JSONSchema and by extension swagger allow for items that have a fixed size array
-with schema's describing the items at each index. This can be combined with additional items
+JSONSchema and by extension Swagger allow for items that have a fixed size array,
+with the schema describing the items at each index. This can be combined with additional items
 to form some kind of tuple with varargs.
+
 To map this to go it creates a struct that has fixed names and a custom json serializer.
+
+NOTE: the additionalItems keyword is not supported by Swagger 2.0. However, the generator and validator parts
+in go-swagger do.
+
+
+Documenting the generated code
 
 The code that is generated also gets the doc comments that are used by the scanner
 to generate a spec from go code. So that after generation you should be able to reverse

--- a/generator/formats.go
+++ b/generator/formats.go
@@ -1,0 +1,204 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+// TODO: we may probably find a way to register most of this dynamically from strfmt
+
+// map of function calls to be generated to get the zero value of a given type
+var zeroes = map[string]string{
+	"bool":    "false",
+	"float32": "0",
+	"float64": "0",
+	"int":     "0",
+	"int8":    "0",
+	"int16":   "0",
+	"int32":   "0",
+	"int64":   "0",
+	"string":  "\"\"",
+	"uint":    "0",
+	"uint8":   "0",
+	"uint16":  "0",
+	"uint32":  "0",
+	"uint64":  "0",
+	// Extended formats (23 formats corresponding to the Default registry
+	// provided by go-openapi/strfmt)
+	"strfmt.Base64":     "nil",
+	"strfmt.CreditCard": "strfmt.CreditCard(\"\")",
+	"strfmt.Date":       "strfmt.Date{}",
+	"strfmt.DateTime":   "strfmt.DateTime{}",
+	"strfmt.Duration":   "0",
+	"strfmt.Email":      "strfmt.Email(\"\")",
+	"strfmt.HexColor":   "strfmt.HexColor(\"#000000\")",
+	"strfmt.Hostname":   "strfmt.Hostname(\"\")",
+	"strfmt.IPv4":       "strfmt.IPv4(\"\")",
+	"strfmt.IPv6":       "strfmt.IPv6(\"\")",
+	"strfmt.ISBN":       "strfmt.ISBN(\"\")",
+	"strfmt.ISBN10":     "strfmt.ISBN10(\"\")",
+	"strfmt.ISBN13":     "strfmt.ISBN13(\"\")",
+	"strfmt.MAC":        "strfmt.MAC(\"\")",
+	//"strfmt.ObjectId":	N/A  /* bson objectID has no zero initializer */,
+	"strfmt.Password": "strfmt.Password(\"\")",
+	"strfmt.RGBColor": "strfmt.RGBColor(\"rgb(0,0,0)\")",
+	"strfmt.SSN":      "strfmt.SSN(\"\")",
+	"strfmt.URI":      "strfmt.URI(\"\")",
+	"strfmt.UUID":     "strfmt.UUID(\"\")",
+	"strfmt.UUID3":    "strfmt.UUID3(\"\")",
+	"strfmt.UUID4":    "strfmt.UUID4(\"\")",
+	"strfmt.UUID5":    "strfmt.UUID5(\"\")",
+	//"file":       "runtime.File",
+}
+
+// conversion functions from string representation to a numerical or boolean
+// primitive type
+var stringConverters = map[string]string{
+	"bool":    "swag.ConvertBool",
+	"float32": "swag.ConvertFloat32",
+	"float64": "swag.ConvertFloat64",
+	"int8":    "swag.ConvertInt8",
+	"int16":   "swag.ConvertInt16",
+	"int32":   "swag.ConvertInt32",
+	"int64":   "swag.ConvertInt64",
+	"uint8":   "swag.ConvertUint8",
+	"uint16":  "swag.ConvertUint16",
+	"uint32":  "swag.ConvertUint32",
+	"uint64":  "swag.ConvertUint64",
+}
+
+// formatting (string representation) functions from a native representation
+// of a numerical or boolean primitive type
+var stringFormatters = map[string]string{
+	"bool":    "swag.FormatBool",
+	"float32": "swag.FormatFloat32",
+	"float64": "swag.FormatFloat64",
+	"int8":    "swag.FormatInt8",
+	"int16":   "swag.FormatInt16",
+	"int32":   "swag.FormatInt32",
+	"int64":   "swag.FormatInt64",
+	"uint8":   "swag.FormatUint8",
+	"uint16":  "swag.FormatUint16",
+	"uint32":  "swag.FormatUint32",
+	"uint64":  "swag.FormatUint64",
+}
+
+// typeMapping contains a mapping of format (or type name) to go type
+var typeMapping = map[string]string{
+	// Standard formats with native, straightforward, mapping
+	"binary":  "io.ReadCloser",
+	"boolean": "bool",
+	"char":    "rune",
+	"double":  "float64",
+	"float":   "float32",
+	"int":     "int64",
+	"int8":    "int8",
+	"int16":   "int16",
+	"int32":   "int32",
+	"int64":   "int64",
+	"integer": "int64",
+	"number":  "float64",
+	"uint":    "uint64",
+	"uint8":   "uint8",
+	"uint16":  "uint16",
+	"uint32":  "uint32",
+	"uint64":  "uint64",
+	// Extended format registry from go-openapi/strfmt.
+	// Currently, 23 such formats are supported (default strftm registry),
+	// plus the following aliases:
+	//  - "datetime" alias for the more official "date-time"
+	//  - "objectid" and "ObjectId" aliases for "bsonobjectid"
+	"byte":         "strfmt.Base64",
+	"creditcard":   "strfmt.CreditCard",
+	"date":         "strfmt.Date",
+	"date-time":    "strfmt.DateTime",
+	"datetime":     "strfmt.DateTime",
+	"duration":     "strfmt.Duration",
+	"email":        "strfmt.Email",
+	"hexcolor":     "strfmt.HexColor",
+	"hostname":     "strfmt.Hostname",
+	"ipv4":         "strfmt.IPv4",
+	"ipv6":         "strfmt.IPv6",
+	"isbn":         "strfmt.ISBN",
+	"isbn10":       "strfmt.ISBN10",
+	"isbn13":       "strfmt.ISBN13",
+	"mac":          "strfmt.MAC",
+	"bsonobjectid": "strfmt.ObjectId",
+	"objectid":     "strfmt.ObjectId",
+	"ObjectId":     "strfmt.ObjectId", // NOTE: does it work with uppercase?
+	"password":     "strfmt.Password",
+	"rgbcolor":     "strfmt.RGBColor",
+	"ssn":          "strfmt.SSN",
+	"uri":          "strfmt.URI",
+	"uuid":         "strfmt.UUID",
+	"uuid3":        "strfmt.UUID3",
+	"uuid4":        "strfmt.UUID4",
+	"uuid5":        "strfmt.UUID5",
+	// For file producers
+	"file": "runtime.File",
+}
+
+// go primitive types
+var primitives = map[string]struct{}{
+	"bool":       struct{}{},
+	"byte":       struct{}{},
+	"[]byte":     struct{}{},
+	"complex64":  struct{}{},
+	"complex128": struct{}{},
+	"float32":    struct{}{},
+	"float64":    struct{}{},
+	"int":        struct{}{},
+	"int8":       struct{}{},
+	"int16":      struct{}{},
+	"int32":      struct{}{},
+	"int64":      struct{}{},
+	"rune":       struct{}{},
+	"string":     struct{}{},
+	"uint":       struct{}{},
+	"uint8":      struct{}{},
+	"uint16":     struct{}{},
+	"uint32":     struct{}{},
+	"uint64":     struct{}{},
+}
+
+// Formats with a custom formatter.
+// Currently, 23 such formats are supported
+// + 2 interfaces for io.Writers and Closers
+var customFormatters = map[string]struct{}{
+	"strfmt.Base64":     struct{}{},
+	"strfmt.CreditCard": struct{}{},
+	"strfmt.Date":       struct{}{},
+	"strfmt.DateTime":   struct{}{},
+	"strfmt.Duration":   struct{}{},
+	"strfmt.Email":      struct{}{},
+	"strfmt.HexColor":   struct{}{},
+	"strfmt.Hostname":   struct{}{},
+	"strfmt.IPv4":       struct{}{},
+	"strfmt.IPv6":       struct{}{},
+	"strfmt.ISBN":       struct{}{},
+	"strfmt.ISBN10":     struct{}{},
+	"strfmt.ISBN13":     struct{}{},
+	"strfmt.MAC":        struct{}{},
+	"strfmt.ObjectID":   struct{}{},
+	"strfmt.Password":   struct{}{},
+	"strfmt.RGBColor":   struct{}{},
+	"strfmt.SSN":        struct{}{},
+	"strfmt.URI":        struct{}{},
+	"strfmt.UUID":       struct{}{},
+	"strfmt.UUID3":      struct{}{},
+	"strfmt.UUID4":      struct{}{},
+	"strfmt.UUID5":      struct{}{},
+	// Special
+	"io.ReadCloser": struct{}{}, // for "format": "binary"
+	"io.Writer":     struct{}{},
+	// NOTE: runtime.File is not a customFormatters
+}

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -2170,10 +2170,43 @@ func TestGenModel_Issue1347(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
 			err := templates.MustGet("model").Execute(buf, genModel)
 			if assert.NoError(t, err) {
+				ff, err := opts.LanguageOpts.FormatContent("Foo.go", buf.Bytes())
+				if assert.NoError(t, err) {
+					res := string(ff)
+					//log.Println("1347")
+					//log.Println(res)
+					// Just verify that the validation call is generated even though we add a non-required property
+					assertInCode(t, `validate.FormatOf("config1", "body", "hostname", m.Config1.String(), formats)`, res)
+				} else {
+					fmt.Println(buf.String())
+				}
+			}
+		}
+	}
+}
+
+// This tests to check that format validation is performed on MAC format
+func TestGenModel_Issue1348(t *testing.T) {
+	specDoc, err := loads.Spec("../fixtures/bugs/1348/fixture-1348.yaml")
+	if assert.NoError(t, err) {
+		definitions := specDoc.Spec().Definitions
+		k := "ContainerConfig"
+		schema := definitions[k]
+		opts := opts()
+		genModel, err := makeGenDefinition(k, "models", schema, specDoc, opts)
+		if assert.NoError(t, err) {
+			buf := bytes.NewBuffer(nil)
+			err := templates.MustGet("model").Execute(buf, genModel)
+			if assert.NoError(t, err) {
 				ct, err := opts.LanguageOpts.FormatContent("foo.go", buf.Bytes())
 				if assert.NoError(t, err) {
 					res := string(ct)
-					assertInCode(t, `validate.FormatOf("config1", "body", "hostname", m.Config1.String(), formats)`, res)
+					//log.Println("1348")
+					//log.Println(res)
+					// Just verify that the validation call is generated with proper format
+					assertInCode(t, `if err := validate.FormatOf("config1", "body", "mac", m.Config1.String(), formats)`, res)
+				} else {
+					fmt.Println(buf.String())
 				}
 			}
 		}

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -552,6 +552,7 @@ func (g *GenOpts) location(t *TemplateOpts, data interface{}) (string, string, e
 
 func (g *GenOpts) render(t *TemplateOpts, data interface{}) ([]byte, error) {
 	var templ *template.Template
+
 	if strings.HasPrefix(strings.ToLower(t.Source), "asset:") {
 		tt, err := templates.Get(strings.TrimPrefix(t.Source, "asset:"))
 		if err != nil {
@@ -561,7 +562,17 @@ func (g *GenOpts) render(t *TemplateOpts, data interface{}) ([]byte, error) {
 	}
 
 	if templ == nil {
+		// try to load from repository (and enable dependencies)
+		name := swag.ToJSONName(strings.TrimSuffix(t.Source, ".gotmpl"))
+		tt, err := templates.Get(name)
+		if err == nil {
+			templ = tt
+		}
+	}
+
+	if templ == nil {
 		// try to load template from disk, in TemplateDir if specified
+		// (dependencies resolution is limited to preloaded assets)
 		var templateFile string
 		if g.TemplateDir != "" {
 			templateFile = filepath.Join(g.TemplateDir, t.Source)
@@ -575,10 +586,10 @@ func (g *GenOpts) render(t *TemplateOpts, data interface{}) ([]byte, error) {
 		tt, err := template.New(t.Source).Funcs(FuncMap).Parse(string(content))
 		if err != nil {
 			return nil, fmt.Errorf("template parsing failed on template %s: %v", t.Name, err)
-			//return nil, err
 		}
 		templ = tt
 	}
+
 	if templ == nil {
 		return nil, fmt.Errorf("template %q not found", t.Source)
 	}

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -191,10 +191,6 @@ func GoLangOpts() *LanguageOpts {
 	return opts
 }
 
-// Debug when the env var DEBUG or SWAGGER_DEBUG is not empty
-// the generators will be very noisy about what they are doing
-var Debug = os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != ""
-
 func findSwaggerSpec(nm string) (string, error) {
 	specs := []string{"swagger.json", "swagger.yml", "swagger.yaml"}
 	if nm != "" {

--- a/generator/types.go
+++ b/generator/types.go
@@ -44,118 +44,6 @@ const (
 	body        = "body"
 )
 
-var zeroes = map[string]string{
-	"string":            "\"\"",
-	"int8":              "0",
-	"int":               "0",
-	"int16":             "0",
-	"int32":             "0",
-	"int64":             "0",
-	"uint":              "0",
-	"uint8":             "0",
-	"uint16":            "0",
-	"uint32":            "0",
-	"uint64":            "0",
-	"bool":              "false",
-	"float32":           "0",
-	"float64":           "0",
-	"strfmt.DateTime":   "strfmt.DateTime{}",
-	"strfmt.Date":       "strfmt.Date{}",
-	"strfmt.URI":        "strfmt.URI(\"\")",
-	"strfmt.Email":      "strfmt.Email(\"\")",
-	"strfmt.Hostname":   "strfmt.Hostname(\"\")",
-	"strfmt.IPv4":       "strfmt.IPv4(\"\")",
-	"strfmt.IPv6":       "strfmt.IPv6(\"\")",
-	"strfmt.UUID":       "strfmt.UUID(\"\")",
-	"strfmt.UUID3":      "strfmt.UUID3(\"\")",
-	"strfmt.UUID4":      "strfmt.UUID4(\"\")",
-	"strfmt.UUID5":      "strfmt.UUID5(\"\")",
-	"strfmt.ISBN":       "strfmt.ISBN(\"\")",
-	"strfmt.ISBN10":     "strfmt.ISBN10(\"\")",
-	"strfmt.ISBN13":     "strfmt.ISBN13(\"\")",
-	"strfmt.CreditCard": "strfmt.CreditCard(\"\")",
-	"strfmt.SSN":        "strfmt.SSN(\"\")",
-	"strfmt.Password":   "strfmt.Password(\"\")",
-	"strfmt.HexColor":   "strfmt.HexColor(\"#000000\")",
-	"strfmt.RGBColor":   "strfmt.RGBColor(\"rgb(0,0,0)\")",
-	"strfmt.Base64":     "nil",
-	"strfmt.Duration":   "0",
-}
-
-var stringConverters = map[string]string{
-	"int8":    "swag.ConvertInt8",
-	"int16":   "swag.ConvertInt16",
-	"int32":   "swag.ConvertInt32",
-	"int64":   "swag.ConvertInt64",
-	"uint8":   "swag.ConvertUint8",
-	"uint16":  "swag.ConvertUint16",
-	"uint32":  "swag.ConvertUint32",
-	"uint64":  "swag.ConvertUint64",
-	"bool":    "swag.ConvertBool",
-	"float32": "swag.ConvertFloat32",
-	"float64": "swag.ConvertFloat64",
-}
-
-var stringFormatters = map[string]string{
-	"int8":    "swag.FormatInt8",
-	"int16":   "swag.FormatInt16",
-	"int32":   "swag.FormatInt32",
-	"int64":   "swag.FormatInt64",
-	"uint8":   "swag.FormatUint8",
-	"uint16":  "swag.FormatUint16",
-	"uint32":  "swag.FormatUint32",
-	"uint64":  "swag.FormatUint64",
-	"bool":    "swag.FormatBool",
-	"float32": "swag.FormatFloat32",
-	"float64": "swag.FormatFloat64",
-}
-
-// typeMapping contains a mapping of format or type name to go type
-var typeMapping = map[string]string{
-	"byte":       "strfmt.Base64",
-	"date":       "strfmt.Date",
-	"datetime":   "strfmt.DateTime",
-	"date-time":  "strfmt.DateTime",
-	"uri":        "strfmt.URI",
-	"email":      "strfmt.Email",
-	"hostname":   "strfmt.Hostname",
-	"ipv4":       "strfmt.IPv4",
-	"ipv6":       "strfmt.IPv6",
-	"mac":        "strfmt.MAC",
-	"uuid":       "strfmt.UUID",
-	"uuid3":      "strfmt.UUID3",
-	"uuid4":      "strfmt.UUID4",
-	"uuid5":      "strfmt.UUID5",
-	"isbn":       "strfmt.ISBN",
-	"isbn10":     "strfmt.ISBN10",
-	"isbn13":     "strfmt.ISBN13",
-	"creditcard": "strfmt.CreditCard",
-	"ssn":        "strfmt.SSN",
-	"hexcolor":   "strfmt.HexColor",
-	"rgbcolor":   "strfmt.RGBColor",
-	"duration":   "strfmt.Duration",
-	"password":   "strfmt.Password",
-	"ObjectId":   "strfmt.ObjectId",
-	"binary":     "io.ReadCloser",
-	"char":       "rune",
-	"int":        "int64",
-	"int8":       "int8",
-	"int16":      "int16",
-	"int32":      "int32",
-	"int64":      "int64",
-	"uint":       "uint64",
-	"uint8":      "uint8",
-	"uint16":     "uint16",
-	"uint32":     "uint32",
-	"uint64":     "uint64",
-	"float":      "float32",
-	"double":     "float64",
-	"number":     "float64",
-	"integer":    "int64",
-	"boolean":    "bool",
-	"file":       "runtime.File",
-}
-
 // swaggerTypeMapping contains a mapping from go type to swagger type or format
 var swaggerTypeName map[string]string
 
@@ -615,14 +503,6 @@ func boolExtension(ext spec.Extensions, key string) *bool {
 	return nil
 }
 
-func logDebug(frmt string, args ...interface{}) {
-	if Debug {
-		_, file, pos, _ := runtime.Caller(2)
-		log.Printf("%s:%d: %s", filepath.Base(file), pos, fmt.Sprintf(frmt, args...))
-	}
-
-}
-
 func (t *typeResolver) ResolveSchema(schema *spec.Schema, isAnonymous, isRequired bool) (result resolvedType, err error) {
 	logDebug("resolving schema (anon: %t, req: %t) %s\n", isAnonymous, isRequired, t.ModelName /*bbb*/)
 	if schema == nil {
@@ -747,70 +627,25 @@ type resolvedType struct {
 }
 
 func (rt *resolvedType) Zero() string {
+	// zero function provided as native or by strfmt function
 	if zr, ok := zeroes[rt.GoType]; ok {
 		return zr
 	}
+	// map and slice initializer
 	if rt.IsMap || rt.IsArray {
 		return "make(" + rt.GoType + ", 0, 50)"
 	}
+	// object initializer
 	if rt.IsTuple || rt.IsComplexObject {
 		if rt.IsNullable {
 			return "new(" + rt.GoType + ")"
 		}
 		return rt.GoType + "{}"
 	}
+	// interface initializer
 	if rt.IsInterface {
 		return "nil"
 	}
 
 	return ""
-}
-
-var primitives = map[string]struct{}{
-	"bool":       struct{}{},
-	"uint":       struct{}{},
-	"uint8":      struct{}{},
-	"uint16":     struct{}{},
-	"uint32":     struct{}{},
-	"uint64":     struct{}{},
-	"int":        struct{}{},
-	"int8":       struct{}{},
-	"int16":      struct{}{},
-	"int32":      struct{}{},
-	"int64":      struct{}{},
-	"float32":    struct{}{},
-	"float64":    struct{}{},
-	"string":     struct{}{},
-	"complex64":  struct{}{},
-	"complex128": struct{}{},
-	"byte":       struct{}{},
-	"[]byte":     struct{}{},
-	"rune":       struct{}{},
-}
-
-var customFormatters = map[string]struct{}{
-	"strfmt.DateTime":   struct{}{},
-	"strfmt.Date":       struct{}{},
-	"strfmt.URI":        struct{}{},
-	"strfmt.Email":      struct{}{},
-	"strfmt.Hostname":   struct{}{},
-	"strfmt.IPv4":       struct{}{},
-	"strfmt.IPv6":       struct{}{},
-	"strfmt.UUID":       struct{}{},
-	"strfmt.UUID3":      struct{}{},
-	"strfmt.UUID4":      struct{}{},
-	"strfmt.UUID5":      struct{}{},
-	"strfmt.ISBN":       struct{}{},
-	"strfmt.ISBN10":     struct{}{},
-	"strfmt.ISBN13":     struct{}{},
-	"strfmt.CreditCard": struct{}{},
-	"strfmt.SSN":        struct{}{},
-	"strfmt.Password":   struct{}{},
-	"strfmt.HexColor":   struct{}{},
-	"strfmt.RGBColor":   struct{}{},
-	"strfmt.Base64":     struct{}{},
-	"strfmt.Duration":   struct{}{},
-	"strfmt.ObjectID":   struct{}{},
-	"io.ReadCloser":     struct{}{},
-	"io.Writer":         struct{}{},
 }


### PR DESCRIPTION
This PR provides the generation part for #1348
The fix will be effective with the validation part, starting with go-openapi/validate#50

Plus:
Minor refactoring:

    split format definitions, reorder them and check they match definitions strfmt default registry (e.g. for bsonobjectid)
    split debug related definitions
    some layout, structuring in doc.go
