### PR TITLE
Make generate server sort the models #1349

### DIFF
--- a/generator/structs.go
+++ b/generator/structs.go
@@ -34,6 +34,14 @@ type GenDefinition struct {
 	DependsOn      []string
 }
 
+// GenDefinitions represents a list of operations to generate
+// this implements a sort by operation id
+type GenDefinitions []GenDefinition
+
+func (g GenDefinitions) Len() int           { return len(g) }
+func (g GenDefinitions) Less(i, j int) bool { return g[i].Name < g[j].Name }
+func (g GenDefinitions) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
+
 // GenSchemaList is a list of schemas for generation.
 //
 // It can be sorted by name to get a stable struct layout for

--- a/generator/support.go
+++ b/generator/support.go
@@ -525,7 +525,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 	baseImport := a.GenOpts.LanguageOpts.baseImport(a.Target)
 	var imports map[string]string
 
-	var genMods []GenDefinition
+	var genMods GenDefinitions
 	importPath := a.GenOpts.ExistingModels
 	if a.GenOpts.ExistingModels == "" {
 		if imports == nil {
@@ -555,6 +555,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 			genMods = append(genMods, *mod)
 		}
 	}
+	sort.Sort(genMods)
 
 	log.Println("planning operations")
 	tns := make(map[string]struct{})


### PR DESCRIPTION
The array used to generate the models is not currently sorted, so
the models are generated in whatever order comes out of the map.
When there are multiple models that fail to generate properly, this lack
of sorting results in changes in the reported failures from run to run.
Sorting results in deterministic behavior in the case of errors, making
it easier to fix the errors.

The generated operations are being sorted, this just applies the same
pattern to the models as well.

Signed-off-by: Greg Marr <greg.marr@autodesk.com>