### PR TITLE
Document how to avoid "target must reside inside a location in the $GOPATH/src" using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ rpm, deb and docker image.
 ```
 docker pull quay.io/goswagger/swagger
 
-alias swagger="docker run --rm -it -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger"
+alias swagger="docker run --rm -it -e GOPATH=$HOME/go:/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger"
 swagger version
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,7 @@ rpm, deb and docker image.
 ```
 docker pull quay.io/goswagger/swagger
 
-alias swagger="docker run --rm -it -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger"
+alias swagger="docker run --rm -it -e GOPATH=$HOME/go:/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger"
 swagger version
 ```
 


### PR DESCRIPTION
This adds @casualjim's suggestion from https://github.com/go-swagger/go-swagger/issues/754#issuecomment-262822894 to the docs.