### PR TITLE
Small refactoring on custom extensions usage

### DIFF
--- a/generator/discriminators.go
+++ b/generator/discriminators.go
@@ -31,7 +31,7 @@ func discriminatorInfo(doc *analysis.Spec) *discInfo {
 	baseTypes := make(map[string]discor)
 	for _, sch := range doc.AllDefinitions() {
 		if sch.Schema.Discriminator != "" {
-			tpe, _ := sch.Schema.Extensions.GetString("x-go-name")
+			tpe, _ := sch.Schema.Extensions.GetString(xGoName)
 			if tpe == "" {
 				tpe = swag.ToGoName(sch.Name)
 			}
@@ -48,11 +48,11 @@ func discriminatorInfo(doc *analysis.Spec) *discInfo {
 		for _, ao := range sch.Schema.AllOf {
 			if ao.Ref.String() != "" {
 				if bt, ok := baseTypes[ao.Ref.String()]; ok {
-					name, _ := sch.Schema.Extensions.GetString("x-class")
+					name, _ := sch.Schema.Extensions.GetString(xClass)
 					if name == "" {
 						name = sch.Name
 					}
-					tpe, _ := sch.Schema.Extensions.GetString("x-go-name")
+					tpe, _ := sch.Schema.Extensions.GetString(xGoName)
 					if tpe == "" {
 						tpe = swag.ToGoName(sch.Name)
 					}

--- a/generator/model.go
+++ b/generator/model.go
@@ -139,7 +139,7 @@ func makeGenDefinition(name, pkg string, schema spec.Schema, specDoc *loads.Docu
 
 func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema, specDoc *loads.Document, opts *GenOpts) (*GenDefinition, error) {
 
-	_, ok := schema.Extensions["x-go-type"]
+	_, ok := schema.Extensions[xGoType]
 	if ok {
 		return nil, nil
 	}
@@ -717,7 +717,7 @@ func (sg *schemaGenContext) buildProperties() error {
 			}
 			var nm = filepath.Base(emprop.Schema.Ref.GetURL().Fragment)
 			var tn string
-			if gn, ok := emprop.Schema.Extensions["x-go-name"]; ok {
+			if gn, ok := emprop.Schema.Extensions[xGoName]; ok {
 				tn = gn.(string)
 			} else {
 				tn = swag.ToGoName(nm)
@@ -748,7 +748,7 @@ func (sg *schemaGenContext) buildProperties() error {
 		}
 		sg.MergeResult(emprop, false)
 
-		if customTag, found := emprop.Schema.Extensions["x-go-custom-tag"]; found {
+		if customTag, found := emprop.Schema.Extensions[xGoCustomTag]; found {
 			emprop.GenSchema.CustomTag = customTag.(string)
 		}
 		if emprop.GenSchema.HasDiscriminator {
@@ -1319,7 +1319,7 @@ func (sg *schemaGenContext) GoName() string {
 }
 
 func goName(sch *spec.Schema, orig string) string {
-	name, _ := sch.Extensions.GetString("x-go-name")
+	name, _ := sch.Extensions.GetString(xGoName)
 	if name != "" {
 		return name
 	}

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -383,7 +383,7 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	var successResponses []GenResponse
 	if operation.Responses != nil {
 		for _, v := range srs {
-			name, ok := v.Response.Extensions.GetString("x-go-name")
+			name, ok := v.Response.Extensions.GetString(xGoName)
 			if !ok {
 				name = runtime.Statuses[v.Code]
 			}
@@ -431,11 +431,11 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 
 	swsp := resolver.Doc.Spec()
 	var extraSchemes []string
-	if ess, ok := operation.Extensions.GetStringSlice("x-schemes"); ok {
+	if ess, ok := operation.Extensions.GetStringSlice(xSchemes); ok {
 		extraSchemes = append(extraSchemes, ess...)
 	}
 
-	if ess1, ok := swsp.Extensions.GetStringSlice("x-schemes"); ok {
+	if ess1, ok := swsp.Extensions.GetStringSlice(xSchemes); ok {
 		extraSchemes = concatUnique(ess1, extraSchemes)
 	}
 	sort.Strings(extraSchemes)

--- a/generator/typeresolver_test.go
+++ b/generator/typeresolver_test.go
@@ -417,7 +417,7 @@ func basicTaskListResolver(t testing.TB) (*loads.Document, *typeResolver, error)
 	}
 	swsp := tlb.Spec()
 	uc := swsp.Definitions["UserCard"]
-	uc.AddExtension("x-go-name", "UserItem")
+	uc.AddExtension(xGoName, "UserItem")
 	swsp.Definitions["UserCard"] = uc
 	resolver := &typeResolver{
 		Doc:           tlb,
@@ -427,7 +427,7 @@ func basicTaskListResolver(t testing.TB) (*loads.Document, *typeResolver, error)
 	resolver.KnownDefs = make(map[string]struct{})
 	for k, sch := range swsp.Definitions {
 		resolver.KnownDefs[k] = struct{}{}
-		if nm, ok := sch.Extensions["x-go-name"]; ok {
+		if nm, ok := sch.Extensions[xGoName]; ok {
 			resolver.KnownDefs[nm.(string)] = struct{}{}
 		}
 	}


### PR DESCRIPTION
Small refactoring on custom extensions usage:
- declare supported extensions as constants in types.go
- propagate extensions in resolverType