### PR TITLE
pin go-openapi/{analysis,spec,validate} versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,7 +44,6 @@
   version = "v1.4.2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/analysis"
   packages = ["."]
   revision = "8ed83f2ea9f00f945516462951a288eaa68bf0d6"
@@ -115,10 +114,9 @@
   revision = "cf0bdb963811675a4d7e74901cefc7411a1df939"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  revision = "a52193aca9d575f354d8be388254c134765ea793"
+  revision = "a762d5dd38f7c7e9e1a13c3e98344cfbe4aa15d9"
 
 [[projects]]
   branch = "master"
@@ -375,6 +373,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "099583f45b31cedee91e8f63ee15cef606d882bd2da0ca686b06b0b732e28915"
+  inputs-digest = "1696214cf5094075b8f8feb88fc4467818f2f1ca11e65bae6681c0e849290af5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -76,17 +76,28 @@
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/loads"
-  packages = [".","fmts"]
+  packages = [
+    ".",
+    "fmts"
+  ]
   revision = "c3e1ca4c0b6160cac10aeef7e8b425cc95b9c820"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/runtime"
-  packages = [".","client","flagext","middleware","middleware/denco","middleware/header","middleware/untyped","security"]
+  packages = [
+    ".",
+    "client",
+    "flagext",
+    "middleware",
+    "middleware/denco",
+    "middleware/header",
+    "middleware/untyped",
+    "security"
+  ]
   revision = "2da70401d8fa078b6fecdd7afdf3b589ae9669e4"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   revision = "a4fa9574c7aa73b2fc54e251eb9524d0482bb592"
@@ -130,7 +141,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
@@ -160,7 +181,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "5f62e4f3afa2f576dc86531b7df4d966b19ef8f8"
 
 [[projects]]
@@ -184,13 +209,19 @@
 [[projects]]
   branch = "master"
   name = "github.com/pquerna/cachecontrol"
-  packages = [".","cacheobject"]
+  packages = [
+    ".",
+    "cacheobject"
+  ]
   revision = "0dec1b30a0215bb68605dfc568e8855066c9202d"
 
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "5660eeed305fe5f69c8fc6cf899132a459a97064"
 
 [[projects]]
@@ -238,19 +269,29 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["ed25519","ed25519/internal/edwards25519"]
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519"
+  ]
   revision = "6a293f2d4b14b8e6d3f0539e383f6d0d30fce3fd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","idna"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "idna"
+  ]
   revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
+  packages = [
+    ".",
+    "internal"
+  ]
   revision = "9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402"
 
 [[projects]]
@@ -262,30 +303,66 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
   revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
-  packages = ["go/ast/astutil","go/buildutil","go/loader","imports"]
+  packages = [
+    "go/ast/astutil",
+    "go/buildutil",
+    "go/loader",
+    "imports"
+  ]
   revision = "9c477bae194915bfd4bc8c314e90e28b9ec1c831"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
-  packages = ["bson","internal/json"]
+  packages = [
+    "bson",
+    "internal/json"
+  ]
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [[projects]]
   name = "gopkg.in/square/go-jose.v2"
-  packages = [".","cipher","json"]
+  packages = [
+    ".",
+    "cipher",
+    "json"
+  ]
   revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
   version = "v2.1.3"
 
@@ -298,6 +375,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "843d507471a279f79b325cbdbbf77f88e322560dea323059d2f4a141ab6b24a3"
+  inputs-digest = "099583f45b31cedee91e8f63ee15cef606d882bd2da0ca686b06b0b732e28915"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,8 +22,8 @@
 
 
 [[constraint]]
-  branch = "master"
   name = "github.com/go-openapi/analysis"
+  revision = "8ed83f2ea9f00f945516462951a288eaa68bf0d6"
 
 [[constraint]]
   branch = "master"
@@ -54,8 +54,8 @@
   name = "github.com/go-openapi/swag"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/go-openapi/validate"
+  revision = "a762d5dd38f7c7e9e1a13c3e98344cfbe4aa15d9"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,8 +42,8 @@
   name = "github.com/go-openapi/runtime"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/go-openapi/spec"
+  revision = "a4fa9574c7aa73b2fc54e251eb9524d0482bb592"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
Was using go-swagger 0.13.0 as a library until I noticed a compilation error between go-swagger and go-openapi/spec. I fixed it by specifying a commit for the go-openapi/spec dependency.

This commit is supposed to be for the 0.13.0 tag (commit b015bd). I couldn't open a PR unless I made the commit against master (I'm not that experienced with GitHub).

If this isn't merged, the workaround is for my client project to have
```toml
[[override]]
  name = "github.com/go-openapi/spec"
  revision = "a4fa9574c7aa73b2fc54e251eb9524d0482bb592"
```
in addition to its
```toml
[[constraint]]
  name = "github.com/go-swagger/go-swagger"
  version = "0.13.0"
```
in its `Gopkg.toml`. I'd much rather not need that `[[override]]` block (I'd much rather merge this PR).