### PR TITLE
Replace tylerb/graceful with inbuilt methods Go 1.8 onwards

### DIFF
--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -107,7 +107,6 @@ func (s *Server) log(rp string) {
 For this generation to compile you need to have some packages in your GOPATH:
 
 	* github.com/go-openapi/runtime
-	* github.com/tylerb/graceful
 	* `+flagsPackage+`
 
 You can get these now with: go get -u -f %s/...

--- a/cmd/swagger/commands/generate/support.go
+++ b/cmd/swagger/commands/generate/support.go
@@ -58,7 +58,6 @@ For this generation to compile you need to have some packages in your vendor or 
 
   * github.com/go-openapi/runtime
   * github.com/asaskevich/govalidator		
-  * github.com/tylerb/graceful		
   * github.com/jessevdk/go-flags		
   * golang.org/x/net/context/ctxhttp
 

--- a/cmd/swagger/commands/serve.go
+++ b/cmd/swagger/commands/serve.go
@@ -10,14 +10,13 @@ import (
 	"net/url"
 	"path"
 	"strconv"
-	"time"
+	//"time"
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 	"github.com/gorilla/handlers"
 	"github.com/toqueteos/webbrowser"
-	"github.com/tylerb/graceful"
 )
 
 // ServeCmd to serve a swagger spec with docs ui
@@ -91,9 +90,8 @@ func (s *ServeCmd) Execute(args []string) error {
 	handler = handlers.CORS()(middleware.Spec(basePath, b, handler))
 	errFuture := make(chan error)
 	go func() {
-		docServer := &graceful.Server{Server: new(http.Server)}
+		docServer := new(http.Server)
 		docServer.SetKeepAlivesEnabled(true)
-		docServer.TCPKeepAlive = 3 * time.Minute
 		docServer.Handler = handler
 
 		errFuture <- docServer.Serve(listener)

--- a/generator/templates/server/configureapi.gotmpl
+++ b/generator/templates/server/configureapi.gotmpl
@@ -15,8 +15,8 @@ import (
   runtime "github.com/go-openapi/runtime"
   middleware "github.com/go-openapi/runtime/middleware"
   security "github.com/go-openapi/runtime/security"
-  graceful "github.com/tylerb/graceful"
   "golang.org/x/net/context"
+
 
   {{range .DefaultImports}}{{printf "%q" .}}
   {{end}}
@@ -112,7 +112,7 @@ func configureTLS(tlsConfig *tls.Config) {
 // If you need to modify a config, store server instance to stop it individually later, this is the place.
 // This function can be called multiple times, depending on the number of serving schemes.
 // scheme value will be set accordingly: "http", "https" or "unix"
-func configureServer(s *graceful.Server, scheme, addr string) {
+func configureServer(s *http.Server, scheme, addr string) {
 }
 
 // The middleware configuration is for the handler executors. These do not apply to the swagger.json document.

--- a/generator/templates/server/main.gotmpl
+++ b/generator/templates/server/main.gotmpl
@@ -16,7 +16,7 @@ import (
   {{ end -}}
   {{ if .UsePFlags }}flag "github.com/spf13/pflag"
   {{ end -}}
-	graceful "github.com/tylerb/graceful"
+
 
   {{range .DefaultImports}}{{printf "%q" .}}
   {{end}}

--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -165,6 +165,7 @@ func NewServer(api *{{ .Package }}.{{ pascalize .Name }}API) *Server {
   {{ end }}{{ end }}
 	s.shutdown = make(chan struct{})
 	s.api = api
+    s.interrupt = make(chan os.Signal, 1)
 	return s
 }
 
@@ -340,10 +341,10 @@ func (s *Server) Serve() (err error) {
 			s.Logf("Stopped serving {{ humanize .Name }} at http://%s", l.Addr())
 		}(s.httpServerL)
 
-        interrupt := s.interruptChan()
-        signalNotify(interrupt)
+        signalNotify(s.interrupt)
         quitting := make(chan struct{})
-        go s.handleInterrupt(interrupt, quitting, s.httpServerL)
+        once := new(sync.Once)
+		go handleInterrupt(once, s, quitting)
 		
         go s.handleShutdown(&wg, httpServer)
 	}
@@ -597,34 +598,24 @@ func (s *Server) TLSListener() (net.Listener, error) {
 	return s.httpsServerL, nil
 }
 
-func (s *Server) interruptChan() chan os.Signal {
-    s.chanLock.Lock()
-    defer s.chanLock.Unlock()
+func handleInterrupt(once *sync.Once, s *Server, quitting chan struct{}) {
+    once.Do(func(){
+	for _ = range s.interrupt {
+		if s.interrupted {
+			s.Logf("Server already shutting down")
+			continue
+		}
+		s.interrupted = true
+		s.Logf("Shutting down... ")
+		close(quitting)
 
-    if s.interrupt == nil {
-        s.interrupt = make(chan os.Signal, 1)
-    }
-    
-    return s.interrupt
-
-}
-
-func (s *Server) handleInterrupt(interrupt chan os.Signal, quitting chan struct{}, l net.Listener) {
-    for _ = range interrupt {
-        if s.interrupted {
-            s.Logf("Server already shutting down")
-            continue
-        }
-        s.interrupted = true
-        s.Logf("Shutting down... ")
-        close(quitting)
-        
-        //s.SetKeepAlivesEnabled(false)
-        if err := l.Close(); err != nil {
-            s.Logf("Error: %s", err)
-        }
-        //s.shutdown <- struct{}{}
-    }
+		//s.SetKeepAlivesEnabled(false)
+		if err := s.httpServerL.Close(); err != nil {
+			s.Logf("Error: %s", err)
+		}
+		//s.shutdown <- struct{}{}
+	}
+    })
 }
 
 func signalNotify(interrupt chan<- os.Signal) {

--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -288,6 +288,10 @@ func (s *Server) Serve() (err error) {
 	}
 
 	var wg sync.WaitGroup
+    quitting := make(chan struct{})
+    once := new(sync.Once)
+    signalNotify(s.interrupt)
+    go handleInterrupt(once, s, quitting)
 
 	if s.hasScheme(schemeUnix) {
 		domainSocket := new(http.Server)
@@ -341,10 +345,6 @@ func (s *Server) Serve() (err error) {
 			s.Logf("Stopped serving {{ humanize .Name }} at http://%s", l.Addr())
 		}(s.httpServerL)
 
-        signalNotify(s.interrupt)
-        quitting := make(chan struct{})
-        once := new(sync.Once)
-		go handleInterrupt(once, s, quitting)
 		
         go s.handleShutdown(&wg, httpServer)
 	}
@@ -611,6 +611,12 @@ func handleInterrupt(once *sync.Once, s *Server, quitting chan struct{}) {
 
 		//s.SetKeepAlivesEnabled(false)
 		if err := s.httpServerL.Close(); err != nil {
+			s.Logf("Error: %s", err)
+		}
+		if err := s.httpsServerL.Close(); err != nil {
+			s.Logf("Error: %s", err)
+		}
+		if err := s.domainSocketL.Close(); err != nil {
 			s.Logf("Error: %s", err)
 		}
 		//s.shutdown <- struct{}{}

--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -7,13 +7,18 @@
 package {{ .APIPackage }}
 
 import (
+    "context"
 	"crypto/tls"
+	"errors"
 	"log"
 	"net"
 	"net/http"
+    "os"
+    "os/signal"
 	"strconv"
+	"sync"
 	"sync/atomic"
-	"errors"
+    "syscall"
 	"time"
 
 
@@ -23,7 +28,7 @@ import (
   "github.com/go-openapi/runtime/flagext"
   {{ if .UsePFlags }}flag "github.com/spf13/pflag"
   {{ end -}}
-  graceful "github.com/tylerb/graceful"
+  "golang.org/x/net/netutil"
 
   {{ range .DefaultImports }}{{ printf "%q" . }}
   {{ end }}
@@ -183,7 +188,7 @@ type Server struct {
 	CleanupTimeout   time.Duration{{ if .UseGoStructFlags }}    `long:"cleanup-timeout" description:"grace period for which to wait before shutting down the server" default:"10s"`{{ end }}
 	MaxHeaderSize    flagext.ByteSize{{ if .UseGoStructFlags }} `long:"max-header-size" description:"controls the maximum number of bytes the server will read parsing the request header's keys and values, including the request line. It does not limit the size of the request body." default:"1MiB"`{{ end }}
 
-  SocketPath {{ if .UsePFlags }}string{{ else }}flags.Filename `long:"socket-path" description:"the unix socket to listen on" default:"/var/run/{{ dasherize .Name }}.sock"`{{ end }}
+    SocketPath {{ if .UsePFlags }}string{{ else }}flags.Filename `long:"socket-path" description:"the unix socket to listen on" default:"/var/run/{{ dasherize .Name }}.sock"`{{ end }}
 	domainSocketL net.Listener
 
 	Host string{{ if .UseGoStructFlags }} `long:"host" description:"the IP to listen on" default:"localhost" env:"HOST"`{{ end }}
@@ -199,7 +204,7 @@ type Server struct {
 	TLSCertificate    {{ if .UsePFlags }}string{{ else }}flags.Filename `long:"tls-certificate" description:"the certificate to use for secure connections" env:"TLS_CERTIFICATE"`{{ end }}
 	TLSCertificateKey {{ if .UsePFlags }}string{{ else }}flags.Filename `long:"tls-key" description:"the private key to use for secure conections" env:"TLS_PRIVATE_KEY"`{{ end }}
 	TLSCACertificate  {{ if .UsePFlags }}string{{ else }}flags.Filename `long:"tls-ca" description:"the certificate authority file to be used with mutual tls auth" env:"TLS_CA_CERTIFICATE"`{{ end }}
-  TLSListenLimit    int{{ if .UseGoStructFlags }}            `long:"tls-listen-limit" description:"limit the number of outstanding requests"`{{ end }}
+    TLSListenLimit    int{{ if .UseGoStructFlags }}            `long:"tls-listen-limit" description:"limit the number of outstanding requests"`{{ end }}
 	TLSKeepAlive      time.Duration{{ if .UseGoStructFlags }}  `long:"tls-keep-alive" description:"sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)"`{{ end }}
 	TLSReadTimeout    time.Duration{{ if .UseGoStructFlags }}  `long:"tls-read-timeout" description:"maximum duration before timing out read of the request"`{{ end }}
 	TLSWriteTimeout   time.Duration{{ if .UseGoStructFlags }}  `long:"tls-write-timeout" description:"maximum duration before timing out write of the response"`{{ end }}
@@ -211,6 +216,10 @@ type Server struct {
 	hasListeners      bool
 	shutdown          chan struct{}
 	shuttingDown      int32
+
+    interrupted       bool
+    interrupt         chan os.Signal
+    chanLock          sync.RWMutex
 }
 
 // Logf logs message either via defined user logger or via system one if no user logger is defined.
@@ -280,12 +289,11 @@ func (s *Server) Serve() (err error) {
 	var wg sync.WaitGroup
 
 	if s.hasScheme(schemeUnix) {
-		domainSocket := &graceful.Server{Server: new(http.Server)}
+		domainSocket := new(http.Server)
 		domainSocket.MaxHeaderBytes = int(s.MaxHeaderSize)
 		domainSocket.Handler = s.handler
-		domainSocket.LogFunc = s.Logf
 		if int64(s.CleanupTimeout) > 0 {
-			domainSocket.Timeout = s.CleanupTimeout
+			domainSocket.IdleTimeout = s.CleanupTimeout
 		}
 
 		configureServer(domainSocket, "unix", string(s.SocketPath))
@@ -303,22 +311,22 @@ func (s *Server) Serve() (err error) {
 	}
 
 	if s.hasScheme(schemeHTTP) {
-		httpServer := &graceful.Server{Server: new(http.Server)}
+		httpServer := new(http.Server)
 		httpServer.MaxHeaderBytes = int(s.MaxHeaderSize)
 		httpServer.ReadTimeout = s.ReadTimeout
 		httpServer.WriteTimeout = s.WriteTimeout
 		httpServer.SetKeepAlivesEnabled(int64(s.KeepAlive) > 0)
-		httpServer.TCPKeepAlive = s.KeepAlive
+		//httpServer.TCPKeepAlive = s.KeepAlive
 		if s.ListenLimit > 0 {
-			httpServer.ListenLimit = s.ListenLimit
+			s.httpServerL = netutil.LimitListener(s.httpServerL, s.ListenLimit)
 		}
 
 		if int64(s.CleanupTimeout) > 0 {
-			httpServer.Timeout = s.CleanupTimeout
+			httpServer.IdleTimeout = s.CleanupTimeout
 		}
 
 		httpServer.Handler = s.handler
-		httpServer.LogFunc = s.Logf
+		//httpServer.LogFunc = s.Logf
 
 		configureServer(httpServer, "http", s.httpServerL.Addr().String())
 
@@ -331,24 +339,30 @@ func (s *Server) Serve() (err error) {
 			}
 			s.Logf("Stopped serving {{ humanize .Name }} at http://%s", l.Addr())
 		}(s.httpServerL)
-		go s.handleShutdown(&wg, httpServer)
+
+        interrupt := s.interruptChan()
+        signalNotify(interrupt)
+        quitting := make(chan struct{})
+        go s.handleInterrupt(interrupt, quitting, s.httpServerL)
+		
+        go s.handleShutdown(&wg, httpServer)
 	}
 
 	if s.hasScheme(schemeHTTPS) {
-		httpsServer := &graceful.Server{Server: new(http.Server)}
+		httpsServer := new(http.Server)
 		httpsServer.MaxHeaderBytes = int(s.MaxHeaderSize)
 		httpsServer.ReadTimeout = s.TLSReadTimeout
 		httpsServer.WriteTimeout = s.TLSWriteTimeout
 		httpsServer.SetKeepAlivesEnabled(int64(s.TLSKeepAlive) > 0)
-		httpsServer.TCPKeepAlive = s.TLSKeepAlive
+		//httpsServer.TCPKeepAlive = s.TLSKeepAlive
 		if s.TLSListenLimit > 0 {
-			httpsServer.ListenLimit = s.TLSListenLimit
+			s.httpsServerL = netutil.LimitListener(s.httpsServerL, s.TLSListenLimit)
 		}
 		if int64(s.CleanupTimeout) > 0 {
-			httpsServer.Timeout = s.CleanupTimeout
+			httpsServer.IdleTimeout = s.CleanupTimeout
 		}
 		httpsServer.Handler = s.handler
-		httpsServer.LogFunc = s.Logf
+		//httpsServer.LogFunc = s.Logf
 
     // Inspired by https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
 		httpsServer.TLSConfig = &tls.Config{
@@ -418,9 +432,9 @@ func (s *Server) Serve() (err error) {
 			s.Logf("Stopped serving {{ humanize .Name }} at https://%s", l.Addr())
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
 		go s.handleShutdown(&wg, httpsServer)
-  }
+    }
 
-  wg.Wait()
+    wg.Wait()
 	return nil
 }
 
@@ -505,22 +519,42 @@ func (s *Server) Shutdown() error {
 	return nil
 }
 
-func (s *Server) handleShutdown(wg *sync.WaitGroup, server *graceful.Server) {
+func (s *Server) handleShutdown(wg *sync.WaitGroup, server *http.Server) {
 	defer wg.Done()
-	for {
-		select {
-		case <-s.shutdown:
-			atomic.AddInt32(&s.shuttingDown, 1)
-			server.Stop(s.CleanupTimeout)
-			<-server.StopChan()
-			s.api.ServerShutdown()
-			return
-		case <-server.StopChan():
-			atomic.AddInt32(&s.shuttingDown, 1)
-			s.api.ServerShutdown()
-			return
-		}
-	}
+
+    ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Second)
+    defer cancel()
+
+    <-s.shutdown
+    if err := server.Shutdown(ctx); err != nil {
+        // Error from closing listeners, or context timeout:
+        s.Logf("HTTP server Shutdown: %v", err)
+    } else {
+        atomic.AddInt32(&s.shuttingDown, 1)
+        select {
+        case <- ctx.Done():
+            if err := ctx.Err(); err != nil {
+                s.Logf("Error %s", err)
+            }
+        default:
+                done := make(chan error)
+                defer close(done)
+                go func() {
+                    <- ctx.Done()
+                    done <- ctx.Err()        
+                }()
+                go func() {
+                    //done <- s.api.Shutdown(ctx)
+                    s.api.ServerShutdown()
+                    done <- errors.New("API shut down")
+                }()
+                if err := <-done; err != nil {
+                    s.Logf("Error %s", err)
+                }
+
+        }
+    }
+    return
 }
 
 // GetHandler returns a handler useful for testing
@@ -561,4 +595,38 @@ func (s *Server) TLSListener() (net.Listener, error) {
 		}
 	}
 	return s.httpsServerL, nil
+}
+
+func (s *Server) interruptChan() chan os.Signal {
+    s.chanLock.Lock()
+    defer s.chanLock.Unlock()
+
+    if s.interrupt == nil {
+        s.interrupt = make(chan os.Signal, 1)
+    }
+    
+    return s.interrupt
+
+}
+
+func (s *Server) handleInterrupt(interrupt chan os.Signal, quitting chan struct{}, l net.Listener) {
+    for _ = range interrupt {
+        if s.interrupted {
+            s.Logf("Server already shutting down")
+            continue
+        }
+        s.interrupted = true
+        s.Logf("Shutting down... ")
+        close(quitting)
+        
+        //s.SetKeepAlivesEnabled(false)
+        if err := l.Close(); err != nil {
+            s.Logf("Error: %s", err)
+        }
+        //s.shutdown <- struct{}{}
+    }
+}
+
+func signalNotify(interrupt chan<- os.Signal) {
+    signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
 }


### PR DESCRIPTION
For simplicity, examples not re-generated in this commit. 