### PR TITLE
Allow struct fields to be annotated with swagger:ignore

### DIFF
--- a/fixtures/goparsing/classification/models/nomodel.go
+++ b/fixtures/goparsing/classification/models/nomodel.go
@@ -629,3 +629,17 @@ type JSONString struct {
 	// The ",string" directive should be ignore before the type isn't scalar
 	SomethingElse Cars `json:"somethingElse,string"`
 }
+
+// IgnoredFields demostrates the use of swagger:ignore on struct fields.
+//
+// swagger:model ignoredFields
+type IgnoredFields struct {
+	SomeIncludedField string `json:"someIncludedField"`
+
+	// swagger:ignore
+	SomeIgnoredField string `json:"someIgnoredField"`
+
+	// This swagger:ignore tag won't work - it needs to be in the field's doc
+	// block
+	SomeErroneouslyIncludedField string `json:"someErroneouslyIncludedField"` // swagger:ignore
+}

--- a/scan/schema_test.go
+++ b/scan/schema_test.go
@@ -585,8 +585,6 @@ func TestInterfaceDiscriminators(t *testing.T) {
 
 		assertProperty(t, &schema, "integer", "doors", "int64", "Doors")
 	}
-
-	schema, ok = noModelDefs["jsonString"]
 }
 
 func TestStringStructTag(t *testing.T) {
@@ -610,6 +608,14 @@ func TestStringStructTag(t *testing.T) {
 	if assert.True(t, ok) {
 		assert.NotEqual(t, "string", prop.Type)
 	}
+}
+
+func TestIgnoredStructField(t *testing.T) {
+	_ = classificationProg
+	sch := noModelDefs["ignoredFields"]
+	assertProperty(t, &sch, "string", "someIncludedField", "", "SomeIncludedField")
+	assertProperty(t, &sch, "string", "someErroneouslyIncludedField", "", "SomeErroneouslyIncludedField")
+	assert.Len(t, sch.Properties, 2)
 }
 
 func TestAliasedModels(t *testing.T) {


### PR DESCRIPTION
Sometimes it's useful to includ a field in a request or response but leave it
undocumented. This change allows such struct fields to be annotated with
`swagger:ignore`, e.g.

```go
type Foo struct {
  // swagger:ignore
  Bar string `json:"bar"`
}
```

See #1497.

Signed-off-by: Neil Garb <neil@luno.com>