### PR TITLE
Allow white space sensitive markdown in comments.

### DIFF
--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -82,7 +82,7 @@ var (
 			")?\\p{Zs}+" +
 			rxOpID + "\\p{Zs}*$")
 	rxBeginYAMLSpec    = regexp.MustCompile(`---\p{Zs}*$`)
-	rxUncommentHeaders = regexp.MustCompile(`^[\p{Zs}\t/\*-]*`)
+	rxUncommentHeaders = regexp.MustCompile(`^[\p{Zs}\t/\*-]*\|?`)
 	rxUncommentYAML    = regexp.MustCompile(`^[\p{Zs}\t]*/*`)
 	rxOperation        = regexp.MustCompile(
 		"swagger:operation\\p{Zs}*" +

--- a/scan/scanner_test.go
+++ b/scan/scanner_test.go
@@ -487,6 +487,18 @@ See how markdown works now, we can have lists:
 [Links works too](http://localhost)
 `
 
+	text4 := `This has whitespace sensitive markdown in the description
+
+|+ first item
+|    + nested item
+|    + also nested item
+
+Sample code block:
+
+|    fmt.Println("Hello World!")
+
+`
+
 	var err error
 
 	st := &sectionedParser{}
@@ -512,6 +524,14 @@ See how markdown works now, we can have lists:
 
 	assert.EqualValues(t, []string{"This has a title, and markdown in the description"}, st.Title())
 	assert.EqualValues(t, []string{"See how markdown works now, we can have lists:", "", "+ first item", "+ second item", "+ third item", "", "[Links works too](http://localhost)"}, st.Description())
+
+	st = &sectionedParser{}
+	st.setTitle = func(lines []string) {}
+	err = st.Parse(ascg(text4))
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, []string{"This has whitespace sensitive markdown in the description"}, st.Title())
+	assert.EqualValues(t, []string{"+ first item", "    + nested item", "    + also nested item", "", "Sample code block:", "", "    fmt.Println(\"Hello World!\")"}, st.Description())
 }
 
 func dummyBuilder() schemaValidations {


### PR DESCRIPTION
I am looking to allow white space sensitive markdown when writing the API documentation in the comments of my server's source.  This will allow writing nested lists and white space sensitive code blocks.

To use it, start a line with |.  The pipe character will be removed but no further white space.

e.g.:

```
// | + first item
// |      + nested item  
``` 

Let me know what you think!