### PR TITLE
Generate consumer/producer handlers that are not whitelisted

### DIFF
--- a/fixtures/enhancements/1557/swagger.yml
+++ b/fixtures/enhancements/1557/swagger.yml
@@ -1,0 +1,20 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Example
+schemes:
+  - http
+paths:
+  /pdf:
+    post:
+      summary: Accepts and returns a pdf file
+      consumes:
+        - application/pdf
+      produces:
+        - application/pdf
+      responses:
+        200:
+          description: A pdf file
+          schema:
+            type: string
+            format: binary

--- a/generator/support.go
+++ b/generator/support.go
@@ -352,6 +352,23 @@ func (a *appGenerator) makeConsumes() (consumes GenSerGroups, consumesJSON bool)
 	for _, cons := range a.Analyzed.RequiredConsumes() {
 		cn, ok := mediaTypeName(cons)
 		if !ok {
+			nm := swag.ToJSONName(cons)
+			ser := GenSerializer{
+				AppName:        a.Name,
+				ReceiverName:   a.Receiver,
+				Name:           nm,
+				MediaType:      cons,
+				Implementation: "",
+			}
+
+			consumes = append(consumes, GenSerGroup{
+				AppName:        ser.AppName,
+				ReceiverName:   ser.ReceiverName,
+				Name:           ser.Name,
+				MediaType:      cons,
+				AllSerializers: []GenSerializer{ser},
+				Implementation: ser.Implementation,
+			})
 			continue
 		}
 		nm := swag.ToJSONName(cn)
@@ -413,6 +430,22 @@ func (a *appGenerator) makeProduces() (produces GenSerGroups, producesJSON bool)
 	for _, prod := range a.Analyzed.RequiredProduces() {
 		pn, ok := mediaTypeName(prod)
 		if !ok {
+			nm := swag.ToJSONName(prod)
+			ser := GenSerializer{
+				AppName:        a.Name,
+				ReceiverName:   a.Receiver,
+				Name:           nm,
+				MediaType:      prod,
+				Implementation: "",
+			}
+			produces = append(produces, GenSerGroup{
+				AppName:        ser.AppName,
+				ReceiverName:   ser.ReceiverName,
+				Name:           ser.Name,
+				MediaType:      prod,
+				Implementation: ser.Implementation,
+				AllSerializers: []GenSerializer{ser},
+			})
 			continue
 		}
 		nm := swag.ToJSONName(pn)


### PR DESCRIPTION
Fixes #1284 

Specifying consumers/producers that are not explicitly added to the whitelist will create an empty handler. Here are some example generated handlers for content types `application/pdf` and `text/csv`:

```go
api.ApplicationPdfConsumer = runtime.ConsumerFunc(func(r io.Reader, target interface{}) error {
	return errors.NotImplemented("applicationPdf consumer has not yet been implemented")
})

api.ApplicationPdfProducer = runtime.ProducerFunc(func(w io.Writer, data interface{}) error {
	return errors.NotImplemented("applicationPdf producer has not yet been implemented")
})

api.CsvProducer = runtime.ProducerFunc(func(w io.Writer, data interface{}) error {
	return errors.NotImplemented("csv producer has not yet been implemented")
})
```

Since the [implementation](https://github.com/go-swagger/go-swagger/compare/master...Xzya:master#diff-372f29802f9bee6924d8b6004b79a7f2R361) is left empty, the template will [automatically generate](https://github.com/go-swagger/go-swagger/blob/master/generator/templates/server/configureapi.gotmpl#L63) the empty handler. This could also be replaced with the `runtime.DiscardConsumer`/`runtime.DiscardProducer`, but I feel like this is easier for the user to figure out.