### PR TITLE
Update README.md to add Nutanix to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Iron.io
 [ManifoldCo](https://github.com/manifoldco)
 [Metaparticle.io](https://github.com/metaparticle-io/metaparticle-ast)
 [Netlify](https://github.com/netlify/open-api)
+[Nutanix](https://github.com/nutanix)
 [OAS2](https://github.com/hypnoglow/oas2)
 [OVH API](https://github.com/appscode/go-ovh)
 [RackHD](https://github.com/RackHD/RackHD)


### PR DESCRIPTION
Added Nutanix to the list of companies using go-swagger. 

We're using this for swagger validate internally to ratchet up the quality gate for our various internal swagger.json/swagger.yaml implementations, as well as using swagger generate for nusights, which is one of our telemetry frameworks.