### PR TITLE
Feature/x-order

### DIFF
--- a/fixtures/codegen/x-order.yml
+++ b/fixtures/codegen/x-order.yml
@@ -1,0 +1,109 @@
+swagger: '2.0'
+info:
+  description: Test for x-order
+  version: 0.0.1
+  title: Test for x-order
+  contact:
+    email: takano@liberent.co.jp
+schemes:
+  - http
+paths:
+  /user/startSession:
+    post:
+      summary: Test for x-order
+      description: Test for x-order
+      operationId: StartSession
+      consumes:
+        - application/json
+        - application/x-msgpack-array
+      produces:
+        - application/json
+        - application/x-msgpack-array
+      parameters:
+        - in: body
+          name: clientProfile
+          description: client profile
+          required: true
+          schema:
+            $ref: '#/definitions/clientProfile'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/sessionData'
+          headers:
+            X-Server-Time:
+              type: integer
+              format: uint64
+              description: Unixtime
+            Content-Encoding:
+              type: string
+              description: gzip etc
+        '400':
+          description: Invalid input
+        '503':
+          description: Service in Maintenance.
+
+definitions:
+  empty:
+    type: object
+  clientProfile:
+    type: object
+    properties:
+      deviceId:
+        x-order: 0
+        type: string
+        description: deveide unique
+      os:
+        x-order: 1
+        type: string
+        description: 'OS("ios","android","pc")'
+      appVersion:
+        x-order: 2
+        type: string
+        description: app version
+      masterVersion:
+        x-order: 3
+        type: integer
+        format: uint64
+        description: master data version
+  sessionData:
+    type: object
+    properties:
+      sessionId:
+        x-order: 0
+        type: string
+        description: session unique
+      deviceId:
+        x-order: 1
+        x-go-custom-tag: hello1
+        type: string
+        description: deveide unique
+      uMain:
+        $ref: '#/definitions/u_main'
+        x-order: 2
+        x-go-custom-tag: hello2
+        description: Sample
+  u_main:
+    type: object
+    properties:
+      uuid:
+        x-order: 0
+        type: string
+        format: string
+        description: UUID
+      uid:
+        x-order: 1
+        type: integer
+        format: uint32
+        description: public user id
+      name:
+        x-order: 2
+        type: string
+        format: string
+        description: user name
+      ts:
+        x-order: 3
+        type: integer
+        format: uint64
+        description: registerd timestamp

--- a/generator/model.go
+++ b/generator/model.go
@@ -837,9 +837,12 @@ func (sg *schemaGenContext) buildProperties() error {
 			emprop.GenSchema.ValueExpression += "()"
 		}
 
+		emprop.GenSchema.Extensions = emprop.Schema.Extensions
+
 		// set custom serializer tag
 		if customTag, found := emprop.Schema.Extensions[xGoCustomTag]; found {
 			emprop.GenSchema.CustomTag = customTag.(string)
+			delete(emprop.GenSchema.Extensions, xGoCustomTag)
 		}
 		sg.GenSchema.Properties = append(sg.GenSchema.Properties, emprop.GenSchema)
 	}

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -47,10 +47,6 @@ func (g GenDefinitions) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 // version control and such
 type GenSchemaList []GenSchema
 
-func (g GenSchemaList) Len() int           { return len(g) }
-func (g GenSchemaList) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
-func (g GenSchemaList) Less(i, j int) bool { return g[i].Name < g[j].Name }
-
 // GenSchema contains all the information needed to generate the code
 // for a schema
 type GenSchema struct {
@@ -93,6 +89,19 @@ type GenSchema struct {
 	IncludeValidator        bool
 	IncludeModel            bool
 	Default                 interface{}
+}
+
+func (g GenSchemaList) Len() int      { return len(g) }
+func (g GenSchemaList) Swap(i, j int) { g[i], g[j] = g[j], g[i] }
+func (g GenSchemaList) Less(i, j int) bool {
+	a, ok := g[i].Extensions[xOrder].(float64)
+	if ok {
+		b, ok := g[j].Extensions[xOrder].(float64)
+		if ok {
+			return a < b
+		}
+	}
+	return g[i].Name < g[j].Name
 }
 
 type sharedValidations struct {

--- a/generator/types.go
+++ b/generator/types.go
@@ -50,6 +50,7 @@ const (
 	xNullable    = "x-nullable" // turns the schema into a pointer
 	xOmitEmpty   = "x-omitempty"
 	xSchemes     = "x-schemes" // additional schemes supported for operations (server generation)
+	xOrder       = "x-order"   // sort propaties by
 )
 
 // swaggerTypeMapping contains a mapping from go type to swagger type or format


### PR DESCRIPTION
`x-order`:  To sort struct properties order.

It useful with msgpack-array.

```
  sessionData:
    type: object
    properties:
      sessionId:
        x-order: 0
        type: string
        description: session unique
      deviceId:
        x-order: 1
        x-go-custom-tag: hello1
        type: string
        description: deveide unique
      uMain:
        $ref: '#/definitions/u_main'
        x-order: 2
        x-go-custom-tag: hello2
        description: Sample
```

Output is sorted by x-order, no alphabet order.

```
type SessionData struct {

	SessionID string `json:"sessionId,omitempty"`

	DeviceID string `json:"deviceId,omitempty" hello1`

	UMain *UMain `json:"uMain,omitempty" hello2`
}
```
