### PR TITLE
optimize to clone schema

### DIFF
--- a/generator/operation.go
+++ b/generator/operation.go
@@ -1070,7 +1070,14 @@ func (b *codeGenOpBuilder) buildOperationSchema(schemaPath, containerName, schem
 		ExtraSchemas:     make(map[string]GenSchema),
 	}
 
-	br, bs := b.saveResolveContext(rslv, sch)
+	var (
+		br *typeResolver
+		bs *spec.Schema
+	)
+	// these backups are not needed when sch has name.
+	if sch.Ref.String() == "" {
+		br, bs = b.saveResolveContext(rslv, sch)
+	}
 
 	if err := sc.makeGenSchema(); err != nil {
 		return GenSchema{}, err


### PR DESCRIPTION
`generate xxx` (`planning operations` phase) is too slow.

`codeGenOpBuilder.MakeOperation()` takes about 500msec for **an operation** in my env.
And I have over 100 operations in my swagger.yml, then...

    500msec/op * 100op = 50s

It takes about 1min.

---

This is caused by `codeGenOpBuilder.saveResolveContext` (actually `cloneSchema()` is too slow).
So I optimize to call it when those backups are never used.
