### PR TITLE
Reverts silent change brought by #1612

### DIFF
--- a/generator/model.go
+++ b/generator/model.go
@@ -842,7 +842,6 @@ func (sg *schemaGenContext) buildProperties() error {
 		// set custom serializer tag
 		if customTag, found := emprop.Schema.Extensions[xGoCustomTag]; found {
 			emprop.GenSchema.CustomTag = customTag.(string)
-			delete(emprop.GenSchema.Extensions, xGoCustomTag)
 		}
 		sg.GenSchema.Properties = append(sg.GenSchema.Properties, emprop.GenSchema)
 	}

--- a/generator/shared_test.go
+++ b/generator/shared_test.go
@@ -341,13 +341,11 @@ func TestShared_DirectoryTemplate(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll("TestGenDir")
 		log.SetOutput(os.Stdout)
-		Debug = false
 	}()
 
 	// Not skipping format
 	content := "func x {}"
 
-	Debug = true
 	_ = templates.AddFile("gendir", content)
 
 	opts := GenOpts{}


### PR DESCRIPTION
Adding support for the x-order custom tag silently (and slightly) changed behavior with x-go-custom-tag.
Reverted to the original behavior.