### PR TITLE
Improve go.mod support in generator

### DIFF
--- a/generator/moreschemavalidation_test.go
+++ b/generator/moreschemavalidation_test.go
@@ -298,7 +298,7 @@ func TestMoreModelValidations(t *testing.T) {
 		fixtureSpec := fixture.SpecFile
 		runTitle := strings.Join([]string{"codegen", strings.TrimSuffix(path.Base(fixtureSpec), path.Ext(fixtureSpec))}, "-")
 		t.Run(runTitle, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			log.SetOutput(ioutil.Discard)
 			specDoc, err := loads.Spec(fixtureSpec)
 			if !dassert.NoErrorf(err, "unexpected failure loading spec %s: %v", fixtureSpec, err) {


### PR DESCRIPTION
This improves the `go.mod` support added in #1636 by adding support for
targets not at the module level.

Imagine you generate code like this:

```bash
$ swagger generate client --name my-api --target ./pkg/api
```

Then it would assume `go.mod` is under `pkg/api` and not detect that go
modules are used. The fix is to walk up the directory to find the first
occurance of `go.mod` and assume that as the module base URL.