### PR TITLE
add yml output file support

### DIFF
--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -96,9 +96,8 @@ func writeToFile(swspec *spec.Swagger, pretty bool, output string) error {
 func marshalToJSONFormat(swspec *spec.Swagger, pretty bool) ([]byte, error) {
 	if pretty {
 		return json.MarshalIndent(swspec, "", "  ")
-	} else {
-		return json.Marshal(swspec)
 	}
+	return json.Marshal(swspec)
 }
 
 func marshalToYAMLFormat(swspec *spec.Swagger) ([]byte, error) {
@@ -112,5 +111,5 @@ func marshalToYAMLFormat(swspec *spec.Swagger) ([]byte, error) {
 		return nil, err
 	}
 
-  return yaml.Marshal(jsonObj);
+	return yaml.Marshal(jsonObj)
 }

--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -73,13 +73,13 @@ func loadSpec(input string) (*spec.Swagger, error) {
 }
 
 func writeToFile(swspec *spec.Swagger, pretty bool, output string) error {
-	var data []byte
+	var b []byte
 	var err error
 
 	if strings.HasSuffix(output, "yml") || strings.HasSuffix(output, "yaml") {
-		data, err = marshalToYAMLFormat(swspec)
+		b, err = marshalToYAMLFormat(swspec)
 	} else {
-		data, err = marshalToJSONFormat(swspec, pretty)
+		b, err = marshalToJSONFormat(swspec, pretty)
 	}
 
 	if err != nil {
@@ -87,10 +87,10 @@ func writeToFile(swspec *spec.Swagger, pretty bool, output string) error {
 	}
 
 	if output == "" {
-		fmt.Println(string(data))
+		fmt.Println(string(b))
 		return nil
 	}
-	return ioutil.WriteFile(output, data, 0644)
+	return ioutil.WriteFile(output, b, 0644)
 }
 
 func marshalToJSONFormat(swspec *spec.Swagger, pretty bool) ([]byte, error) {

--- a/cmd/swagger/commands/generate/spec_test.go
+++ b/cmd/swagger/commands/generate/spec_test.go
@@ -1,0 +1,81 @@
+package generate
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/go-swagger/go-swagger/scan"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	basePath       = "../../../../fixtures/goparsing/spec"
+	jsonResultFile = "../../../../fixtures/goparsing/spec/api_spec.json"
+	yamlResultFile = "../../../../fixtures/goparsing/spec/api_spec.yml"
+)
+
+func TestGenerateJSONSpec(t *testing.T) {
+	opts := scan.Opts{
+		BasePath: basePath,
+	}
+
+	swspec, err := scan.Application(opts)
+	assert.NoError(t, err)
+
+	data, err := marshalToJSONFormat(swspec, true)
+	assert.NoError(t, err)
+
+	expected, err := ioutil.ReadFile(jsonResultFile)
+	assert.NoError(t, err)
+
+	varifyJSONData(t, data, expected)
+}
+
+func TestGenerateYAMLSpec(t *testing.T) {
+	opts := scan.Opts{
+		BasePath: basePath,
+	}
+
+	swspec, err := scan.Application(opts)
+	assert.NoError(t, err)
+
+	data, err := marshalToYAMLFormat(swspec)
+	assert.NoError(t, err)
+
+	expected, err := ioutil.ReadFile(yamlResultFile)
+	assert.NoError(t, err)
+
+	varifyYAMLData(t, data, expected)
+}
+
+func varifyJSONData(t *testing.T, data, expectedJSON []byte) {
+	var got interface{}
+	var expected interface{}
+
+	err := json.Unmarshal(data, &got)
+	assert.NoError(t, err)
+
+	err = json.Unmarshal(expectedJSON, &expected)
+	assert.NoError(t, err)
+
+	if !assert.ObjectsAreEqual(got, expected) {
+		assert.Fail(t, "marshaled JSON data doesn't equal expected JSON data")
+	}
+}
+
+func varifyYAMLData(t *testing.T, data, expectedYAML []byte) {
+	var got interface{}
+	var expected interface{}
+
+	err := yaml.Unmarshal(data, &got)
+	assert.NoError(t, err)
+
+	err = yaml.Unmarshal(expectedYAML, &expected)
+	assert.NoError(t, err)
+
+	if !assert.ObjectsAreEqual(got, expected) {
+		assert.Fail(t, "marshaled YAML data doesn't equal expected YAML data")
+	}
+}

--- a/fixtures/goparsing/spec/api.go
+++ b/fixtures/goparsing/spec/api.go
@@ -1,0 +1,78 @@
+// Package booking API.
+//
+// the purpose of this application is to provide an application
+// that is using plain go code to define an API
+//
+//
+//     Schemes: https
+//     Host: localhost
+//     Version: 0.0.1
+//
+//     Consumes:
+//     - application/json
+//
+//     Produces:
+//     - application/json
+//
+//
+// swagger:meta
+package spec
+
+import (
+	"net/http"
+
+	"github.com/go-swagger/scan-repo-boundary/makeplans"
+)
+
+// Customer of the site.
+//
+// swagger:model Customer
+type Customer struct {
+	Name string `json:"name"`
+}
+
+// IgnoreMe should not be added to definitions since it is not annotated.
+type IgnoreMe struct {
+	Name string `json:"name"`
+}
+
+// DateRange represents a scheduled appointments time
+// DateRange should be in definitions since it's being used in a response
+type DateRange struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// BookingResponse represents a scheduled appointment
+//
+// swagger:response BookingResponse
+type BookingResponse struct {
+	// Booking struct
+	//
+	// in: body
+	// required: true
+	Body struct {
+		Booking  makeplans.Booking `json:"booking"`
+		Customer Customer          `json:"customer"`
+		Dates    DateRange         `json:"dates"`
+	}
+}
+
+// Bookings swagger:route GET /admin/bookings/ booking Bookings
+//
+// Bookings lists all the appointments that have been made on the site.
+//
+//
+// Consumes:
+// application/json
+//
+// Schemes: http, https
+//
+// Produces:
+// application/json
+//
+// Responses:
+// 200: BookingResponse
+func bookings(w http.ResponseWriter, r *http.Request) {
+
+}

--- a/fixtures/goparsing/spec/api_spec.json
+++ b/fixtures/goparsing/spec/api_spec.json
@@ -1,0 +1,113 @@
+{
+  "consumes":[
+    "application/json"
+  ],
+  "produces":[
+    "application/json"
+  ],
+  "schemes":[
+    "https"
+  ],
+  "swagger":"2.0",
+  "info":{
+    "description":"the purpose of this application is to provide an application\nthat is using plain go code to define an API",
+    "title":"API.",
+    "version":"0.0.1"
+  },
+  "host":"localhost",
+  "paths":{
+    "/admin/bookings/":{
+      "get":{
+        "consumes":[
+          "application/json"
+        ],
+        "produces":[
+          "application/json"
+        ],
+        "schemes":[
+          "http",
+          "https"
+        ],
+        "tags":[
+          "booking"
+        ],
+        "summary":"Bookings lists all the appointments that have been made on the site.",
+        "operationId":"Bookings",
+        "responses":{
+          "200":{
+            "$ref":"#/responses/BookingResponse"
+          }
+        }
+      }
+    }
+  },
+  "definitions":{
+    "Booking":{
+      "description":"A Booking in the system",
+      "type":"object",
+      "required":[
+        "id",
+        "Subject"
+      ],
+      "properties":{
+        "Subject":{
+          "description":"Subject the subject of this booking",
+          "type":"string"
+        },
+        "id":{
+          "description":"ID the id of the booking",
+          "type":"integer",
+          "format":"int64",
+          "x-go-name":"ID",
+          "readOnly":true
+        }
+      },
+      "x-go-package":"github.com/go-swagger/go-swagger/vendor/github.com/go-swagger/scan-repo-boundary/makeplans"
+    },
+    "Customer":{
+      "type":"object",
+      "title":"Customer of the site.",
+      "properties":{
+        "name":{
+          "type":"string",
+          "x-go-name":"Name"
+        }
+      },
+      "x-go-package":"github.com/go-swagger/go-swagger/fixtures/goparsing/spec"
+    },
+    "DateRange":{
+      "description":"DateRange represents a scheduled appointments time\nDateRange should be in definitions since it's being used in a response",
+      "type":"object",
+      "properties":{
+        "end":{
+          "type":"string",
+          "x-go-name":"End"
+        },
+        "start":{
+          "type":"string",
+          "x-go-name":"Start"
+        }
+      },
+      "x-go-package":"github.com/go-swagger/go-swagger/fixtures/goparsing/spec"
+    }
+  },
+  "responses":{
+    "BookingResponse":{
+      "description":"BookingResponse represents a scheduled appointment",
+      "schema":{
+        "type":"object",
+        "properties":{
+          "booking":{
+            "$ref":"#/definitions/Booking"
+          },
+          "customer":{
+            "$ref":"#/definitions/Customer"
+          },
+          "dates":{
+            "$ref":"#/definitions/DateRange"
+          }
+        }
+      }
+    }
+  }
+}

--- a/fixtures/goparsing/spec/api_spec.yml
+++ b/fixtures/goparsing/spec/api_spec.yml
@@ -1,0 +1,82 @@
+consumes:
+- application/json
+produces:
+- application/json
+schemes:
+- https
+swagger: '2.0'
+info:
+  description: |-
+    the purpose of this application is to provide an application
+    that is using plain go code to define an API
+  title: API.
+  version: 0.0.1
+host: localhost
+paths:
+  "/admin/bookings/":
+    get:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      schemes:
+      - http
+      - https
+      tags:
+      - booking
+      summary: Bookings lists all the appointments that have been made on the site.
+      operationId: Bookings
+      responses:
+        '200':
+          "$ref": "#/responses/BookingResponse"
+definitions:
+  Booking:
+    description: A Booking in the system
+    type: object
+    required:
+    - id
+    - Subject
+    properties:
+      Subject:
+        description: Subject the subject of this booking
+        type: string
+      id:
+        description: ID the id of the booking
+        type: integer
+        format: int64
+        x-go-name: ID
+        readOnly: true
+    x-go-package: github.com/go-swagger/go-swagger/vendor/github.com/go-swagger/scan-repo-boundary/makeplans
+  Customer:
+    type: object
+    title: Customer of the site.
+    properties:
+      name:
+        type: string
+        x-go-name: Name
+    x-go-package: github.com/go-swagger/go-swagger/fixtures/goparsing/spec
+  DateRange:
+    description: |-
+      DateRange represents a scheduled appointments time
+      DateRange should be in definitions since it's being used in a response
+    type: object
+    properties:
+      end:
+        type: string
+        x-go-name: End
+      start:
+        type: string
+        x-go-name: Start
+    x-go-package: github.com/go-swagger/go-swagger/fixtures/goparsing/spec
+responses:
+  BookingResponse:
+    description: BookingResponse represents a scheduled appointment
+    schema:
+      type: object
+      properties:
+        booking:
+          "$ref": "#/definitions/Booking"
+        customer:
+          "$ref": "#/definitions/Customer"
+        dates:
+          "$ref": "#/definitions/DateRange"


### PR DESCRIPTION
When user run the `generate` command with a output file which has `.yml` or `.yaml` suffix. The swagger will generate yaml format output