### PR TITLE
remove telling user they need to install context package

### DIFF
--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -78,7 +78,6 @@ func (c *Client) log(rp string) {
 For this generation to compile you need to have some packages in your GOPATH:
 
 	* github.com/go-openapi/runtime
-	* golang.org/x/net/context
 	* golang.org/x/net/context/ctxhttp
 
 You can get these now with: go get -u -f %s/...


### PR DESCRIPTION
user is not required to install old version of context