### PR TITLE
Make extension generation optional

### DIFF
--- a/scan/parameters.go
+++ b/scan/parameters.go
@@ -483,7 +483,7 @@ func (pp *paramStructParser) parseStructType(gofile *ast.File, operation *spec.O
 				}
 
 				if nm != gnm {
-					ps.AddExtension("x-go-name", gnm)
+					addExtension(&ps.VendorExtensible, "x-go-name", gnm)
 				}
 				pt[nm] = ps
 				sequence = append(sequence, nm)

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -30,6 +30,14 @@ import (
 	"github.com/go-openapi/spec"
 )
 
+func addExtension(ve *spec.VendorExtensible, key string, value interface{}) {
+	if os.Getenv("SWAGGER_GENERATE_EXTENSION") == "false" {
+		return
+	}
+
+	ve.AddExtension(key, value)
+}
+
 type schemaTypable struct {
 	schema *spec.Schema
 	level  int
@@ -278,13 +286,13 @@ func (scp *schemaParser) parseDecl(definitions map[string]spec.Schema, decl *sch
 
 	if schPtr.Ref.String() == "" {
 		if decl.Name != decl.GoName {
-			schPtr.AddExtension("x-go-name", decl.GoName)
+			addExtension(&schPtr.VendorExtensible, "x-go-name", decl.GoName)
 		}
 		for _, pkgInfo := range scp.program.AllPackages {
 			if pkgInfo.Importable {
 				for _, fil := range pkgInfo.Files {
 					if fil.Pos() == decl.File.Pos() {
-						schPtr.AddExtension("x-go-package", pkgInfo.Pkg.Path())
+						addExtension(&schPtr.VendorExtensible, "x-go-package", pkgInfo.Pkg.Path())
 					}
 				}
 			}
@@ -508,7 +516,7 @@ func (scp *schemaParser) parseInterfaceType(gofile *ast.File, bschema *spec.Sche
 							if ml > 1 {
 								mv := matches[ml-1]
 								if mv != "" {
-									bschema.AddExtension("x-class", mv)
+									addExtension(&bschema.VendorExtensible, "x-class", mv)
 								}
 							}
 						}
@@ -564,7 +572,7 @@ func (scp *schemaParser) parseInterfaceType(gofile *ast.File, bschema *spec.Sche
 			}
 
 			if ps.Ref.String() == "" && nm != gnm {
-				ps.AddExtension("x-go-name", gnm)
+				addExtension(&ps.VendorExtensible, "x-go-name", gnm)
 			}
 			seenProperties[nm] = gnm
 			schema.Properties[nm] = ps
@@ -629,7 +637,7 @@ func (scp *schemaParser) parseStructType(gofile *ast.File, bschema *spec.Schema,
 							if ml > 1 {
 								mv := matches[ml-1]
 								if mv != "" {
-									bschema.AddExtension("x-class", mv)
+									addExtension(&bschema.VendorExtensible, "x-class", mv)
 								}
 							}
 						}
@@ -699,7 +707,7 @@ func (scp *schemaParser) parseStructType(gofile *ast.File, bschema *spec.Schema,
 			}
 
 			if ps.Ref.String() == "" && nm != gnm {
-				ps.AddExtension("x-go-name", gnm)
+				addExtension(&ps.VendorExtensible, "x-go-name", gnm)
 			}
 			// we have 2 cases:
 			// 1. field with different name override tag

--- a/scan/schema_test.go
+++ b/scan/schema_test.go
@@ -15,6 +15,7 @@
 package scan
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -778,4 +779,27 @@ func assertRefDefinition(t testing.TB, defs map[string]spec.Schema, defName, ref
 			}
 		}
 	}
+}
+
+func TestAddExtension(t *testing.T) {
+	ve := &spec.VendorExtensible{
+		Extensions: make(spec.Extensions),
+	}
+
+	key := "x-go-name"
+	value := "Name"
+	addExtension(ve, key, value)
+	assert.Equal(t, value, ve.Extensions[key].(string))
+
+	key2 := "x-go-package"
+	value2 := "schema"
+	os.Setenv("SWAGGER_GENERATE_EXTENSION", "true")
+	addExtension(ve, key2, value2)
+	assert.Equal(t, value2, ve.Extensions[key2].(string))
+
+	key3 := "x-go-class"
+	value3 := "Spec"
+	os.Setenv("SWAGGER_GENERATE_EXTENSION", "false")
+	addExtension(ve, key3, value3)
+	assert.Equal(t, nil, ve.Extensions[key3])
 }


### PR DESCRIPTION
Right now, when generating swagger spec, Go language extension is added by default. Make Go language extension generation optional by setting up an env variable. By default, it is still generating Go extension spec unless the env variable `SWAGGER_GENERATE_EXTENSION` set to `false`

The use case is when visualization of the spec or generate code in other language by using the spec file (generated by go-swagger), we don't wanna these language specific extension appeared in the spec file as it may not make sense to other language.

Usage:

```
export SWAGGER_GENERATE_EXTENSION=false
swagger generate spec -o openapi.yml -q
```