### PR TITLE
Add include/exclude parameters to spec generator

### DIFF
--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -36,6 +36,8 @@ type SpecFile struct {
 	Compact    bool           `long:"compact" description:"when present, doesn't prettify the json"`
 	Output     flags.Filename `long:"output" short:"o" description:"the file to write to"`
 	Input      flags.Filename `long:"input" short:"i" description:"the file to use as input"`
+	Include    []string       `long:"include" short:"c" description:"include packages matching pattern"`
+	Exclude    []string       `long:"exclude" short:"x" description:"exclude packages matching pattern"`
 }
 
 // Execute runs this command
@@ -50,6 +52,8 @@ func (s *SpecFile) Execute(args []string) error {
 	opts.Input = input
 	opts.ScanModels = s.ScanModels
 	opts.BuildTags = s.BuildTags
+	opts.Include = s.Include
+	opts.Exclude = s.Exclude
 	swspec, err := scan.Application(opts)
 	if err != nil {
 		return err

--- a/scan/classifier.go
+++ b/scan/classifier.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"go/ast"
 	"log"
+	"regexp"
 
 	"golang.org/x/tools/go/loader"
 )
@@ -27,7 +28,11 @@ type packageFilter struct {
 }
 
 func (pf *packageFilter) Matches(path string) bool {
-	return path == pf.Name
+	matched, err := regexp.MatchString(pf.Name, path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return matched
 }
 
 type packageFilters []packageFilter

--- a/scan/scanner_test.go
+++ b/scan/scanner_test.go
@@ -114,7 +114,7 @@ func extraModelsClassifier(t testing.TB) (*loader.Program, map[string]spec.Schem
 }
 
 func TestAppScanner_NewSpec(t *testing.T) {
-	scanner, err := newAppScanner(&Opts{BasePath: "../fixtures/goparsing/petstore/petstore-fixture"}, nil, nil)
+	scanner, err := newAppScanner(&Opts{BasePath: "../fixtures/goparsing/petstore/petstore-fixture"})
 	assert.NoError(t, err)
 	assert.NotNil(t, scanner)
 	doc, err := scanner.Parse()
@@ -125,7 +125,7 @@ func TestAppScanner_NewSpec(t *testing.T) {
 }
 
 func TestAppScanner_Definitions(t *testing.T) {
-	scanner, err := newAppScanner(&Opts{BasePath: "../fixtures/goparsing/bookings"}, nil, nil)
+	scanner, err := newAppScanner(&Opts{BasePath: "../fixtures/goparsing/bookings"})
 	assert.NoError(t, err)
 	assert.NotNil(t, scanner)
 	doc, err := scanner.Parse()
@@ -1066,7 +1066,7 @@ func TestEnhancement793(t *testing.T) {
 	scanner, err := newAppScanner(&Opts{
 		BasePath:   "../fixtures/enhancements/793",
 		ScanModels: true,
-	}, nil, nil)
+	})
 	assert.NoError(t, err)
 	assert.NotNil(t, scanner)
 	doc, err := scanner.Parse()


### PR DESCRIPTION
Add include/exclude parameters to spec generator. Both are treated as a regular expression against package name and allow to narrow the list of analyzed packages.