### PR TITLE
Handle relative path when using Go modules

### DIFF
--- a/generator/shared.go
+++ b/generator/shared.go
@@ -250,14 +250,14 @@ func GoLangOpts() *LanguageOpts {
 
 		}
 
-		mod, err := tryResolveModule(tgtAbsPath)
+		mod, goModuleAbsPath, err := tryResolveModule(tgtAbsPath)
 		switch {
 		case err != nil:
 			log.Fatalf("Failed to resolve module using go.mod file: %s", err)
 		case mod != "":
-			relTgt := relPathToRelGoPath(tgt)
+			relTgt := relPathToRelGoPath(goModuleAbsPath, tgtAbsPath)
 			if !strings.HasSuffix(mod, relTgt) {
-				return mod + "/" + relTgt
+				return mod + relTgt
 			}
 			return mod
 		}
@@ -276,49 +276,51 @@ var moduleRe = regexp.MustCompile(`module[ \t]+([^\s]+)`)
 // resolveGoModFile walks up the directory tree starting from 'dir' until it
 // finds a go.mod file. If go.mod is found it will return the related file
 // object. If no go.mod file is found it will return an error.
-func resolveGoModFile(dir string) (*os.File, error) {
+func resolveGoModFile(dir string) (*os.File, string, error) {
 	goModPath := filepath.Join(dir, "go.mod")
 	f, err := os.Open(goModPath)
 	if err != nil {
 		if os.IsNotExist(err) && dir != filepath.Dir(dir) {
 			return resolveGoModFile(filepath.Dir(dir))
 		}
-		return nil, err
+		return nil, "", err
 	}
-	return f, nil
+	return f, dir, nil
 }
 
 // relPathToRelGoPath takes a relative os path and returns the relative go
 // package path. For unix nothing will change but for windows \ will be
 // converted to /.
-func relPathToRelGoPath(path string) string {
-	if path == "." {
+func relPathToRelGoPath(modAbsPath, absPath string) string {
+	if absPath == "." {
 		return ""
 	}
+
+	path := strings.TrimPrefix(absPath, modAbsPath)
 	pathItems := strings.Split(path, string(filepath.Separator))
 	return strings.Join(pathItems, "/")
 }
 
-func tryResolveModule(baseTargetPath string) (string, error) {
-	f, err := resolveGoModFile(baseTargetPath)
+func tryResolveModule(baseTargetPath string) (string, string, error) {
+	f, goModAbsPath, err := resolveGoModFile(baseTargetPath)
 	switch {
 	case os.IsNotExist(err):
-		return "", nil
+		return "", "", nil
 	case err != nil:
-		return "", err
+		return "", "", err
 	}
 
 	src, err := ioutil.ReadAll(f)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	match := moduleRe.FindSubmatch(src)
 	if len(match) != 2 {
-		return "", nil
+		return "", "", nil
 	}
 
-	return string(match[1]), nil
+	return string(match[1]), goModAbsPath, nil
 }
 
 func findSwaggerSpec(nm string) (string, error) {


### PR DESCRIPTION
This is a follow up to #1661 which correctly handles relative paths when using go modules.

#1661 didn't account for situations where you want to generate server code in a sub package of your module, so it generated the wrong imports because it used the go module path as base import instead of go module + relative package.

E.g. if you had a module `github.com/a/b` and wanted to generate go-swagger code from the package `github.com/a/b/my-server` then the import paths would be `github.com/a/b/restapi/..` instead of `github.com/a/b/my-server/restapi/..`.