### PR TITLE
WIP: Support server generation in a subdirectory #1624

### DIFF
--- a/fixtures/enhancements/1624/.gitignore
+++ b/fixtures/enhancements/1624/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/enhancements/1624/fixture-1624.json
+++ b/fixtures/enhancements/1624/fixture-1624.json
@@ -1,0 +1,3713 @@
+{
+  "info": {
+    "title": "API title",
+    "version": "0.0.1"
+  },
+  "swagger": "2.0",
+  "produces": [
+    "application/json",
+    "text/plain"
+  ],
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "private_token",
+      "in": "query"
+    },
+    "oauth2": {
+      "type": "oauth2",
+      "authorizationUrl": "https://local.tools.stack.local/torca/oauth/authorize",
+      "flow": "implicit"
+    }
+  },
+  "host": "local.tools.stack.local",
+  "basePath": "/torca/nmdb/api",
+  "schemes": [
+    "https"
+  ],
+  "tags": [
+    {
+      "name": "devices",
+      "description": "Operations about devices"
+    },
+    {
+      "name": "info",
+      "description": "Operations about infos"
+    }
+  ],
+  "paths": {
+    "/v2/devices": {
+      "get": {
+        "summary": "Query Nmdb::Device Object.",
+        "description": "Query Nmdb::Device Object.",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "description": "Page offset to fetch.",
+            "type": "integer",
+            "format": "int32",
+            "default": 1,
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "description": "Number of results to return per page.",
+            "type": "integer",
+            "format": "int32",
+            "default": 20,
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "description": "Pad a number of results.",
+            "type": "integer",
+            "format": "int32",
+            "default": 0,
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "fmt",
+            "type": "string",
+            "default": "full_root",
+            "enum": [
+              "full",
+              "full_root",
+              "base"
+            ],
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "rels",
+            "description": "Comma-separated list of relationships. Maximum 5 levels. \n e.g. interfaces,interfaces.ip_address",
+            "type": "string",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "description": "Supports nesting up to 2 levels. \n e.g {\"host_name\":\"~hhcvi\",\"interfaces\":{\"ip_address\":{\"network_address\":\"~10.10.10\"},\"name\":\"eth0\"}}",
+            "type": "string",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "type": "string",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Query Nmdb::Device Object.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Device"
+              }
+            }
+          },
+          "406": {
+            "description": "NmdbQueryError",
+            "schema": {
+              "$ref": "#/definitions/NmdbQueryError"
+            }
+          }
+        },
+        "tags": [
+          "devices"
+        ],
+        "operationId": "getV2Devices"
+      },
+      "post": {
+        "summary": "Create Nmdb::Device Object.",
+        "description": "Create Nmdb::Device Object.",
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "V2Devices",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/postV2Devices"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create Nmdb::Device Object.",
+            "schema": {
+              "$ref": "#/definitions/Device"
+            }
+          }
+        },
+        "tags": [
+          "devices"
+        ],
+        "operationId": "postV2Devices"
+      }
+    },
+    "/v2/devices/{id}": {
+      "get": {
+        "summary": "GET Nmdb::Device Object.",
+        "description": "GET Nmdb::Device Object.",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "integer",
+            "format": "int32",
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "fmt",
+            "type": "string",
+            "default": "full_root",
+            "enum": [
+              "full",
+              "full_root",
+              "base"
+            ],
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "rels",
+            "description": "Comma-separated list of relationships. Maximum 5 levels. \n e.g. interfaces,interfaces.ip_address",
+            "type": "string",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GET Nmdb::Device Object.",
+            "schema": {
+              "$ref": "#/definitions/Device"
+            }
+          },
+          "406": {
+            "description": "NmdbQueryError",
+            "schema": {
+              "$ref": "#/definitions/NmdbQueryError"
+            }
+          }
+        },
+        "tags": [
+          "devices"
+        ],
+        "operationId": "getV2DevicesId"
+      },
+      "put": {
+        "summary": "Update Nmdb::Device Object.",
+        "description": "Update Nmdb::Device Object.",
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "integer",
+            "format": "int32",
+            "required": true
+          },
+          {
+            "name": "V2Devices",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/putV2Devices"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Update Nmdb::Device Object.",
+            "schema": {
+              "$ref": "#/definitions/Device"
+            }
+          }
+        },
+        "tags": [
+          "devices"
+        ],
+        "operationId": "putV2DevicesId"
+      }
+    },
+    "/v2/info/version": {
+      "get": {
+        "summary": "Get API Version",
+        "description": "Get API Version",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Get API Version",
+            "schema": {
+              "$ref": "#/definitions/Version"
+            }
+          }
+        },
+        "tags": [
+          "info"
+        ],
+        "operationId": "getV2InfoVersion"
+      }
+    }
+  },
+  "definitions": {
+    "Device": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ciid": {
+          "type": "string"
+        },
+        "host_name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "zone_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "project_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_model_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "rack_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_status_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_status_reason_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "asset_tag": {
+          "type": "string"
+        },
+        "reconciliation_identity": {
+          "type": "string"
+        },
+        "serial_number": {
+          "type": "string"
+        },
+        "application_environment_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pod_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "vm_capacity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "switch_domain_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "blade_slot": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "blade_slots_required": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "blade_chassis_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "virtual_host_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "physical_host_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "blade_capacity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_type_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ru_required": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "primary_device_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "instance_id": {
+          "type": "string"
+        },
+        "operating_system_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "workbook_version": {
+          "type": "string"
+        },
+        "virtualized_on_vm_host_pool_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "contained_in_vm_host_pool_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "a_or_b": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bottom_ru": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "event_logs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EventLog"
+          }
+        },
+        "sync_status": {
+          "$ref": "#/definitions/SyncStatus"
+        },
+        "device_status": {
+          "$ref": "#/definitions/DeviceStatus"
+        },
+        "device_status_reason": {
+          "$ref": "#/definitions/DeviceStatusReason"
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          }
+        },
+        "device_model": {
+          "$ref": "#/definitions/DeviceModel"
+        },
+        "device_type": {
+          "$ref": "#/definitions/DeviceType"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        },
+        "rack": {
+          "$ref": "#/definitions/Rack"
+        },
+        "zone": {
+          "$ref": "#/definitions/Zone"
+        },
+        "pod": {
+          "$ref": "#/definitions/Pod"
+        },
+        "application_environment": {
+          "$ref": "#/definitions/ApplicationEnvironment"
+        },
+        "operating_system": {
+          "$ref": "#/definitions/OperatingSystem"
+        },
+        "host_name_reservation": {
+          "$ref": "#/definitions/HostNameReservation"
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interface"
+          }
+        },
+        "switch_ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SwitchPort"
+          }
+        },
+        "nat_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatEntry"
+          }
+        },
+        "load_balancer_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerEntry"
+          }
+        },
+        "blades": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "blade_chassis": {
+          "$ref": "#/definitions/Device"
+        },
+        "virtual_clients": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "virtual_host": {
+          "$ref": "#/definitions/Device"
+        },
+        "virtual_hosts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "physical_host": {
+          "$ref": "#/definitions/Device"
+        },
+        "host_pool": {
+          "$ref": "#/definitions/VmHostPool"
+        },
+        "virtualization_pool": {
+          "$ref": "#/definitions/VmHostPool"
+        },
+        "primary_device": {
+          "$ref": "#/definitions/Device"
+        },
+        "subnet_assignments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SubnetAssignment"
+          }
+        },
+        "subnets": {
+          "$ref": "#/definitions/Subnet"
+        }
+      },
+      "description": "Update Nmdb::Device Object."
+    },
+    "EventLog": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "event_class": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "data": {
+          "type": "string"
+        },
+        "loggable_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "loggable_type": {
+          "type": "string"
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "loggable": {
+          "$ref": "#/definitions/Loggable"
+        }
+      }
+    },
+    "Loggable": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "SyncStatus": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "status": {
+          "type": "string"
+        },
+        "locked": {
+          "type": "boolean"
+        },
+        "details": {
+          "type": "string"
+        },
+        "last_sync_start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_sync_end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "synchronizable_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "synchronizable_type": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "synchronizable": {
+          "$ref": "#/definitions/Synchronizable"
+        }
+      }
+    },
+    "Synchronizable": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "DeviceStatus": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "integration_id": {
+          "type": "string"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "racks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rack"
+          }
+        },
+        "device_status_reasons": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceStatusReason"
+          }
+        }
+      }
+    },
+    "Rack": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ciid": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "width": {
+          "type": "string"
+        },
+        "height": {
+          "type": "string"
+        },
+        "depth": {
+          "type": "string"
+        },
+        "total_ru_space": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "max_power_watts": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "location_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "fibre_connection_count": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ethernet_connection_count": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_status_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_status_reason_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pod_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "reconciliation_identity": {
+          "type": "string"
+        },
+        "event_logs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EventLog"
+          }
+        },
+        "sync_status": {
+          "$ref": "#/definitions/SyncStatus"
+        },
+        "device_status": {
+          "$ref": "#/definitions/DeviceStatus"
+        },
+        "device_status_reason": {
+          "$ref": "#/definitions/DeviceStatusReason"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Location"
+        },
+        "pod": {
+          "$ref": "#/definitions/Pod"
+        }
+      }
+    },
+    "DeviceStatusReason": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device_status_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "integration_id": {
+          "type": "string"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "racks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rack"
+          }
+        },
+        "device_status": {
+          "$ref": "#/definitions/DeviceStatus"
+        }
+      }
+    },
+    "Location": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "site": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "building": {
+          "type": "string"
+        },
+        "floor": {
+          "type": "string"
+        },
+        "room": {
+          "type": "string"
+        },
+        "latitude": {
+          "type": "string"
+        },
+        "longitude": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "pods": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Pod"
+          }
+        }
+      }
+    },
+    "Pod": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "pod_type_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "environment_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "location_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pod_type": {
+          "$ref": "#/definitions/PodType"
+        },
+        "location": {
+          "$ref": "#/definitions/Location"
+        },
+        "zones": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Zone"
+          }
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "racks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rack"
+          }
+        },
+        "data_transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataTransaction"
+          }
+        }
+      }
+    },
+    "PodType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "pods": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Pod"
+          }
+        }
+      }
+    },
+    "Zone": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pod_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "zone_group_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "vlans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Vlan"
+          }
+        },
+        "subnets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          }
+        },
+        "pod": {
+          "$ref": "#/definitions/Pod"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Zone"
+          }
+        },
+        "data_transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataTransaction"
+          }
+        },
+        "parent": {
+          "$ref": "#/definitions/Zone"
+        }
+      }
+    },
+    "Vlan": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "primary_number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "zone_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "direction_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "vlan_type_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "description": {
+          "type": "string"
+        },
+        "is_primary": {
+          "type": "boolean"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Note"
+          }
+        },
+        "subnets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          }
+        },
+        "zone": {
+          "$ref": "#/definitions/Zone"
+        },
+        "direction": {
+          "$ref": "#/definitions/Direction"
+        },
+        "vlan_type": {
+          "$ref": "#/definitions/VlanType"
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interface"
+          }
+        },
+        "switch_ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SwitchPort"
+          }
+        },
+        "data_transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataTransaction"
+          }
+        }
+      }
+    },
+    "Note": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "Subnet": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "network_address": {
+          "type": "string"
+        },
+        "netmask": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "default_gateway_id": {
+          "type": "string"
+        },
+        "broadcast": {
+          "type": "string"
+        },
+        "zone_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "supernet_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "default_gateway": {
+          "type": "string"
+        },
+        "vlan_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "direction_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "int_address": {
+          "type": "string"
+        },
+        "cidr_address": {
+          "type": "string"
+        },
+        "zone": {
+          "$ref": "#/definitions/Zone"
+        },
+        "vlan": {
+          "$ref": "#/definitions/Vlan"
+        },
+        "direction": {
+          "$ref": "#/definitions/Direction"
+        },
+        "ip_addresses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IpAddress"
+          }
+        },
+        "data_transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataTransaction"
+          }
+        },
+        "subnets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          }
+        },
+        "supernet": {
+          "$ref": "#/definitions/Subnet"
+        },
+        "devices": {
+          "$ref": "#/definitions/Device"
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          }
+        }
+      }
+    },
+    "Direction": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "zone_group_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "dns_suffix": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "vlans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Vlan"
+          }
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interface"
+          }
+        },
+        "subnets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          }
+        },
+        "data_transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataTransaction"
+          }
+        }
+      }
+    },
+    "Interface": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "mac_address": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "device_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "require_ip": {
+          "type": "boolean"
+        },
+        "require_switch_port": {
+          "type": "boolean"
+        },
+        "require_default_gateway": {
+          "type": "boolean"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "media": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "vlan_direction_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "interface_speed_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "vlan_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "subnet_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "direction_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "duplex_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "medium_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "switch_port_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pci_slot": {
+          "type": "string"
+        },
+        "a_or_b": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "require_route_for_management": {
+          "type": "boolean"
+        },
+        "require_route_for_getronics": {
+          "type": "boolean"
+        },
+        "default_gateway_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "static_routes": {
+          "type": "string"
+        },
+        "interface_type_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "connector_type_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "mac_addr": {
+          "type": "string"
+        },
+        "device": {
+          "$ref": "#/definitions/Device"
+        },
+        "subnet": {
+          "$ref": "#/definitions/Subnet"
+        },
+        "ip_address": {
+          "$ref": "#/definitions/IpAddress"
+        },
+        "vlan": {
+          "$ref": "#/definitions/Vlan"
+        },
+        "direction": {
+          "$ref": "#/definitions/Direction"
+        },
+        "duplex": {
+          "$ref": "#/definitions/Duplex"
+        },
+        "interface_speed": {
+          "$ref": "#/definitions/InterfaceSpeed"
+        },
+        "medium": {
+          "$ref": "#/definitions/Medium"
+        },
+        "switch_port": {
+          "$ref": "#/definitions/SwitchPort"
+        },
+        "interface_type": {
+          "$ref": "#/definitions/InterfaceType"
+        },
+        "connector_type": {
+          "$ref": "#/definitions/ConnectorType"
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          }
+        }
+      }
+    },
+    "IpAddress": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "network_address": {
+          "type": "string"
+        },
+        "int_address": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "interface_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "subnet_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "dns_name": {
+          "type": "string"
+        },
+        "inet_address": {
+          "type": "string"
+        },
+        "ip_type": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "subnet": {
+          "$ref": "#/definitions/Subnet"
+        },
+        "interface": {
+          "$ref": "#/definitions/Interface"
+        },
+        "outgoing_load_balancer_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerEntry"
+          }
+        },
+        "incoming_load_balancer_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerEntry"
+          }
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          }
+        }
+      }
+    },
+    "LoadBalancerEntry": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "virtual_ip_address_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "description": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "physical_ip_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device": {
+          "$ref": "#/definitions/Device"
+        },
+        "virtual_ip_address": {
+          "$ref": "#/definitions/IpAddress"
+        },
+        "physical_ip": {
+          "$ref": "#/definitions/IpAddress"
+        }
+      }
+    },
+    "Version": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "event": {
+          "type": "string"
+        },
+        "item_type": {
+          "type": "string"
+        },
+        "item_id": {
+          "type": "string"
+        },
+        "whodunnit": {
+          "type": "string"
+        },
+        "object_changes": {
+          "type": "string"
+        }
+      },
+      "description": "Get API Version"
+    },
+    "Duplex": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "switch_ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SwitchPort"
+          }
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interface"
+          }
+        }
+      }
+    },
+    "SwitchPort": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "port_number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "speed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "stp": {
+          "type": "boolean"
+        },
+        "direction": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "duplex_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "medium_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "zone_group_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "blade": {
+          "type": "string"
+        },
+        "switch_port_type_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "vlan_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "cc_frame_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pvlan_edge": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "in_use": {
+          "type": "boolean"
+        },
+        "ether_channel": {
+          "type": "boolean"
+        },
+        "blade_serial_number": {
+          "type": "string"
+        },
+        "trunk_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "stp_port_fast": {
+          "type": "boolean"
+        },
+        "vpc": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "wwn": {
+          "type": "string"
+        },
+        "connected_mac": {
+          "type": "string"
+        },
+        "connected_mac_updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "bottom_ru": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "supports_kvm": {
+          "type": "boolean"
+        },
+        "capability": {
+          "type": "string"
+        },
+        "interface_speed_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "port_channel": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device": {
+          "$ref": "#/definitions/Device"
+        },
+        "duplex": {
+          "$ref": "#/definitions/Duplex"
+        },
+        "medium": {
+          "$ref": "#/definitions/Medium"
+        },
+        "switch_port_type": {
+          "$ref": "#/definitions/SwitchPortType"
+        },
+        "interface_speed": {
+          "$ref": "#/definitions/InterfaceSpeed"
+        },
+        "vlan": {
+          "$ref": "#/definitions/Vlan"
+        },
+        "interface": {
+          "$ref": "#/definitions/Interface"
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          }
+        }
+      }
+    },
+    "Medium": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "switch_ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SwitchPort"
+          }
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interface"
+          }
+        }
+      }
+    },
+    "SwitchPortType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "switch_ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SwitchPort"
+          }
+        }
+      }
+    },
+    "InterfaceSpeed": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interface"
+          }
+        },
+        "switch_ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SwitchPort"
+          }
+        }
+      }
+    },
+    "InterfaceType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interface"
+          }
+        }
+      }
+    },
+    "ConnectorType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Interface"
+          }
+        }
+      }
+    },
+    "DataTransaction": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "transactable_type": {
+          "type": "string"
+        },
+        "transactable_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "data_cleanup_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "transactions": {
+          "type": "string"
+        },
+        "data_cleanup": {
+          "$ref": "#/definitions/DataCleanup"
+        }
+      }
+    },
+    "DataCleanup": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "data_transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataTransaction"
+          }
+        }
+      }
+    },
+    "VlanType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "vlans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Vlan"
+          }
+        }
+      }
+    },
+    "DeviceModel": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "vendor_name": {
+          "type": "string"
+        },
+        "manufacturer_name": {
+          "type": "string"
+        },
+        "integration_class": {
+          "type": "string"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "device_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceType"
+          }
+        },
+        "default_interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DefaultInterface"
+          }
+        }
+      }
+    },
+    "DeviceType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "networkable": {
+          "type": "boolean"
+        },
+        "routable": {
+          "type": "boolean"
+        },
+        "interfaceable": {
+          "type": "boolean"
+        },
+        "switchable": {
+          "type": "boolean"
+        },
+        "has_switch_ports": {
+          "type": "boolean"
+        },
+        "rackable": {
+          "type": "boolean"
+        },
+        "virtual_client": {
+          "type": "boolean"
+        },
+        "virtual_host": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device_category_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "has_blades": {
+          "type": "boolean"
+        },
+        "is_blade": {
+          "type": "boolean"
+        },
+        "is_load_balancer": {
+          "type": "boolean"
+        },
+        "is_patch_panel": {
+          "type": "boolean"
+        },
+        "extends_switch": {
+          "type": "boolean"
+        },
+        "esmt_device_category_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "esmt_device_type_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "esmt_device_class_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "device_models": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceModel"
+          }
+        },
+        "esmt_device_class": {
+          "$ref": "#/definitions/EsmtDeviceClass"
+        },
+        "esmt_device_type": {
+          "$ref": "#/definitions/EsmtDeviceType"
+        },
+        "esmt_device_category": {
+          "$ref": "#/definitions/EsmtDeviceCategory"
+        },
+        "device_category": {
+          "$ref": "#/definitions/DeviceCategory"
+        }
+      }
+    },
+    "EsmtDeviceClass": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceType"
+          }
+        }
+      }
+    },
+    "EsmtDeviceType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceType"
+          }
+        }
+      }
+    },
+    "EsmtDeviceCategory": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device_categories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceCategory"
+          }
+        },
+        "device_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceType"
+          }
+        }
+      }
+    },
+    "DeviceCategory": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "interfaceable": {
+          "type": "boolean"
+        },
+        "networkable": {
+          "type": "boolean"
+        },
+        "routable": {
+          "type": "boolean"
+        },
+        "switchable": {
+          "type": "boolean"
+        },
+        "has_switch_ports": {
+          "type": "boolean"
+        },
+        "rackable": {
+          "type": "boolean"
+        },
+        "virtual_host": {
+          "type": "boolean"
+        },
+        "virtual_client": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "has_blades": {
+          "type": "boolean"
+        },
+        "is_blade": {
+          "type": "boolean"
+        },
+        "is_load_balancer": {
+          "type": "boolean"
+        },
+        "is_patch_panel": {
+          "type": "boolean"
+        },
+        "extends_switch": {
+          "type": "boolean"
+        },
+        "device_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceType"
+          }
+        },
+        "esmt_device_type": {
+          "$ref": "#/definitions/EsmtDeviceType"
+        },
+        "esmt_device_category": {
+          "$ref": "#/definitions/EsmtDeviceCategory"
+        }
+      }
+    },
+    "DefaultInterface": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "device_model_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "direction": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "speed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "require_ip": {
+          "type": "boolean"
+        },
+        "require_switch_port": {
+          "type": "boolean"
+        },
+        "require_default_gateway": {
+          "type": "boolean"
+        },
+        "interface_type": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device_model": {
+          "$ref": "#/definitions/DeviceModel"
+        }
+      }
+    },
+    "Project": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        },
+        "system_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ciid": {
+          "type": "string"
+        },
+        "instance_id": {
+          "type": "string"
+        },
+        "reconciliation_identity": {
+          "type": "string"
+        },
+        "workbook_location": {
+          "type": "string"
+        },
+        "device_status_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_status_reason_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "event_logs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EventLog"
+          }
+        },
+        "sync_status": {
+          "$ref": "#/definitions/SyncStatus"
+        },
+        "device_status": {
+          "$ref": "#/definitions/DeviceStatus"
+        },
+        "device_status_reason": {
+          "$ref": "#/definitions/DeviceStatusReason"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "system": {
+          "$ref": "#/definitions/System"
+        }
+      }
+    },
+    "System": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ciid": {
+          "type": "string"
+        },
+        "instance_id": {
+          "type": "string"
+        },
+        "reconciliation_identity": {
+          "type": "string"
+        },
+        "device_status_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_status_reason_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "event_logs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EventLog"
+          }
+        },
+        "sync_status": {
+          "$ref": "#/definitions/SyncStatus"
+        },
+        "device_status": {
+          "$ref": "#/definitions/DeviceStatus"
+        },
+        "device_status_reason": {
+          "$ref": "#/definitions/DeviceStatusReason"
+        },
+        "projects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Project"
+          }
+        }
+      }
+    },
+    "ApplicationEnvironment": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "ciid": {
+          "type": "string"
+        },
+        "impact_scale": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "instance_id": {
+          "type": "string"
+        },
+        "reconciliation_identity": {
+          "type": "string"
+        },
+        "device_status_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_status_reason_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "event_logs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EventLog"
+          }
+        },
+        "sync_status": {
+          "$ref": "#/definitions/SyncStatus"
+        },
+        "device_status": {
+          "$ref": "#/definitions/DeviceStatus"
+        },
+        "device_status_reason": {
+          "$ref": "#/definitions/DeviceStatusReason"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        }
+      }
+    },
+    "OperatingSystem": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "ciid": {
+          "type": "string"
+        },
+        "device_status_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_status_reason_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "reconciliation_identity": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "instance_id": {
+          "type": "string"
+        },
+        "event_logs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EventLog"
+          }
+        },
+        "sync_status": {
+          "$ref": "#/definitions/SyncStatus"
+        },
+        "device_status": {
+          "$ref": "#/definitions/DeviceStatus"
+        },
+        "device_status_reason": {
+          "$ref": "#/definitions/DeviceStatusReason"
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        }
+      }
+    },
+    "HostNameReservation": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "host_name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device": {
+          "$ref": "#/definitions/Device"
+        }
+      }
+    },
+    "NatEntry": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "in_ip_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "out_ip_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "description": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device": {
+          "$ref": "#/definitions/Device"
+        },
+        "in_ip": {
+          "$ref": "#/definitions/IpAddress"
+        },
+        "out_ip": {
+          "$ref": "#/definitions/IpAddress"
+        }
+      }
+    },
+    "VmHostPool": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ciid": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        },
+        "clients": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Device"
+          }
+        }
+      }
+    },
+    "SubnetAssignment": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "device_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "subnet_id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "assigns_vips": {
+          "type": "boolean"
+        },
+        "assigns_physical_ips": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "device": {
+          "$ref": "#/definitions/Device"
+        },
+        "subnet": {
+          "$ref": "#/definitions/Subnet"
+        }
+      }
+    },
+    "NmdbQueryError": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "filters": {
+          "type": "string"
+        },
+        "rels": {
+          "type": "string"
+        }
+      },
+      "description": "GET Nmdb::Device Object."
+    },
+    "postV2Devices": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object",
+          "properties": {
+            "ciid": {
+              "type": "string"
+            },
+            "host_name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "zone_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "project_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "device_model_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "rack_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "device_status_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "device_status_reason_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "asset_tag": {
+              "type": "string"
+            },
+            "reconciliation_identity": {
+              "type": "string"
+            },
+            "serial_number": {
+              "type": "string"
+            },
+            "application_environment_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "pod_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "vm_capacity": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "switch_domain_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "blade_slot": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "blade_slots_required": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "blade_chassis_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "virtual_host_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "physical_host_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "blade_capacity": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "device_type_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "ru_required": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "primary_device_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "instance_id": {
+              "type": "string"
+            },
+            "operating_system_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "workbook_version": {
+              "type": "string"
+            },
+            "virtualized_on_vm_host_pool_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "contained_in_vm_host_pool_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "a_or_b": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "bottom_ru": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "host_name_reservation_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "interfaces_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "mac_address": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "require_ip": {
+                    "type": "boolean"
+                  },
+                  "require_switch_port": {
+                    "type": "boolean"
+                  },
+                  "require_default_gateway": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "media": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "vlan_direction_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "interface_speed_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "vlan_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "subnet_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "direction_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "duplex_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "medium_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "switch_port_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "pci_slot": {
+                    "type": "string"
+                  },
+                  "a_or_b": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "require_route_for_management": {
+                    "type": "boolean"
+                  },
+                  "require_route_for_getronics": {
+                    "type": "boolean"
+                  },
+                  "default_gateway_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "static_routes": {
+                    "type": "string"
+                  },
+                  "interface_type_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "connector_type_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "mac_addr": {
+                    "type": "string"
+                  },
+                  "ip_address_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "switch_ports_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "port_number": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "speed": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "stp": {
+                    "type": "boolean"
+                  },
+                  "direction": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "duplex_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "medium_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "zone_group_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "blade": {
+                    "type": "string"
+                  },
+                  "switch_port_type_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "vlan_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "cc_frame_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "pvlan_edge": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "in_use": {
+                    "type": "boolean"
+                  },
+                  "ether_channel": {
+                    "type": "boolean"
+                  },
+                  "blade_serial_number": {
+                    "type": "string"
+                  },
+                  "trunk_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "stp_port_fast": {
+                    "type": "boolean"
+                  },
+                  "vpc": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "wwn": {
+                    "type": "string"
+                  },
+                  "connected_mac": {
+                    "type": "string"
+                  },
+                  "connected_mac_updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "bottom_ru": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "supports_kvm": {
+                    "type": "boolean"
+                  },
+                  "capability": {
+                    "type": "string"
+                  },
+                  "interface_speed_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "port_channel": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "nat_entries_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "in_ip_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "out_ip_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "load_balancer_entries_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "virtual_ip_address_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "physical_ip_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "subnet_assignments_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "subnet_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "assigns_vips": {
+                    "type": "boolean"
+                  },
+                  "assigns_physical_ips": {
+                    "type": "boolean"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "body"
+      ],
+      "description": "Create Nmdb::Device Object."
+    },
+    "putV2Devices": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "ciid": {
+              "type": "string"
+            },
+            "host_name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "zone_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "project_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "device_model_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "rack_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "device_status_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "device_status_reason_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "asset_tag": {
+              "type": "string"
+            },
+            "reconciliation_identity": {
+              "type": "string"
+            },
+            "serial_number": {
+              "type": "string"
+            },
+            "application_environment_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "pod_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "vm_capacity": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "switch_domain_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "blade_slot": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "blade_slots_required": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "blade_chassis_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "virtual_host_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "physical_host_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "blade_capacity": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "device_type_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "ru_required": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "primary_device_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "instance_id": {
+              "type": "string"
+            },
+            "operating_system_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "workbook_version": {
+              "type": "string"
+            },
+            "virtualized_on_vm_host_pool_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "contained_in_vm_host_pool_id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "a_or_b": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "bottom_ru": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "interfaces_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "mac_address": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "require_ip": {
+                    "type": "boolean"
+                  },
+                  "require_switch_port": {
+                    "type": "boolean"
+                  },
+                  "require_default_gateway": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "media": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "vlan_direction_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "interface_speed_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "vlan_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "subnet_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "direction_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "duplex_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "medium_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "switch_port_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "pci_slot": {
+                    "type": "string"
+                  },
+                  "a_or_b": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "require_route_for_management": {
+                    "type": "boolean"
+                  },
+                  "require_route_for_getronics": {
+                    "type": "boolean"
+                  },
+                  "default_gateway_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "static_routes": {
+                    "type": "string"
+                  },
+                  "interface_type_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "connector_type_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "mac_addr": {
+                    "type": "string"
+                  },
+                  "ip_address_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "switch_ports_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "port_number": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "speed": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "stp": {
+                    "type": "boolean"
+                  },
+                  "direction": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "duplex_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "medium_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "zone_group_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "blade": {
+                    "type": "string"
+                  },
+                  "switch_port_type_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "vlan_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "cc_frame_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "pvlan_edge": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "in_use": {
+                    "type": "boolean"
+                  },
+                  "ether_channel": {
+                    "type": "boolean"
+                  },
+                  "blade_serial_number": {
+                    "type": "string"
+                  },
+                  "trunk_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "stp_port_fast": {
+                    "type": "boolean"
+                  },
+                  "vpc": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "wwn": {
+                    "type": "string"
+                  },
+                  "connected_mac": {
+                    "type": "string"
+                  },
+                  "connected_mac_updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "bottom_ru": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "supports_kvm": {
+                    "type": "boolean"
+                  },
+                  "capability": {
+                    "type": "string"
+                  },
+                  "interface_speed_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "port_channel": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "nat_entries_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "in_ip_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "out_ip_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "load_balancer_entries_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "virtual_ip_address_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "physical_ip_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "subnet_assignments_attributes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "device_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "subnet_id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "assigns_vips": {
+                    "type": "boolean"
+                  },
+                  "assigns_physical_ips": {
+                    "type": "boolean"
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "_destroy": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "body"
+      ],
+      "description": "Update Nmdb::Device Object."
+    }
+  }
+}

--- a/fixtures/enhancements/1624/gen-fixtures.sh
+++ b/fixtures/enhancements/1624/gen-fixtures.sh
@@ -1,0 +1,46 @@
+#! /bin/bash 
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+# A small utility to build fixture servers
+testcases="fixture-1624.json"
+for testcase in ${testcases} ; do
+    target=gen-${testcase%.json}
+    spec=./${testcase}
+    serverName="nrcodegen"
+    serverPackage="pkg/to/nrcodegen"
+    configureFile="${serverPackage}/configure_nrcodegen.go"
+    logfile=${testcase%.json}.log
+    rm -rf ${target}
+    mkdir ${target}
+    swagger generate server --spec ${spec} --name=${serverName} --target ${target} --output=${logfile} --server-package=${serverPackage}
+    if [[ $? != 0 ]] ; then
+        echo "Server generation failed for ${spec}"
+        exit 1
+    fi
+    echo "${spec}: Server generation OK"
+    
+    grep -Fq "${serverPackage}" ${target}/cmd/${serverName}"-server"/main.go
+    if [[ $? != 0 ]] ; then
+        echo "${spec}: imports using ServerPackage failed for ${spec}"
+        exit 1
+    fi
+    echo "${spec}: imports using ServerPackage OK"
+    
+    grep -Fxq "package ${serverName}" ${target}/${serverPackage}/configure_nrcodegen.go
+    if [[ $? != 0 ]] ; then
+        echo "${spec}: ServerPackage name failed for ${spec}"
+        exit 1
+    fi
+    echo "${spec}: ServerPackage name OK"
+
+    (cd ${target}/cmd/${serverName}"-server"; go build)
+    if [[ $? != 0 ]] ; then
+        echo "Server build failed for ${spec}"
+        exit 1
+    fi
+    echo "${spec}: Server build OK"
+    if [[ -n ${clean} ]] ; then 
+        rm -rf ${target}
+    fi
+done

--- a/generator/client.go
+++ b/generator/client.go
@@ -111,7 +111,7 @@ func GenerateClient(name string, modelNames, operationIDs []string, opts *GenOpt
 		APIPackage:        opts.LanguageOpts.MangleName(swag.ToFileName(opts.APIPackage), "api"),
 		ModelsPackage:     opts.LanguageOpts.MangleName(swag.ToFileName(opts.ModelPackage), "definitions"),
 		ServerPackage:     opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
-		Server:            opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
+		ServerImport:      opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
 		ClientPackage:     opts.LanguageOpts.MangleName(swag.ToFileName(opts.ClientPackage), "client"),
 		OperationsPackage: opts.LanguageOpts.MangleName(swag.ToFileName(opts.ClientPackage), "client"),
 		Principal:         opts.Principal,

--- a/generator/client.go
+++ b/generator/client.go
@@ -111,6 +111,7 @@ func GenerateClient(name string, modelNames, operationIDs []string, opts *GenOpt
 		APIPackage:        opts.LanguageOpts.MangleName(swag.ToFileName(opts.APIPackage), "api"),
 		ModelsPackage:     opts.LanguageOpts.MangleName(swag.ToFileName(opts.ModelPackage), "definitions"),
 		ServerPackage:     opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
+		Server:            opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
 		ClientPackage:     opts.LanguageOpts.MangleName(swag.ToFileName(opts.ClientPackage), "client"),
 		OperationsPackage: opts.LanguageOpts.MangleName(swag.ToFileName(opts.ClientPackage), "client"),
 		Principal:         opts.Principal,

--- a/generator/server_test.go
+++ b/generator/server_test.go
@@ -84,7 +84,7 @@ func testAppGenerator(t testing.TB, specPath, name string) (*appGenerator, error
 		APIPackage:      apiPackage,
 		ModelsPackage:   opts.LanguageOpts.MangleName(swag.ToFileName(opts.ModelPackage), "definitions"),
 		ServerPackage:   opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
-		Server:          opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
+		ServerImport:    opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
 		ClientPackage:   opts.LanguageOpts.MangleName(swag.ToFileName(opts.ClientPackage), "client"),
 		Principal:       opts.Principal,
 		DefaultScheme:   "http",

--- a/generator/server_test.go
+++ b/generator/server_test.go
@@ -84,6 +84,7 @@ func testAppGenerator(t testing.TB, specPath, name string) (*appGenerator, error
 		APIPackage:      apiPackage,
 		ModelsPackage:   opts.LanguageOpts.MangleName(swag.ToFileName(opts.ModelPackage), "definitions"),
 		ServerPackage:   opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
+		Server:          opts.LanguageOpts.MangleName(swag.ToFileName(opts.ServerPackage), "server"),
 		ClientPackage:   opts.LanguageOpts.MangleName(swag.ToFileName(opts.ClientPackage), "client"),
 		Principal:       opts.Principal,
 		DefaultScheme:   "http",

--- a/generator/support.go
+++ b/generator/support.go
@@ -140,7 +140,7 @@ func newAppGenerator(name string, modelNames, operationIDs []string, opts *GenOp
 		Package:           apiPackage,
 		APIPackage:        apiPackage,
 		ModelsPackage:     opts.LanguageOpts.MangleName(swag.ToFileName(opts.ModelPackage), "definitions"),
-		Server:            server,
+		ServerImport:      server,
 		ServerPackage:     serverPackage,
 		ClientPackage:     opts.LanguageOpts.MangleName(swag.ToFileName(opts.ClientPackage), "client"),
 		OperationsPackage: filepath.Join(server, apiPackage),
@@ -160,7 +160,7 @@ type appGenerator struct {
 	Package           string
 	APIPackage        string
 	ModelsPackage     string
-	Server            string
+	ServerImport      string
 	ServerPackage     string
 	ClientPackage     string
 	OperationsPackage string
@@ -274,7 +274,7 @@ func (a *appGenerator) GenerateSupport(ap *GenApp) error {
 	importPath := filepath.ToSlash(filepath.Join(baseImport, a.OperationsPackage))
 	app.DefaultImports = append(
 		app.DefaultImports,
-		filepath.ToSlash(filepath.Join(baseImport, a.Server)),
+		filepath.ToSlash(filepath.Join(baseImport, a.ServerImport)),
 		importPath,
 	)
 
@@ -704,10 +704,10 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 	}
 
 	var serverPackageName string
-	if strings.Contains(a.Server, "/") {
-		serverPackageName = a.GenOpts.LanguageOpts.MangleName(a.Server[strings.LastIndex(a.Server, "/")+1:], "server")
+	if strings.Contains(a.ServerImport, "/") {
+		serverPackageName = a.GenOpts.LanguageOpts.MangleName(a.ServerImport[strings.LastIndex(a.ServerImport, "/")+1:], "server")
 	} else {
-		serverPackageName = a.Server
+		serverPackageName = a.ServerImport
 	}
 
 	return GenApp{

--- a/generator/support.go
+++ b/generator/support.go
@@ -705,7 +705,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 
 	var serverPackageName string
 	if strings.Contains(a.Server, "/") {
-		serverPackageName = a.Server[strings.LastIndex(a.Server, "/")+1:]
+		serverPackageName = a.GenOpts.LanguageOpts.MangleName(a.Server[strings.LastIndex(a.Server, "/")+1:], "server")
 	} else {
 		serverPackageName = a.Server
 	}


### PR DESCRIPTION
example : `swagger generate server -f ./api/swagger/swagger.yaml -s pkg/srv`

`configure_srv.go` will have **srv** as package name (last part of **pkg/srv**)
Imports to operations will be like **[...]/pkg/srv/operations**

I added a test but I guess it won't be run for now and I'm not totally sure how I should reference it, from a go file or a script, like codegen-nonreg.sh