### PR TITLE
There is a panic when invalid schema of route/operation is used in spec generation. It should prevent it

### DIFF
--- a/scan/route_params.go
+++ b/scan/route_params.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-openapi/spec"
 	"strconv"
 	"strings"
+	"errors"
 )
 
 const (
@@ -98,6 +99,10 @@ func (s *setOpParams) Parse(lines []string) error {
 
 		key := strings.ToLower(strings.TrimSpace(kv[0]))
 		value := strings.TrimSpace(kv[1])
+
+		if current == nil {
+			return errors.New("invalid route/operation schema provided")
+		}
 
 		switch key {
 		case ParamDescriptionKey:

--- a/scan/route_params.go
+++ b/scan/route_params.go
@@ -1,10 +1,10 @@
 package scan
 
 import (
+	"errors"
 	"github.com/go-openapi/spec"
 	"strconv"
 	"strings"
-	"errors"
 )
 
 const (


### PR DESCRIPTION
When run 

swagger generate spec -o swagger.json 

i got follow issue

```
Rinats-MacBook-Pro:gomoona rinat$
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x118 pc=0x1603e4a]

goroutine 1 [running]:
github.com/go-swagger/go-swagger/scan.(*setOpParams).Parse(0xc42e2476e0, 0xc423b9fb00, 0x5, 0x8, 0xc423b9fb00, 0x0)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/scan/route_params.go:109 +0x29a
github.com/go-swagger/go-swagger/scan.(*tagParser).Parse(0xc4205cf310, 0xc423b9fb00, 0x5, 0x8, 0x0, 0xc423b9fb00)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/scan/scanner.go:558 +0x52
github.com/go-swagger/go-swagger/scan.(*sectionedParser).Parse(0xc4205cf9f0, 0xc42e247340, 0xc4205cf620, 0xd)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/scan/scanner.go:944 +0x7f4
github.com/go-swagger/go-swagger/scan.(*routesParser).Parse(0xc43bf5a5c0, 0xc4207fcf80, 0x16fe000, 0xc4277248d0, 0xc42c913d70, 0xc42c913da0, 0x0, 0x0)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/scan/routes.go:110 +0xc55
github.com/go-swagger/go-swagger/scan.(*appScanner).parseRoutes(0xc4304e0d00, 0xc4207fcf80, 0x0, 0x0)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/scan/scanner.go:423 +0xea
github.com/go-swagger/go-swagger/scan.(*appScanner).Parse(0xc4304e0d00, 0xc4304e0d00, 0x0, 0x0)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/scan/scanner.go:351 +0x27b
github.com/go-swagger/go-swagger/scan.Application(0x16c6e1c, 0x1, 0x0, 0x0, 0x16a230f, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/scan/scanner.go:186 +0x72
github.com/go-swagger/go-swagger/cmd/swagger/commands/generate.(*SpecFile).Execute(0xc420246160, 0xc4200b7f80, 0x0, 0x4, 0xc420246160, 0x1)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/cmd/swagger/commands/generate/spec.go:61 +0x196
github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags.(*Parser).ParseArgs(0xc420133b00, 0xc4200c0100, 0x4, 0x4, 0x1012518, 0x30, 0xc4200c4900, 0xc420475b00, 0xc420357800)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags/parser.go:316 +0x80b
github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags.(*Parser).Parse(0xc420133b00, 0x6, 0x179d2fe, 0x6, 0x0, 0x17e8067)
	/Users/rinat/dev/go/src/github.com/go-swagger/go-swagger/vendor/github.com/jessevdk/go-flags/parser.go:186 +0x71
```

and now:

```
swagger generate spec -o swagger.json
operation (nightSettings): invalid route schema provided
```

It was faced by mistaken misprint "swagger:route" when need to use "swagger:operation"