### PR TITLE
Use JSON for examples of type object

### DIFF
--- a/fixtures/goparsing/spec/api.go
+++ b/fixtures/goparsing/spec/api.go
@@ -55,6 +55,8 @@ type BookingResponse struct {
 		Booking  makeplans.Booking `json:"booking"`
 		Customer Customer          `json:"customer"`
 		Dates    DateRange         `json:"dates"`
+		// example: {"key": "value"}
+		Map map[string]string `json:"map"`
 	}
 }
 

--- a/fixtures/goparsing/spec/api_spec.json
+++ b/fixtures/goparsing/spec/api_spec.json
@@ -105,6 +105,14 @@
           },
           "dates":{
             "$ref":"#/definitions/DateRange"
+          },
+          "map": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "example": {"key": "value"},
+            "x-go-name": "Map"
           }
         }
       }

--- a/fixtures/goparsing/spec/api_spec.yml
+++ b/fixtures/goparsing/spec/api_spec.yml
@@ -80,3 +80,10 @@ responses:
           "$ref": "#/definitions/Customer"
         dates:
           "$ref": "#/definitions/DateRange"
+        map:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            key: value
+          x-go-name: Map

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -15,6 +15,7 @@
 package scan
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -307,6 +308,12 @@ func parseValueFromSchema(s string, schema *spec.SimpleSchema) (interface{}, err
 			return strconv.ParseBool(s)
 		case "number", "float64", "float32":
 			return strconv.ParseFloat(s, 64)
+		case "object":
+			var obj map[string]interface{}
+			if err := json.Unmarshal([]byte(s), &obj); err != nil {
+				return nil, err
+			}
+			return obj, nil
 		default:
 			return s, nil
 		}


### PR DESCRIPTION
The OpenAPI 2.0 spec allows examples to be any JSON value. Currently,
go-swagger supports most types (e.g. ints and strings), but not objects.
This adds support to parse object examples as JSON, allowing users to
document examples for maps.