### PR TITLE
chore: update vendor for performance

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -121,14 +121,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:40bdfd6462aa3addaa8d1a9c042503deffe5f4ff441224b258fe1376a12d9162"
+  digest = "1:abfbaaa212d1b2e50f62b9e546f4197bf2d2d97308db9b367d88c238a83774d9"
   name = "github.com/go-openapi/loads"
   packages = [
     ".",
     "fmts",
   ]
   pruneopts = ""
-  revision = "0362c6bf32fb5b266bde0f64fdc81092c7a599c7"
+  revision = "d72cd69e9468f55c6369c5481c3d011401728c72"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -121,14 +121,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5cafc6762b1b7fe5ba5dd290c087bab2f88abb9c93dd1d5ae1bc259952c0387e"
+  digest = "1:40bdfd6462aa3addaa8d1a9c042503deffe5f4ff441224b258fe1376a12d9162"
   name = "github.com/go-openapi/loads"
   packages = [
     ".",
     "fmts",
   ]
   pruneopts = ""
-  revision = "150d36912387ec2f607be674c5be309ddccc0eed"
+  revision = "0362c6bf32fb5b266bde0f64fdc81092c7a599c7"
 
 [[projects]]
   branch = "master"
@@ -166,11 +166,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:062de20b7d299ae95c902a5c472c4bc87a2f3ae707751fe155ecf640d99074b4"
+  digest = "1:52e268f92bc7adac47ca908335bfd9f90e010c492c59797031cf99ec1caff4e2"
   name = "github.com/go-openapi/swag"
   packages = ["."]
   pruneopts = ""
-  revision = "5899d5c5e619fda5fa86e14795a835f473ca284c"
+  revision = "a0a2ec671c17745100b0116b950a1cd55fd22552"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/go-openapi/loads/.golangci.yml
+++ b/vendor/github.com/go-openapi/loads/.golangci.yml
@@ -1,0 +1,22 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 30
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 4
+
+linters:
+  enable-all: true
+  disable:
+    - maligned
+    - lll
+    - gochecknoglobals
+    - gochecknoinits

--- a/vendor/github.com/go-openapi/loads/README.md
+++ b/vendor/github.com/go-openapi/loads/README.md
@@ -1,5 +1,7 @@
 # Loads OAI specs  [![Build Status](https://travis-ci.org/go-openapi/loads.svg?branch=master)](https://travis-ci.org/go-openapi/loads) [![codecov](https://codecov.io/gh/go-openapi/loads/branch/master/graph/badge.svg)](https://codecov.io/gh/go-openapi/loads) [![Slack Status](https://slackin.goswagger.io/badge.svg)](https://slackin.goswagger.io)
 
 [![license](http://img.shields.io/badge/license-Apache%20v2-orange.svg)](https://raw.githubusercontent.com/go-openapi/loads/master/LICENSE) [![GoDoc](https://godoc.org/github.com/go-openapi/loads?status.svg)](http://godoc.org/github.com/go-openapi/loads)
+[![GolangCI](https://golangci.com/badges/github.com/go-openapi/loads.svg)](https://golangci.com)
+[![Go Report Card](https://goreportcard.com/badge/github.com/go-openapi/loads)](https://goreportcard.com/report/github.com/go-openapi/loads)
 
-Loading of OAI specification documents from local or remote locations.
+Loading of OAI specification documents from local or remote locations. Supports JSON and YAML documents.

--- a/vendor/github.com/go-openapi/loads/doc.go
+++ b/vendor/github.com/go-openapi/loads/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package loads provides document loading methods for swagger (OAI) specifications.
+
+It is used by other go-openapi packages to load and run analysis on local or remote spec documents.
+
+*/
+package loads

--- a/vendor/github.com/go-openapi/loads/fmts/yaml_test.go
+++ b/vendor/github.com/go-openapi/loads/fmts/yaml_test.go
@@ -27,10 +27,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type failJSONMarhal struct {
+type failJSONMarshal struct {
 }
 
-func (f failJSONMarhal) MarshalJSON() ([]byte, error) {
+func (f failJSONMarshal) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("expected")
 }
 
@@ -48,7 +48,7 @@ func TestLoadHTTPBytes(t *testing.T) {
 
 	ts2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusOK)
-		rw.Write([]byte("the content"))
+		_, _ = rw.Write([]byte("the content"))
 	}))
 	defer ts2.Close()
 
@@ -65,7 +65,7 @@ name: a string value
 'y': some value
 `
 	var data yaml.MapSlice
-	yaml.Unmarshal([]byte(sd), &data)
+	_ = yaml.Unmarshal([]byte(sd), &data)
 
 	d, err := YAMLToJSON(data)
 	if assert.NoError(t, err) {
@@ -84,7 +84,8 @@ name: a string value
 
 	d, err = YAMLToJSON(data)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"1":"the int key value","name":"a string value","y":"some value","tag":{"name":"tag name"}}`, string(d))
+	assert.Equal(t, `{"1":"the int key value","name":"a string value","y":"some value","tag":{"name":"tag name"}}`,
+		string(d))
 
 	tag = yaml.MapSlice{{Key: true, Value: "bool tag name"}}
 	data = append(data[:len(data)-1], yaml.MapItem{Key: "tag", Value: tag})
@@ -106,8 +107,9 @@ name: a string value
 	assert.Error(t, err)
 	assert.Nil(t, d)
 
-	// _, err := yamlToJSON(failJSONMarhal{})
-	// assert.Error(t, err)
+	// test failure
+	_, err = YAMLToJSON(failJSONMarshal{})
+	assert.Error(t, err)
 
 	_, err = BytesToYAMLDoc([]byte("- name: hello\n"))
 	assert.Error(t, err)
@@ -142,7 +144,7 @@ func TestLoadStrategy(t *testing.T) {
 
 	ts2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusNotFound)
-		rw.Write([]byte("\n"))
+		_, _ = rw.Write([]byte("\n"))
 	}))
 	defer ts2.Close()
 	_, err = YAMLDoc(ts2.URL)
@@ -151,7 +153,7 @@ func TestLoadStrategy(t *testing.T) {
 
 var yamlPestoreServer = func(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusOK)
-	rw.Write([]byte(yamlPetStore))
+	_, _ = rw.Write([]byte(yamlPetStore))
 }
 
 func TestWithYKey(t *testing.T) {

--- a/vendor/github.com/go-openapi/loads/json_test.go
+++ b/vendor/github.com/go-openapi/loads/json_test.go
@@ -32,7 +32,7 @@ func TestLoadJSON(t *testing.T) {
 
 	ts2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusNotFound)
-		rw.Write([]byte("{}"))
+		_, _ = rw.Write([]byte("{}"))
 	}))
 	defer ts2.Close()
 	_, err = JSONSpec(ts2.URL)
@@ -41,7 +41,7 @@ func TestLoadJSON(t *testing.T) {
 
 var jsonPestoreServer = func(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusOK)
-	rw.Write([]byte(petstoreJSON))
+	_, _ = rw.Write([]byte(petstoreJSON))
 }
 
 const petstoreJSON = `{

--- a/vendor/github.com/go-openapi/loads/spec.go
+++ b/vendor/github.com/go-openapi/loads/spec.go
@@ -16,6 +16,7 @@ package loads
 
 import (
 	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -176,8 +177,8 @@ func Analyzed(data json.RawMessage, version string) (*Document, error) {
 		return nil, err
 	}
 
-	origsqspec := new(spec.Swagger)
-	if err := json.Unmarshal(raw, origsqspec); err != nil {
+	origsqspec, err := cloneSpec(swspec)
+	if err != nil {
 		return nil, err
 	}
 
@@ -276,4 +277,16 @@ func (d *Document) Pristine() *Document {
 // SpecFilePath returns the file path of the spec if one is defined
 func (d *Document) SpecFilePath() string {
 	return d.specFilePath
+}
+
+func cloneSpec(src *spec.Swagger) (*spec.Swagger, error) {
+	var b bytes.Buffer
+	if err := gob.NewEncoder(&b).Encode(src); err != nil {
+		return nil, err
+	}
+	var dst spec.Swagger
+	if err := gob.NewDecoder(&b).Decode(&dst); err != nil {
+		return nil, err
+	}
+	return &dst, nil
 }

--- a/vendor/github.com/go-openapi/loads/spec.go
+++ b/vendor/github.com/go-openapi/loads/spec.go
@@ -51,6 +51,9 @@ func init() {
 	loaders = defaultLoader
 	spec.PathLoader = loaders.Fn
 	AddLoader(swag.YAMLMatcher, swag.YAMLDoc)
+
+	gob.Register(map[string]interface{}{})
+	gob.Register([]interface{}{})
 }
 
 // AddLoader for a document
@@ -77,7 +80,7 @@ func JSONSpec(path string) (*Document, error) {
 		return nil, err
 	}
 	// convert to json
-	return Analyzed(json.RawMessage(data), "")
+	return Analyzed(data, "")
 }
 
 // Document represents a swagger spec document
@@ -121,9 +124,9 @@ func Spec(path string) (*Document, error) {
 				lastErr = err2
 				continue
 			}
-			doc, err := Analyzed(b, "")
-			if err != nil {
-				return nil, err
+			doc, err3 := Analyzed(b, "")
+			if err3 != nil {
+				return nil, err3
 			}
 			if doc != nil {
 				doc.specFilePath = path
@@ -253,6 +256,7 @@ func (d *Document) Raw() json.RawMessage {
 	return d.raw
 }
 
+// OrigSpec yields the original spec
 func (d *Document) OrigSpec() *spec.Swagger {
 	return d.origSpec
 }

--- a/vendor/github.com/go-openapi/loads/spec_test.go
+++ b/vendor/github.com/go-openapi/loads/spec_test.go
@@ -1,3 +1,17 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package loads
 
 import (
@@ -234,7 +248,7 @@ func BenchmarkAnalyzed(b *testing.B) {
     }`)...)
 	}
 
-  d = append(d, []byte(`
+	d = append(d, []byte(`
   },
   "definitions": {
     "Category": {
@@ -354,8 +368,8 @@ func BenchmarkAnalyzed(b *testing.B) {
   }
 }
 `)...)
-  rm := json.RawMessage(d)
-  b.ResetTimer()
+	rm := json.RawMessage(d)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := Analyzed(rm, "")
 		if err != nil {
@@ -364,7 +378,7 @@ func BenchmarkAnalyzed(b *testing.B) {
 	}
 }
 
-var YAMLSpec = `swagger: '2.0'
+const YAMLSpec = `swagger: '2.0'
 
 info:
   version: "1.0.0"
@@ -827,20 +841,20 @@ const PetStore20 = `{
 `
 
 const expectedExpanded = `
-{  
-   "produces":[  
+{
+   "produces":[
       "application/json",
       "plain/text"
    ],
-   "schemes":[  
+   "schemes":[
       "https",
       "http"
    ],
    "swagger":"2.0",
-   "info":{  
+   "info":{
       "description":"Something",
       "title":"Something",
-      "contact":{  
+      "contact":{
          "name":"Somebody",
          "url":"https://url.com",
          "email":"email@url.com"
@@ -849,49 +863,49 @@ const expectedExpanded = `
    },
    "host":"security.sonusnet.com",
    "basePath":"/api",
-   "paths":{  
-      "/whatnot":{  
-         "get":{  
+   "paths":{
+      "/whatnot":{
+         "get":{
             "description":"Get something",
-            "responses":{  
-               "200":{  
+            "responses":{
+               "200":{
                   "description":"The something",
-                  "schema":{  
+                  "schema":{
                      "description":"A collection of service events",
                      "type":"object",
-                     "properties":{  
-                        "page":{  
+                     "properties":{
+                        "page":{
                            "description":"A description of a paged result",
                            "type":"object",
-                           "properties":{  
-                              "page":{  
+                           "properties":{
+                              "page":{
                                  "description":"the page that was requested",
                                  "type":"integer"
                               },
-                              "page_items":{  
+                              "page_items":{
                                  "description":"the number of items per page requested",
                                  "type":"integer"
                               },
-                              "pages":{  
+                              "pages":{
                                  "description":"the total number of pages available",
                                  "type":"integer"
                               },
-                              "total_items":{  
+                              "total_items":{
                                  "description":"the total number of items available",
                                  "type":"integer",
                                  "format":"int64"
                               }
                            }
                         },
-                        "something":{  
+                        "something":{
                            "description":"Something",
                            "type":"object",
-                           "properties":{  
-                              "p1":{  
+                           "properties":{
+                              "p1":{
                                  "description":"A string",
                                  "type":"string"
                               },
-                              "p2":{  
+                              "p2":{
                                  "description":"An integer",
                                  "type":"integer"
                               }
@@ -900,50 +914,50 @@ const expectedExpanded = `
                      }
                   }
                },
-               "500":{  
+               "500":{
                   "description":"Oops"
                }
             }
          }
       }
    },
-   "definitions":{  
-      "Something":{  
+   "definitions":{
+      "Something":{
          "description":"A collection of service events",
          "type":"object",
-         "properties":{  
-            "page":{  
+         "properties":{
+            "page":{
                "description":"A description of a paged result",
                "type":"object",
-               "properties":{  
-                  "page":{  
+               "properties":{
+                  "page":{
                      "description":"the page that was requested",
                      "type":"integer"
                   },
-                  "page_items":{  
+                  "page_items":{
                      "description":"the number of items per page requested",
                      "type":"integer"
                   },
-                  "pages":{  
+                  "pages":{
                      "description":"the total number of pages available",
                      "type":"integer"
                   },
-                  "total_items":{  
+                  "total_items":{
                      "description":"the total number of items available",
                      "type":"integer",
                      "format":"int64"
                   }
                }
             },
-            "something":{  
+            "something":{
                "description":"Something",
                "type":"object",
-               "properties":{  
-                  "p1":{  
+               "properties":{
+                  "p1":{
                      "description":"A string",
                      "type":"string"
                   },
-                  "p2":{  
+                  "p2":{
                      "description":"An integer",
                      "type":"integer"
                   }
@@ -956,45 +970,45 @@ const expectedExpanded = `
 `
 
 const cascadeRefExpanded = `
-{ 
+{
   "swagger": "2.0",
-  "consumes":[  
+  "consumes":[
      "application/json"
   ],
-  "produces":[  
+  "produces":[
      "application/json"
   ],
-  "schemes":[  
+  "schemes":[
      "http"
   ],
-  "info":{  
+  "info":{
      "description":"recursively following JSON references",
      "title":"test 1",
-     "contact":{  
+     "contact":{
         "name":"Fred"
      },
      "version":"0.1.1"
   },
-  "paths":{  
-     "/getAll":{  
-        "get":{  
+  "paths":{
+     "/getAll":{
+        "get":{
            "operationId":"getAll",
-           "parameters":[  
-              {  
+           "parameters":[
+              {
                  "description":"max number of results",
                  "name":"a",
                  "in":"body",
-                 "schema":{  
+                 "schema":{
                     "type":"string"
                  }
               }
            ],
-           "responses":{  
-              "200":{  
+           "responses":{
+              "200":{
                  "description":"Success",
-                 "schema":{  
+                 "schema":{
                     "type":"array",
-                    "items":{  
+                    "items":{
                        "type":"string"
                     }
                  }
@@ -1003,13 +1017,13 @@ const cascadeRefExpanded = `
         }
      }
   },
-  "definitions":{  
-     "a":{  
+  "definitions":{
+     "a":{
         "type":"string"
      },
-     "b":{  
+     "b":{
         "type":"array",
-        "items":{  
+        "items":{
            "type":"string"
         }
      }

--- a/vendor/github.com/go-openapi/loads/spec_test.go
+++ b/vendor/github.com/go-openapi/loads/spec_test.go
@@ -2,6 +2,7 @@ package loads
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,306 @@ func TestFailsInvalidJSON(t *testing.T) {
 	_, err := Analyzed(json.RawMessage([]byte("{]")), "")
 
 	assert.Error(t, err)
+}
+
+func BenchmarkAnalyzed(b *testing.B) {
+	d := []byte(`{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "contact": {
+      "name": "Wordnik API Team",
+      "url": "http://developer.wordnik.com"
+    },
+    "license": {
+      "name": "Creative Commons 4.0 International",
+      "url": "http://creativecommons.org/licenses/by/4.0/"
+    }
+  },
+  "host": "petstore.swagger.wordnik.com",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "security": [
+          {
+            "basic": []
+          }
+        ],
+        "tags": [ "Pet Operations" ],
+        "operationId": "getAllPets",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "The status to filter by",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of results to return",
+            "type": "integer",
+						"format": "int64"
+          }
+        ],
+        "summary": "Finds all pets in the system",
+        "responses": {
+          "200": {
+            "description": "Pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "basic": []
+          }
+        ],
+        "tags": [ "Pet Operations" ],
+        "operationId": "createPet",
+        "summary": "Creates a new pet",
+        "consumes": ["application/x-yaml"],
+        "produces": ["application/x-yaml"],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "The Pet to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/newPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Created Pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }`)
+
+	for i := 0; i < 1000; i++ {
+		d = append(d, []byte(`,
+    "/pets/`)...)
+		d = strconv.AppendInt(d, int64(i), 10)
+		d = append(d, []byte(`": {
+      "delete": {
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "description": "Deletes the Pet by id",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [ "Pet Operations" ],
+        "operationId": "getPetById",
+        "summary": "Finds the pet by id",
+        "responses": {
+          "200": {
+            "description": "Pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of pet",
+          "required": true,
+          "type": "integer",
+          "format": "int64"
+        }
+      ]
+    }`)...)
+	}
+
+  d = append(d, []byte(`
+  },
+  "definitions": {
+    "Category": {
+      "id": "Category",
+      "properties": {
+        "id": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Pet": {
+      "id": "Pet",
+      "properties": {
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "id": {
+          "description": "unique identifier for the pet",
+          "format": "int64",
+          "maximum": 100.0,
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "photoUrls": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "status": {
+          "description": "pet status in the store",
+          "enum": [
+            "available",
+            "pending",
+            "sold"
+          ],
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "$ref": "#/definitions/Tag"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ]
+    },
+    "newPet": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Pet"
+        },
+        {
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "Tag": {
+      "id": "Tag",
+      "properties": {
+        "id": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "consumes": [
+    "application/json",
+    "application/xml"
+  ],
+  "produces": [
+    "application/json",
+    "application/xml",
+    "text/plain",
+    "text/html"
+  ],
+  "securityDefinitions": {
+    "basic": {
+      "type": "basic"
+    },
+    "apiKey": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "X-API-KEY"
+    }
+  }
+}
+`)...)
+  rm := json.RawMessage(d)
+  b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Analyzed(rm, "")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 var YAMLSpec = `swagger: '2.0'

--- a/vendor/github.com/go-openapi/swag/.golangci.yml
+++ b/vendor/github.com/go-openapi/swag/.golangci.yml
@@ -18,3 +18,5 @@ linters:
   disable:
     - maligned
     - lll
+    - gochecknoinits
+    - gochecknoglobals

--- a/vendor/github.com/go-openapi/swag/util_test.go
+++ b/vendor/github.com/go-openapi/swag/util_test.go
@@ -67,6 +67,25 @@ func TestToGoName(t *testing.T) {
 	}
 }
 
+func BenchmarkToGoName(b *testing.B) {
+	samples := []string{
+		"sample text",
+		"sample-text",
+		"sample_text",
+		"sampleText",
+		"sample 2 Text",
+		"findThingById",
+		"日本語sample 2 Text",
+		"日本語findThingById",
+		"findTHINGSbyID",
+	}
+	for i := 0; i < b.N; i++ {
+		for _, s := range samples {
+			ToGoName(s)
+		}
+	}
+}
+
 func TestContainsStringsCI(t *testing.T) {
 	list := []string{"hello", "world", "and", "such"}
 

--- a/vendor/github.com/go-openapi/swag/yaml.go
+++ b/vendor/github.com/go-openapi/swag/yaml.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
-
 	yaml "gopkg.in/yaml.v2"
 )
 

--- a/vendor/github.com/go-openapi/swag/yaml_test.go
+++ b/vendor/github.com/go-openapi/swag/yaml_test.go
@@ -20,9 +20,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
 )
 
 /* currently unused:


### PR DESCRIPTION
improve `swagger generate server` performance on a large schema.

related pull requests:

* https://github.com/go-openapi/swag/pull/25
* https://github.com/go-openapi/loads/pull/19

before:
![profile001](https://user-images.githubusercontent.com/1029249/48658213-37a45f00-ea81-11e8-8a08-ac7587878a3b.png)

after:
![profile008](https://user-images.githubusercontent.com/1029249/48658204-1cd1ea80-ea81-11e8-8d3d-450db1d845c0.png)
