### PR TITLE
Handle array examples; document Example usage

### DIFF
--- a/docs/use/spec/model.md
+++ b/docs/use/spec/model.md
@@ -32,6 +32,7 @@ Annotation | Description
 **Unique** | when set to true the slice can only contain unique items
 **Required** | when set to true this value needs to be set on the schema
 **Read Only** | when set to true this value will be marked as read-only and is not required in request bodies
+**Example** | an example value, parsed as the field's type<br/>(objects and slices are parsed as JSON)
 
 For slice properties there are also items to be defined. This might be a nested collection, for indicating nesting
 level the value is a 0-based index, so items.minLength is the same as items.0.minLength
@@ -74,6 +75,7 @@ type User struct {
 	// the email address for this user
 	//
 	// required: true
+        // example: user@provider.net
 	Email strfmt.Email `json:"login"`
 
 	// the friends for this user
@@ -109,6 +111,7 @@ definitions:
         type: string
         format: email
         x-go-name: Email
+        example: user@provider.net
       friends:
         description: the friends for this user
         type: array

--- a/docs/use/spec/model.md
+++ b/docs/use/spec/model.md
@@ -75,7 +75,7 @@ type User struct {
 	// the email address for this user
 	//
 	// required: true
-        // example: user@provider.net
+	// example: user@provider.net
 	Email strfmt.Email `json:"login"`
 
 	// the friends for this user

--- a/docs/use/spec/params.md
+++ b/docs/use/spec/params.md
@@ -39,6 +39,7 @@ Annotation | Format
 **Maximum items** | the maximum number of items a slice can have
 **Unique** | when set to true the slice can only contain unique items
 **Required** | when set to true this value needs to be present in the request
+**Example** | an example value, parsed as the field's type<br/>(objects and slices are parsed as JSON)
 
 For slice properties there are also items to be defined. This might be a nested collection, for indicating nesting
 level the value is a 0-based index, so items.minLength is the same as items.0.minLength
@@ -74,6 +75,7 @@ type BarSliceParam struct {
 	// items.items.items.pattern: \w+
 	// collection format: pipe
 	// in: query
+        // example: [[["bar_000"]]]
 	BarSlice [][][]string `json:"bar_slice"`
 }
 ```
@@ -94,6 +96,8 @@ operations:
           unique: true
           collectionFormat: pipe
           type: array
+          example:
+            - - - "bar_000"
           items:
             type: array
             maxItems: 9
@@ -117,6 +121,8 @@ operations:
           unique: true
           collectionFormat: pipe
           type: array
+          example:
+            - - - "bar_000"
           items:
             type: array
             maxItems: 9

--- a/docs/use/spec/params.md
+++ b/docs/use/spec/params.md
@@ -75,7 +75,7 @@ type BarSliceParam struct {
 	// items.items.items.pattern: \w+
 	// collection format: pipe
 	// in: query
-        // example: [[["bar_000"]]]
+	// example: [[["bar_000"]]]
 	BarSlice [][][]string `json:"bar_slice"`
 }
 ```

--- a/docs/use/spec/response.md
+++ b/docs/use/spec/response.md
@@ -15,6 +15,7 @@ swagger:response [?response name]
 
 Annotation | Description
 -----------|------------
+**In** | where to find the field
 **Collection Format** | when a slice the formatter for the collection when serialized on the request
 **Maximum** | specifies the maximum a number or integer value can have
 **Minimum** | specifies the minimum a number or integer value can have
@@ -25,6 +26,7 @@ Annotation | Description
 **Minimum items** | the minimum number of items a slice needs to have
 **Maximum items** | the maximum number of items a slice can have
 **Unique** | when set to true the slice can only contain unique items
+**Example** | an example value, parsed as the field's type<br/>(objects and slices are parsed as JSON)
 
 For slice properties there are also items to be defined. This might be a nested collection, for indicating nesting
 level the value is a 0-based index, so items.minLength is the same as items.0.minLength
@@ -53,6 +55,7 @@ type ValidationError struct {
 		// The validation message
 		//
 		// Required: true
+		// Example: Expected type int
 		Message string
 		// An optional field name to which this validation applies
 		FieldName string
@@ -76,6 +79,7 @@ responses:
         Message:
           type: string
           description: The validation message
+          example: Expected type int
         FieldName:
           type: string
           description: an optional field name to which this validation applies

--- a/fixtures/goparsing/spec/api.go
+++ b/fixtures/goparsing/spec/api.go
@@ -57,6 +57,8 @@ type BookingResponse struct {
 		Dates    DateRange         `json:"dates"`
 		// example: {"key": "value"}
 		Map map[string]string `json:"map"`
+		// example: [1, 2]
+		Slice []int `json:"slice"`
 	}
 }
 

--- a/fixtures/goparsing/spec/api_spec.json
+++ b/fixtures/goparsing/spec/api_spec.json
@@ -113,6 +113,18 @@
             },
             "example": {"key": "value"},
             "x-go-name": "Map"
+          },
+          "slice": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "x-go-name": "Slice",
+            "example": [
+              1,
+              2
+            ]
           }
         }
       }

--- a/fixtures/goparsing/spec/api_spec.yml
+++ b/fixtures/goparsing/spec/api_spec.yml
@@ -87,3 +87,12 @@ responses:
           example:
             key: value
           x-go-name: Map
+        slice:
+          type: array
+          items:
+            type: integer
+            format: int64
+          x-go-name: Slice
+          example:
+            - 1
+            - 2

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -311,13 +311,15 @@ func parseValueFromSchema(s string, schema *spec.SimpleSchema) (interface{}, err
 		case "object":
 			var obj map[string]interface{}
 			if err := json.Unmarshal([]byte(s), &obj); err != nil {
-				return nil, err
+				// If we can't parse it, just return the string.
+				return s, nil
 			}
 			return obj, nil
 		case "array":
 			var slice []interface{}
 			if err := json.Unmarshal([]byte(s), &slice); err != nil {
-				return nil, err
+				// If we can't parse it, just return the string.
+				return s, nil
 			}
 			return slice, nil
 		default:

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -314,6 +314,12 @@ func parseValueFromSchema(s string, schema *spec.SimpleSchema) (interface{}, err
 				return nil, err
 			}
 			return obj, nil
+		case "array":
+			var slice []interface{}
+			if err := json.Unmarshal([]byte(s), &slice); err != nil {
+				return nil, err
+			}
+			return slice, nil
 		default:
 			return s, nil
 		}


### PR DESCRIPTION
I previously added JSON parsing for examples on object types; this adds
it for array types. It also adds basic documentation for Example.