### PR TITLE
Fix paths when looking for packages in vendor dir

### DIFF
--- a/scan/schema.go
+++ b/scan/schema.go
@@ -940,7 +940,7 @@ func (scp *schemaParser) packageForSelector(gofile *ast.File, expr ast.Expr) (*l
 		}
 		for _, info := range scp.program.AllPackages {
 			n := info.String()
-			path := "/vendor/" + selPath
+			path := "vendor/" + selPath
 			if strings.HasSuffix(n, path) {
 				pkg = scp.program.Package(n)
 				return pkg, nil


### PR DESCRIPTION
Was hitting `can't determine selector path from ...` error when trying to use a field from a vendored import path, this fixed the issue