### PR TITLE
Check that only a single parameter is passed.

### DIFF
--- a/cmd/swagger/commands/expand.go
+++ b/cmd/swagger/commands/expand.go
@@ -24,8 +24,8 @@ type ExpandSpec struct {
 
 // Execute expands the spec
 func (c *ExpandSpec) Execute(args []string) error {
-	if len(args) == 0 {
-		return errors.New("The validate command requires the swagger document url to be specified")
+	if len(args) != 1 {
+		return errors.New("The expand command requires the single swagger document url to be specified")
 	}
 
 	swaggerDoc := args[0]

--- a/cmd/swagger/commands/flatten.go
+++ b/cmd/swagger/commands/flatten.go
@@ -19,10 +19,10 @@ type FlattenSpec struct {
 	generate.FlattenCmdOptions
 }
 
-// Execute expands the spec
+// Execute flattens the spec
 func (c *FlattenSpec) Execute(args []string) error {
-	if len(args) == 0 {
-		return errors.New("The validate command requires the swagger document url to be specified")
+	if len(args) != 1 {
+		return errors.New("The flatten command requires the single swagger document url to be specified")
 	}
 
 	swaggerDoc := args[0]


### PR DESCRIPTION
It took me some time to figure out why `flatten` does not work for me.