### PR TITLE
Added --skip-validators

### DIFF
--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -32,6 +32,7 @@ type Client struct {
 	DefaultProduces string   `long:"default-produces" description:"the default mime type that API operations produce" default:"application/json"`
 	SkipModels      bool     `long:"skip-models" description:"no models will be generated when this flag is specified"`
 	SkipOperations  bool     `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
+	NoValidators    bool     `long:"skip-validators" description:"no validators will be generated when this flag is specified"`
 	DumpData        bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
 	SkipValidation  bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
 }
@@ -49,7 +50,7 @@ func (c *Client) getOpts() (*generator.GenOpts, error) {
 		DefaultScheme:     c.DefaultScheme,
 		DefaultProduces:   c.DefaultProduces,
 		IncludeModel:      !c.SkipModels,
-		IncludeValidator:  !c.SkipModels,
+		IncludeValidator:  !c.NoValidators,
 		IncludeHandler:    !c.SkipOperations,
 		IncludeParameters: !c.SkipOperations,
 		IncludeResponses:  !c.SkipOperations,

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -24,6 +24,7 @@ type Model struct {
 	shared
 	Name           []string `long:"name" short:"n" description:"the model to generate"`
 	NoStruct       bool     `long:"skip-struct" description:"when present will not generate the model struct"`
+	NoValidators   bool     `long:"skip-validators" description:"when present will not generate the model Validate() and supporting functions"`
 	DumpData       bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
 	SkipValidation bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
 }
@@ -48,6 +49,7 @@ func (m *Model) Execute(args []string) error {
 		SkipOperations: true,
 		SkipModels:     m.NoStruct,
 		SkipValidation: m.SkipValidation,
+		NoValidators:   m.NoValidators,
 	}
 	return s.Execute(args)
 }

--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -30,6 +30,7 @@ type Operation struct {
 	DefaultScheme  string   `long:"default-scheme" description:"the default scheme for this API" default:"http"`
 	NoHandler      bool     `long:"skip-handler" description:"when present will not generate an operation handler"`
 	NoStruct       bool     `long:"skip-parameters" description:"when present will not generate the parameter model struct"`
+	NoValidators   bool     `long:"skip-validators" description:"when present will not generate the Validate() and related functions"`
 	NoResponses    bool     `long:"skip-responses" description:"when present will not generate the response model struct"`
 	NoURLBuilder   bool     `long:"skip-url-builder" description:"when present will not generate a URL builder"`
 	DumpData       bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
@@ -52,6 +53,7 @@ func (o *Operation) getOpts() (*generator.GenOpts, error) {
 		IncludeResponses:  !o.NoResponses,
 		IncludeParameters: !o.NoStruct,
 		IncludeURLBuilder: !o.NoURLBuilder,
+		IncludeValidator:  !o.NoValidators,
 		Tags:              o.Tags,
 		ValidateSpec:      !o.SkipValidation,
 	}, nil

--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	Principal              string   `long:"principal" short:"P" description:"the model to use for the security principal"`
 	DefaultScheme          string   `long:"default-scheme" description:"the default scheme for this API" default:"http"`
 	Models                 []string `long:"model" short:"M" description:"specify a model to include, repeat for multiple"`
+	NoValidators           bool     `long:"skip-validators" description:"no validators will be generated when this flag is specified"`
 	SkipModels             bool     `long:"skip-models" description:"no models will be generated when this flag is specified"`
 	SkipOperations         bool     `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
 	SkipSupport            bool     `long:"skip-support" description:"no supporting files will be generated when this flag is specified"`
@@ -59,7 +60,7 @@ func (s *Server) getOpts() (*generator.GenOpts, error) {
 		Principal:              s.Principal,
 		DefaultScheme:          s.DefaultScheme,
 		IncludeModel:           !s.SkipModels,
-		IncludeValidator:       !s.SkipModels,
+		IncludeValidator:       !s.NoValidators,
 		IncludeHandler:         !s.SkipOperations,
 		IncludeParameters:      !s.SkipOperations,
 		IncludeResponses:       !s.SkipOperations,

--- a/generator/client.go
+++ b/generator/client.go
@@ -150,7 +150,6 @@ func (c *clientGenerator) Generate() error {
 	if c.GenOpts.IncludeModel {
 		for _, mod := range app.Models {
 			modCopy := mod
-			modCopy.IncludeValidator = true
 			if !mod.IsStream {
 				if err := c.GenOpts.renderDefinition(&modCopy); err != nil {
 					return err

--- a/generator/support.go
+++ b/generator/support.go
@@ -218,7 +218,6 @@ func (a *appGenerator) Generate() error {
 		log.Printf("rendering %d models", len(app.Models))
 		for _, mod := range app.Models {
 			modCopy := mod
-			modCopy.IncludeValidator = true // a.GenOpts.IncludeValidator
 			modCopy.IncludeModel = true
 			if err := a.GenOpts.renderDefinition(&modCopy); err != nil {
 				return err


### PR DESCRIPTION
Added a --skip-validators to "generate models|client|server" commands, so generated code does not contain "Validate()" function. 

This allows to generate significantly simpler code, and allows easier extraction of dependencies for generated code.