### PR TITLE
Generate properties with x-order above ones without

### DIFF
--- a/fixtures/codegen/x-order.yml
+++ b/fixtures/codegen/x-order.yml
@@ -70,6 +70,18 @@ definitions:
   sessionData:
     type: object
     properties:
+      aaa:
+        type: string
+        format: string
+        description: ZZZ
+      bbb:
+        type: string
+        format: string
+        description: AAA
+      zzz:
+        type: string
+        format: string
+        description: BBB
       sessionId:
         x-order: 0
         type: string

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -2438,8 +2438,14 @@ func TestGenerateModel_Xorder(t *testing.T) {
 					foundDeviceID := strings.Index(res, "DeviceID")
 					foundSessionID := strings.Index(res, "SessionID")
 					foundUMain := strings.Index(res, "UMain")
+					foundAaa := strings.Index(res, "Aaa")
+					foundBbb := strings.Index(res, "Bbb")
+					foundZzz := strings.Index(res, "Zzz")
 					assert.True(t, foundSessionID < foundDeviceID)
 					assert.True(t, foundSessionID < foundUMain)
+					assert.True(t, foundUMain < foundAaa)
+					assert.True(t, foundAaa < foundBbb)
+					assert.True(t, foundBbb < foundZzz)
 				}
 			}
 		}

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -95,13 +95,25 @@ type GenSchema struct {
 func (g GenSchemaList) Len() int      { return len(g) }
 func (g GenSchemaList) Swap(i, j int) { g[i], g[j] = g[j], g[i] }
 func (g GenSchemaList) Less(i, j int) bool {
-	a, ok := g[i].Extensions[xOrder].(float64)
-	if ok {
-		b, ok := g[j].Extensions[xOrder].(float64)
-		if ok {
-			return a < b
-		}
+	a, okA := g[i].Extensions[xOrder].(float64)
+	b, okB := g[j].Extensions[xOrder].(float64)
+
+	// If both properties have x-order defined, then the one with lower x-order is smaller
+	if okA && okB {
+		return a < b
 	}
+
+	// If only the first property has x-order defined, then it is smaller
+	if okA {
+		return true
+	}
+
+	// If only the second property has x-order defined, then it is smaller
+	if okB {
+		return false
+	}
+
+	// If neither property has x-order defined, then the one with lower lexicographic name is smaller
 	return g[i].Name < g[j].Name
 }
 


### PR DESCRIPTION
Currently if only some properties define x-order, they will potentially be generated between the others that don't because the current sorting comparator takes x-order into account only if both compared properties have it.