### PR TITLE
update go-swagger live playground

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - command: swagger validate examples/generated/swagger.json


### PR DESCRIPTION
Hello! In #1870 we added an online playground for `go-swagger` to the `README.md`, and it seems that it has become quite popular.

In this pull request, I suggest configuring the `go-swagger` live demo to automatically run this command in Gitpod's terminal on startup:

```
swagger validate examples/generated/swagger.json
```

The goal is to show users an example of how they can try `go-swagger`.