### PR TITLE
x-go-type: if no imports are specified, assume that the referred type is inside the same package

### DIFF
--- a/generator/types.go
+++ b/generator/types.go
@@ -153,7 +153,13 @@ func knownDefGoType(def string, schema spec.Schema, clear func(string) string) (
 	}
 	xt := v.(map[string]interface{})
 	t := xt["type"].(string)
-	imp := xt["import"].(map[string]interface{})
+	impIface, ok := xt["import"]
+
+	if !ok {
+		return t, "", ""
+	}
+
+	imp := impIface.(map[string]interface{})
 	pkg := imp["package"].(string)
 	al, ok := imp["alias"]
 	var alias string


### PR DESCRIPTION
Currently there is no way to set x-go-type to another generated type.