### PR TITLE
support keep spec properties order

### DIFF
--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -41,6 +41,7 @@ type Server struct {
 	CompatibilityMode      string   `long:"compatibility-mode" description:"the compatibility mode for the tls server" default:"modern" choice:"modern" choice:"intermediate"`
 	SkipValidation         bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
 	RegenerateConfigureAPI bool     `long:"regenerate-configureapi" description:"Force regeneration of configureapi.go"`
+	KeepSpecOrder          bool     `long:"keep-spec-order" description:"Keep schema properties order identical to spec file"`
 }
 
 func (s *Server) getOpts() (*generator.GenOpts, error) {
@@ -66,6 +67,7 @@ func (s *Server) getOpts() (*generator.GenOpts, error) {
 		IncludeURLBuilder:      !s.SkipOperations,
 		IncludeMain:            !s.ExcludeMain,
 		IncludeSupport:         !s.SkipSupport,
+		PropertiesSpecOrder:    s.KeepSpecOrder,
 		ValidateSpec:           !s.SkipValidation,
 		ExcludeSpec:            s.ExcludeSpec,
 		Template:               s.Template,

--- a/fixtures/codegen/keep-spec-order.yml
+++ b/fixtures/codegen/keep-spec-order.yml
@@ -1,0 +1,33 @@
+swagger: '2.0'
+info:
+  description: Test for keep spec order
+  version: 0.0.1
+  title: Test for keep spec order
+schemes:
+  - http
+paths:
+  /keep/order:
+    get:
+      summary: Test for keep spec order
+      description: Test for keep spec order
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/abctype'
+
+definitions:
+  abctype:
+    type: object
+    properties:
+      ccc:
+        type: string
+      bbb:
+        type: string
+      aaa:
+        type: string
+

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -540,20 +540,21 @@ type SectionOpts struct {
 
 // GenOpts the options for the generator
 type GenOpts struct {
-	IncludeModel      bool
-	IncludeValidator  bool
-	IncludeHandler    bool
-	IncludeParameters bool
-	IncludeResponses  bool
-	IncludeURLBuilder bool
-	IncludeMain       bool
-	IncludeSupport    bool
-	ExcludeSpec       bool
-	DumpData          bool
-	ValidateSpec      bool
-	FlattenOpts       *analysis.FlattenOpts
-	IsClient          bool
-	defaultsEnsured   bool
+	IncludeModel        bool
+	IncludeValidator    bool
+	IncludeHandler      bool
+	IncludeParameters   bool
+	IncludeResponses    bool
+	IncludeURLBuilder   bool
+	IncludeMain         bool
+	IncludeSupport      bool
+	ExcludeSpec         bool
+	DumpData            bool
+	ValidateSpec        bool
+	FlattenOpts         *analysis.FlattenOpts
+	IsClient            bool
+	defaultsEnsured     bool
+	PropertiesSpecOrder bool
 
 	Spec                   string
 	APIPackage             string


### PR DESCRIPTION
This PR solves issue #125 (Keep object's parameters order as specified in swagger spec definition).

Before loading the spec , if argument--keep-spec-order exists , it will inject x-order attribute to each property which is equal to its position in the spec file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-swagger/go-swagger/1939)
<!-- Reviewable:end -->
