### PR TITLE
scan: proper parse for numeric elements (future validation pass)

### DIFF
--- a/fixtures/goparsing/classification/operations/noparams.go
+++ b/fixtures/goparsing/classification/operations/noparams.go
@@ -153,6 +153,19 @@ type NoParams struct {
 	// in: query
 	Category string `json:"category"`
 
+	// Type of this model
+	//
+	// enum: 1,3,5
+	// default: 1
+	// in: query
+	Type int `json:"type"`
+
+	// This is mix in enum. And actually on output should be valid form where int will be int and
+	// string will also be presented.
+	//
+	// enum: 1,bar,none
+	BadEnum int `json:"bad_type"`
+
 	// a FooSlice has foos which are strings
 	//
 	// min items: 3

--- a/fixtures/goparsing/classification/operations/noparams.go
+++ b/fixtures/goparsing/classification/operations/noparams.go
@@ -163,8 +163,9 @@ type NoParams struct {
 	// This is mix in enum. And actually on output should be valid form where int will be int and
 	// string will also be presented.
 	//
-	// enum: 1,bar,none
-	BadEnum int `json:"bad_type"`
+	// enum: 1,rsq,qaz
+	// in: query
+	BadEnum int `json:"bad_enum"`
 
 	// a FooSlice has foos which are strings
 	//

--- a/scan/parameters.go
+++ b/scan/parameters.go
@@ -114,12 +114,7 @@ func (sv paramValidations) SetPattern(val string)          { sv.current.Pattern 
 func (sv paramValidations) SetUnique(val bool)             { sv.current.UniqueItems = val }
 func (sv paramValidations) SetCollectionFormat(val string) { sv.current.CollectionFormat = val }
 func (sv paramValidations) SetEnum(val string) {
-	list := strings.Split(val, ",")
-	interfaceSlice := make([]interface{}, len(list))
-	for i, d := range list {
-		interfaceSlice[i] = d
-	}
-	sv.current.Enum = interfaceSlice
+	sv.current.Enum = parseEnum(val, &spec.SimpleSchema{Type: sv.current.Type, Format: sv.current.Format})
 }
 func (sv paramValidations) SetDefault(val interface{}) { sv.current.Default = val }
 func (sv paramValidations) SetExample(val interface{}) { sv.current.Example = val }
@@ -145,12 +140,7 @@ func (sv itemsValidations) SetPattern(val string)          { sv.current.Pattern 
 func (sv itemsValidations) SetUnique(val bool)             { sv.current.UniqueItems = val }
 func (sv itemsValidations) SetCollectionFormat(val string) { sv.current.CollectionFormat = val }
 func (sv itemsValidations) SetEnum(val string) {
-	list := strings.Split(val, ",")
-	interfaceSlice := make([]interface{}, len(list))
-	for i, d := range list {
-		interfaceSlice[i] = d
-	}
-	sv.current.Enum = interfaceSlice
+	sv.current.Enum = parseEnum(val, &spec.SimpleSchema{Type: sv.current.Type, Format: sv.current.Format})
 }
 func (sv itemsValidations) SetDefault(val interface{}) { sv.current.Default = val }
 func (sv itemsValidations) SetExample(val interface{}) { sv.current.Example = val }

--- a/scan/parameters_test.go
+++ b/scan/parameters_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	gcBadEnum = "bad_enum"
+)
+
 func TestScanFileParam(t *testing.T) {
 	docFile := "../fixtures/goparsing/classification/operations/noparams.go"
 	fileTree, err := goparser.ParseFile(classificationProg.Fset, docFile, nil, goparser.ParseComments)
@@ -139,7 +143,7 @@ func TestParamsParser(t *testing.T) {
 
 	op, okParam := noParamOps["someOperation"]
 	assert.True(t, okParam)
-	assert.Len(t, op.Parameters, 8)
+	assert.Len(t, op.Parameters, 10)
 
 	for _, param := range op.Parameters {
 		switch param.Name {
@@ -199,10 +203,12 @@ func TestParamsParser(t *testing.T) {
 		case "type":
 			assert.Equal(t, "Type of this model", param.Description)
 			assert.Equal(t, "query", param.In)
-			assert.Equal(t, "int", param.Type)
+			assert.Equal(t, "integer", param.Type)
 			assert.EqualValues(t, []interface{}{1, 3, 5}, param.Enum, "%s enum values are incorrect", param.Name)
-		case "bad_type":
-			assert.EqualValues(t, []interface{}{1, "bar", "none"}, param.Enum, "%s enum values are incorrect", param.Name)
+		case gcBadEnum:
+			assert.Equal(t, "query", param.In)
+			assert.Equal(t, "integer", param.Type)
+			assert.EqualValues(t, []interface{}{1, "rsq", "qaz"}, param.Enum, "%s enum values are incorrect", param.Name)
 		case "foo_slice":
 			assert.Equal(t, "a FooSlice has foos which are strings", param.Description)
 			assert.Equal(t, "FooSlice", param.Extensions["x-go-name"])
@@ -296,7 +302,7 @@ func TestParamsParser(t *testing.T) {
 	// assert that the order of the parameters is maintained
 	order, ok := noParamOps["anotherOperation"]
 	assert.True(t, ok)
-	assert.Len(t, order.Parameters, 8)
+	assert.Len(t, order.Parameters, 10)
 
 	for index, param := range order.Parameters {
 		switch param.Name {
@@ -310,12 +316,16 @@ func TestParamsParser(t *testing.T) {
 			assert.Equal(t, 3, index, "%s index incorrect", param.Name)
 		case "category":
 			assert.Equal(t, 4, index, "%s index incorrect", param.Name)
-		case "foo_slice":
+		case "type":
 			assert.Equal(t, 5, index, "%s index incorrect", param.Name)
-		case "bar_slice":
+		case gcBadEnum:
 			assert.Equal(t, 6, index, "%s index incorrect", param.Name)
-		case "items":
+		case "foo_slice":
 			assert.Equal(t, 7, index, "%s index incorrect", param.Name)
+		case "bar_slice":
+			assert.Equal(t, 8, index, "%s index incorrect", param.Name)
+		case "items":
+			assert.Equal(t, 9, index, "%s index incorrect", param.Name)
 		default:
 			assert.Fail(t, "unknown property: "+param.Name)
 		}

--- a/scan/parameters_test.go
+++ b/scan/parameters_test.go
@@ -196,7 +196,13 @@ func TestParamsParser(t *testing.T) {
 			assert.Equal(t, "Category", param.Extensions["x-go-name"])
 			assert.EqualValues(t, []interface{}{"foo", "bar", "none"}, param.Enum, "%s enum values are incorrect", param.Name)
 			assert.Equal(t, "bar", param.Default, "%s default value is incorrect", param.Name)
-
+		case "type":
+			assert.Equal(t, "Type of this model", param.Description)
+			assert.Equal(t, "query", param.In)
+			assert.Equal(t, "int", param.Type)
+			assert.EqualValues(t, []interface{}{1, 3, 5}, param.Enum, "%s enum values are incorrect", param.Name)
+		case "bad_type":
+			assert.EqualValues(t, []interface{}{1, "bar", "none"}, param.Enum, "%s enum values are incorrect", param.Name)
 		case "foo_slice":
 			assert.Equal(t, "a FooSlice has foos which are strings", param.Description)
 			assert.Equal(t, "FooSlice", param.Extensions["x-go-name"])

--- a/scan/responses.go
+++ b/scan/responses.go
@@ -108,12 +108,7 @@ func (sv headerValidations) SetPattern(val string)          { sv.current.Pattern
 func (sv headerValidations) SetUnique(val bool)             { sv.current.UniqueItems = val }
 func (sv headerValidations) SetCollectionFormat(val string) { sv.current.CollectionFormat = val }
 func (sv headerValidations) SetEnum(val string) {
-	list := strings.Split(val, ",")
-	interfaceSlice := make([]interface{}, len(list))
-	for i, d := range list {
-		interfaceSlice[i] = d
-	}
-	sv.current.Enum = interfaceSlice
+	sv.current.Enum = parseEnum(val, &spec.SimpleSchema{Type: sv.current.Type, Format: sv.current.Format})
 }
 func (sv headerValidations) SetDefault(val interface{}) { sv.current.Default = val }
 func (sv headerValidations) SetExample(val interface{}) { sv.current.Example = val }

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -103,12 +103,7 @@ func (sv schemaValidations) SetUnique(val bool)         { sv.current.UniqueItems
 func (sv schemaValidations) SetDefault(val interface{}) { sv.current.Default = val }
 func (sv schemaValidations) SetExample(val interface{}) { sv.current.Example = val }
 func (sv schemaValidations) SetEnum(val string) {
-	list := strings.Split(val, ",")
-	interfaceSlice := make([]interface{}, len(list))
-	for i, d := range list {
-		interfaceSlice[i] = d
-	}
-	sv.current.Enum = interfaceSlice
+	sv.current.Enum = parseEnum(val, &spec.SimpleSchema{Format: sv.current.Format, Type: sv.current.Type[0]})
 }
 
 type schemaDecl struct {

--- a/scan/validators.go
+++ b/scan/validators.go
@@ -809,3 +809,18 @@ func (ss *setOpResponses) Parse(lines []string) error {
 	ss.set(def, scr)
 	return nil
 }
+
+func parseEnum(val string, s *spec.SimpleSchema) []interface{} {
+	list := strings.Split(val, ",")
+	interfaceSlice := make([]interface{}, len(list))
+	for i, d := range list {
+		v, err := parseValueFromSchema(d, s)
+		if err != nil {
+			interfaceSlice[i] = d
+			continue
+		}
+
+		interfaceSlice[i] = v
+	}
+	return interfaceSlice
+}


### PR DESCRIPTION
add correct enum parsing according variable type. 
**This not take care about named enums, only fix correct exposing integer enums into spec.**
Example:
 `enum: 1,2,3`

result for int variable :
`          "type": "integer",
          "format": "int64",
          "default": 1,
          "enum": [
            1,
            2,
            3
          ],`



fix https://github.com/go-swagger/go-swagger/issues/1672

actually this not fix only integer as uses type parse of provided values.