### PR TITLE
chore(ci): set codecov patch expectation to a fixed level

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%
+ignore: generator/bindata.go


### PR DESCRIPTION
exclude bindata.go from test coverage computation

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>