### PR TITLE
Added support for non-standard http codes

### DIFF
--- a/fixtures/bugs/1893/.gitignore
+++ b/fixtures/bugs/1893/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/bugs/1893/fixture-1893.yaml
+++ b/fixtures/bugs/1893/fixture-1893.yaml
@@ -1,0 +1,30 @@
+---
+  swagger: "2.0"
+  info:
+    title: "error codes >= 512"
+    version: "0.0.1"
+    description: "repro issue 1893"
+    license:
+      name: "Apache 2.0"
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  paths:
+    /getRecords:
+      get:
+        operationId: getRecords
+        parameters:
+          - name: records
+            in: body
+            required: true
+            schema:
+              type: array
+              items:
+                type: object
+        responses:
+          default:
+            description: "OK"
+          200:
+            description: "OK"
+          512:
+            description: "512"
+          515:
+            description: "515"

--- a/fixtures/bugs/1893/gen-fixtures.sh
+++ b/fixtures/bugs/1893/gen-fixtures.sh
@@ -1,0 +1,101 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="${testcases} fixture-1893.yaml"
+for opts in  "" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    clientName="codegen-client"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Client generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+
+    clientName="client"
+    swagger generate client --skip-validation ${opts} --spec ${spec} --target ${target} --name=${clientName} 1>${testcase%.*}.log 2>&1
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/client ]] ; then
+        (cd ${target}/client ; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -400,7 +400,12 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 		for _, v := range srs {
 			name, ok := v.Response.Extensions.GetString(xGoName)
 			if !ok {
+				// look for name of well-known codes
 				name = runtime.Statuses[v.Code]
+				if name == "" {
+					// non-standard codes deserve some name
+					name = fmt.Sprintf("Status %d", v.Code)
+				}
 			}
 			name = swag.ToJSONName(b.Name + " " + name)
 			isSuccess := v.Code/100 == 2

--- a/generator/response_test.go
+++ b/generator/response_test.go
@@ -676,3 +676,28 @@ func TestGenResponse_1572(t *testing.T) {
 	// assertParams also works for responses
 	assertParams(t, fixtureConfig, filepath.Join("..", "fixtures", "enhancements", "1572", "fixture-1572.yaml"), true, false)
 }
+
+func TestGenResponse_1893(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer func() {
+		log.SetOutput(os.Stdout)
+	}()
+
+	fixtureConfig := map[string]map[string][]string{
+		// load expectations for parameters in operation get_nested_required_responses.go
+		"getRecords": { // fixture index
+			"clientResponse": { // executed template
+				// expected code lines
+				`type GetRecordsStatus512 struct {`,
+				`type GetRecordsStatus515 struct {`,
+			},
+			"serverResponses": { // executed template
+				// expected code lines
+				`type GetRecordsStatus512 struct {`,
+				`type GetRecordsStatus515 struct {`,
+			},
+		},
+	}
+	// assertParams also works for responses
+	assertParams(t, fixtureConfig, filepath.Join("..", "fixtures", "bugs", "1893", "fixture-1893.yaml"), true, false)
+}

--- a/hack/codegen-nonreg.sh
+++ b/hack/codegen-nonreg.sh
@@ -169,6 +169,7 @@ specdir=${specdir}" fixtures/bugs/1490"
 specdir=${specdir}" fixtures/bugs/973"
 specdir=${specdir}" fixtures/bugs/1020"
 specdir=${specdir}" fixtures/bugs/1339"
+specdir=${specdir}" fixtures/bugs/1893"
 gendir=./tmp-gen
 rm -rf ${gendir}
 


### PR DESCRIPTION
* fixes #1893
* codegen (client and server) now supports codes other than the well-known ones published by go-openapi/runtime

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>