### PR TITLE
fixed push latest tag on releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
               upload_to_github
               upload_to_bintray
 
+              export EXTRA_TAG=latest
               deploy_docker
             fi
 

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -68,9 +68,13 @@ deploy_docker() {
   mkdir -p deploybuild
   cp Dockerfile ./dist/swagger-musl ./deploybuild
   docker build --pull -t quay.io/goswagger/swagger:$CIRCLE_TAG ./deploybuild
-  docker tag quay.io/goswagger/swagger:$CIRCLE_TAG quay.io/goswagger/swagger:latest
   docker login -u $API_USERNAME -p $QUAY_PASS https://quay.io
   docker push quay.io/goswagger/swagger:$CIRCLE_TAG
+
+  if [[ -n "${EXTRA_TAG}" ]] ; then
+    docker tag quay.io/goswagger/swagger:$CIRCLE_TAG quay.io/goswagger/swagger:${EXTRA_TAG}
+    docker push quay.io/goswagger/swagger:${EXTRA_TAG}
+  fi
 }
 
 # prepare


### PR DESCRIPTION
Fixes #1873 (for next release)

@casualjim do you have the possibility to manually tag v0.0.19 as latest on quay.io?
 
Signed-off-by: Frederic BIDON <fredbi@yahoo.com>