### PR TITLE
Honour JSON ,string directive of ptr field when generating spec

### DIFF
--- a/fixtures/goparsing/classification/models/nomodel.go
+++ b/fixtures/goparsing/classification/models/nomodel.go
@@ -642,6 +642,35 @@ type JSONString struct {
 	SomethingElse Cars `json:"somethingElse,string"`
 }
 
+// JSONPtrString has fields with ",string" JSON directives.
+//
+// swagger:model jsonPtrString
+type JSONPtrString struct {
+	// Should be encoded as a string with string format "integer"
+	SomeInt    *int    `json:"someInt,string"`
+	SomeInt8   *int8   `json:"someInt8,string"`
+	SomeInt16  *int16  `json:"someInt16,string"`
+	SomeInt32  *int32  `json:"someInt32,string"`
+	SomeInt64  *int64  `json:"someInt64,string"`
+	SomeUint   *uint   `json:"someUint,string"`
+	SomeUint8  *uint8  `json:"someUint8,string"`
+	SomeUint16 *uint16 `json:"someUint16,string"`
+	SomeUint32 *uint32 `json:"someUint32,string"`
+	SomeUint64 *uint64 `json:"someUint64,string"`
+
+	// Should be encoded as a string with string format "double"
+	SomeFloat64 *float64 `json:"someFloat64,string"`
+
+	// Should be encoded as a string with no format
+	SomeString *string `json:"someString,string"`
+
+	// Should be encoded as a string with no format
+	SomeBool *bool `json:"someBool,string"`
+
+	// The ",string" directive should be ignore before the type isn't scalar
+	SomethingElse *Cars `json:"somethingElse,string"`
+}
+
 // IgnoredFields demostrates the use of swagger:ignore on struct fields.
 //
 // swagger:model ignoredFields

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -1301,17 +1301,7 @@ func parseJSONTag(field *ast.Field) (name string, ignore bool, isString bool, er
 			jsonName := jsonParts[0]
 
 			if len(jsonParts) > 1 && jsonParts[1] == "string" {
-				// Need to check if the field type is a scalar. Otherwise, the
-				// ",string" directive doesn't apply.
-				ident, ok := field.Type.(*ast.Ident)
-				if ok {
-					switch ident.Name {
-					case "int", "int8", "int16", "int32", "int64",
-						"uint", "uint8", "uint16", "uint32", "uint64",
-						"float64", "string", "bool":
-						isString = true
-					}
-				}
+				isString = isFieldStringable(field.Type)
 			}
 
 			if jsonName == "-" {
@@ -1322,4 +1312,23 @@ func parseJSONTag(field *ast.Field) (name string, ignore bool, isString bool, er
 		}
 	}
 	return name, false, false, nil
+}
+
+// isFieldStringable check if the field type is a scalar. If the field type is
+// *ast.StarExpr and is pointer type, check if it refers to a scalar.
+// Otherwise, the ",string" directive doesn't apply.
+func isFieldStringable(tpe ast.Expr) bool {
+	if ident, ok := tpe.(*ast.Ident); ok {
+		switch ident.Name {
+		case "int", "int8", "int16", "int32", "int64",
+			"uint", "uint8", "uint16", "uint32", "uint64",
+			"float64", "string", "bool":
+			return true
+		}
+	} else if starExpr, ok := tpe.(*ast.StarExpr); ok {
+		return isFieldStringable(starExpr.X)
+	} else {
+		return false
+	}
+	return false
 }

--- a/scan/schema_test.go
+++ b/scan/schema_test.go
@@ -627,6 +627,29 @@ func TestStringStructTag(t *testing.T) {
 	}
 }
 
+func TestPtrFieldStringStructTag(t *testing.T) {
+	_ = classificationProg
+	sch := noModelDefs["jsonPtrString"]
+	assertProperty(t, &sch, "string", "someInt", "int64", "SomeInt")
+	assertProperty(t, &sch, "string", "someInt8", "int8", "SomeInt8")
+	assertProperty(t, &sch, "string", "someInt16", "int16", "SomeInt16")
+	assertProperty(t, &sch, "string", "someInt32", "int32", "SomeInt32")
+	assertProperty(t, &sch, "string", "someInt64", "int64", "SomeInt64")
+	assertProperty(t, &sch, "string", "someUint", "uint64", "SomeUint")
+	assertProperty(t, &sch, "string", "someUint8", "uint8", "SomeUint8")
+	assertProperty(t, &sch, "string", "someUint16", "uint16", "SomeUint16")
+	assertProperty(t, &sch, "string", "someUint32", "uint32", "SomeUint32")
+	assertProperty(t, &sch, "string", "someUint64", "uint64", "SomeUint64")
+	assertProperty(t, &sch, "string", "someFloat64", "double", "SomeFloat64")
+	assertProperty(t, &sch, "string", "someString", "", "SomeString")
+	assertProperty(t, &sch, "string", "someBool", "", "SomeBool")
+
+	prop, ok := sch.Properties["somethingElse"]
+	if assert.True(t, ok) {
+		assert.NotEqual(t, "string", prop.Type)
+	}
+}
+
 func TestIgnoredStructField(t *testing.T) {
 	_ = classificationProg
 	sch := noModelDefs["ignoredFields"]


### PR DESCRIPTION
This is an update of pull request: #1511

For example:
```
// swagger:model Foo
type Foo struct {
    Bar *int64 `json:"bar,omitempty,string"`
}
```
The generated spec should be type "string" and format "int64".