### PR TITLE
Integrates flatten fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
   maligned:
     suggest-new: true
   dupl:
-    threshold: 100
+    threshold: 200
   goconst:
     min-len: 2
     min-occurrences: 2

--- a/fixtures/bugs/1042/pet_test.go
+++ b/fixtures/bugs/1042/pet_test.go
@@ -1,4 +1,4 @@
-//+build integration
+//+build ignore
 
 package main
 

--- a/fixtures/bugs/1232/discriminatedMarshalling_test.go
+++ b/fixtures/bugs/1232/discriminatedMarshalling_test.go
@@ -1,4 +1,4 @@
-//+build integration
+//+build ignore
 
 package main
 

--- a/fixtures/bugs/1548/base64Thing_test.go
+++ b/fixtures/bugs/1548/base64Thing_test.go
@@ -1,4 +1,4 @@
-//+build integration
+//+build ignore
 
 package main
 

--- a/fixtures/bugs/1571/tupleThing_test.go
+++ b/fixtures/bugs/1571/tupleThing_test.go
@@ -1,4 +1,4 @@
-//+build integration
+//+build ignore
 
 package main
 

--- a/fixtures/bugs/1851/.gitignore
+++ b/fixtures/bugs/1851/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/bugs/1851/definitions.yaml
+++ b/fixtures/bugs/1851/definitions.yaml
@@ -1,0 +1,12 @@
+definitions:
+  ServerStatus:
+    type: string
+    enum: [OK, Not OK]
+
+  Server:
+    type: object
+    properties:
+      Name:
+        type: string
+      Status:
+        $ref: '#/definitions/ServerStatus'

--- a/fixtures/bugs/1851/fixture-1851.yaml
+++ b/fixtures/bugs/1851/fixture-1851.yaml
@@ -1,0 +1,39 @@
+swagger: '2.0'
+
+info:
+  title: 'Title'
+  version: '1.0'
+
+paths:
+  '/':
+    get:
+      responses:
+        200:
+          description: OK response
+          schema:
+            $ref: '#/definitions/Response'
+    post:
+      parameters:
+        - in: body
+          schema:
+            $ref: '#/definitions/Request'
+          name: filter
+      responses:
+        200:
+          description: OK response
+          schema:
+            $ref: '#/definitions/Response'
+
+definitions:
+  Response:
+    type: object
+    properties:
+      Server:
+        type: array
+        items:
+          $ref: 'definitions.yaml#/definitions/Server'
+  Request:
+    type: object
+    properties:
+      ServerStatus:
+        $ref: 'definitions.yaml#/definitions/ServerStatus'

--- a/fixtures/bugs/1851/gen-fixtures.sh
+++ b/fixtures/bugs/1851/gen-fixtures.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="${testcases} fixture-1851.yaml"
+for opts in  "" "--with-expand" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    serverName="codegensrv"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Model generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    # 1>x.log 2>&1
+    #
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/generator/shared_test.go
+++ b/generator/shared_test.go
@@ -436,10 +436,6 @@ func TestShared_Issue1429(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
 
-	if runtime.GOOS == "windows" {
-		t.Skip("on windows till the bug is resolved for ref resolution")
-	}
-
 	// acknowledge fix in go-openapi/spec
 	specPath := filepath.Join("..", "fixtures", "bugs", "1429", "swagger-1429.yaml")
 	specDoc, err := loads.Spec(specPath)

--- a/go.mod
+++ b/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/coreos/go-oidc v2.0.0+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/go-openapi/analysis v0.19.3
+	github.com/go-openapi/analysis v0.19.4
 	github.com/go-openapi/errors v0.19.2
 	github.com/go-openapi/inflect v0.19.0
 	github.com/go-openapi/loads v0.19.2
 	github.com/go-openapi/runtime v0.19.2
 	github.com/go-openapi/spec v0.19.2
 	github.com/go-openapi/strfmt v0.19.0
-	github.com/go-openapi/swag v0.19.3
+	github.com/go-openapi/swag v0.19.4
 	github.com/go-openapi/validate v0.19.2
 	github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013
 	github.com/gorilla/handlers v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/fredbi/analysis v0.19.3-fix-windows h1:+6LkOis2IaGKWh1IqJr3VCi7fjzmDvjuxor91Bz/Ng4=
+github.com/fredbi/analysis v0.19.3-fix-windows/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -51,6 +53,8 @@ github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpR
 github.com/go-openapi/analysis v0.19.2/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
 github.com/go-openapi/analysis v0.19.3 h1:Xtsy72zXATFJDxzXj/Hluj1PP99LWhws7ZjS6Qwub2k=
 github.com/go-openapi/analysis v0.19.3/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
+github.com/go-openapi/analysis v0.19.4 h1:1TjOzrWkj+9BrjnM1yPAICbaoC0FyfD49oVkTBrSSa0=
+github.com/go-openapi/analysis v0.19.4/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
 github.com/go-openapi/errors v0.17.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
 github.com/go-openapi/errors v0.18.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
 github.com/go-openapi/errors v0.19.2 h1:a2kIyV3w+OS3S97zxUndRVD46+FhGOUBDFY7nmu4CsY=
@@ -90,6 +94,8 @@ github.com/go-openapi/swag v0.19.2 h1:jvO6bCMBEilGwMfHhrd61zIID4oIFdwb76V17SM88d
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.3 h1:FKTmP0GPWwRqRP2WIYltgctgYTN+gr8iZ7zSKdZtbz0=
 github.com/go-openapi/swag v0.19.3/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-openapi/swag v0.19.4 h1:i/65mCM9s1h8eCkT07F5Z/C1e/f8VTgEwer+00yevpA=
+github.com/go-openapi/swag v0.19.4/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2 h1:ky5l57HjyVRrsJfd2+Ro5Z9PjGuKbsmftwyMtk8H7js=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=

--- a/hack/codegen-nonreg.sh
+++ b/hack/codegen-nonreg.sh
@@ -183,6 +183,7 @@ check_list=${check_list}" fixtures/bugs/1767/fixture-1767.yaml"
 check_list=${check_list}" fixtures/bugs/1260/fixture-realiased-types.yaml"
 check_list=${check_list}" fixtures/bugs/1260/test3-swagger.yaml fixtures/bugs/1260/test3-bis-swagger.yaml"
 check_list=${check_list}" fixtures/bugs/1260/test3-ter-swagger.yaml fixtures/bugs/1260/test3-ter-swagger-flat.json"
+check_list=${check_list}" fixtures/bugs/1851/fixture-1851.yaml"
 
 list=( $check_list )
 fixtures_count=${#list[@]}


### PR DESCRIPTION
updates from latest tag on go-openapi/analysis

* fixes #1851
* fixes #1965
* fixes #1886
* reactivated test on windows for #1429

* Fixed build tag issues in some fixture go source (prevented go mod vendor)
* Update vendor (go mod vendor)
* Added fixture to assert #1851 is fixed

Update go-openapi/analysis dependency

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>