### PR TITLE
Codegen edges cases

### DIFF
--- a/fixtures/bugs/1937/.gitignore
+++ b/fixtures/bugs/1937/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/bugs/1937/fixture-1937.yaml
+++ b/fixtures/bugs/1937/fixture-1937.yaml
@@ -1,0 +1,34 @@
+---
+  swagger: "2.0"
+  info:
+    title: "error codes >= 512"
+    version: "0.0.1"
+    description: "repro issue 1893"
+    license:
+      name: "Apache 2.0"
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  definitions:
+    400Schema:
+      type: string
+  paths:
+    /getRecords:
+      get:
+        operationId: getRecords
+        parameters:
+          - name: 101param
+            type: string
+            in: query
+          - name: records
+            in: body
+            required: true
+            schema:
+              $ref: '#/definitions/400Schema'
+        responses:
+          200:
+            description: "OK"
+            headers:
+              101header:
+                type: string
+            schema:
+              $ref: '#/definitions/400Schema'
+

--- a/fixtures/bugs/1937/gen-fixtures.sh
+++ b/fixtures/bugs/1937/gen-fixtures.sh
@@ -1,0 +1,101 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="${testcases} fixture-1937.yaml"
+for opts in  "" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    clientName="codegen-client"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Client generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+
+    clientName="client"
+    swagger generate client --skip-validation ${opts} --spec ${spec} --target ${target} --name=${clientName} 1>${testcase%.*}.log 2>&1
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/client ]] ; then
+        (cd ${target}/client ; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/generator/parameter_test.go
+++ b/generator/parameter_test.go
@@ -4384,3 +4384,25 @@ func TestGenClientParameter_1339(t *testing.T) {
 	}
 	assertParams(t, fixtureConfig, filepath.Join("..", "fixtures", "bugs", "1339", "fixture-1339.yaml"), true, false)
 }
+
+func TestGenClientParameter_1937(t *testing.T) {
+	// names starting with a number
+	log.SetOutput(ioutil.Discard)
+	defer func() {
+		log.SetOutput(os.Stdout)
+	}()
+	// testing fixture-1339.yaml with minimal flatten
+	// param is binary
+
+	fixtureConfig := map[string]map[string][]string{
+
+		// load expectations for parameters
+		"getRecords": { // fixture index
+			"serverParameter": { // executed template
+				`Nr101param *string`,
+				`Records models.Nr400Schema`,
+			},
+		},
+	}
+	assertParams(t, fixtureConfig, filepath.Join("..", "fixtures", "bugs", "1937", "fixture-1937.yaml"), true, false)
+}

--- a/hack/codegen-nonreg.sh
+++ b/hack/codegen-nonreg.sh
@@ -172,6 +172,7 @@ specdir=${specdir}" fixtures/bugs/1339"
 specdir=${specdir}" fixtures/bugs/1893"
 specdir=${specdir}" fixtures/bugs/1518"
 specdir=${specdir}" fixtures/bugs/1993"
+specdir=${specdir}" fixtures/bugs/1937"
 gendir=./tmp-gen
 rm -rf ${gendir}
 


### PR DESCRIPTION
updated from latest tag of go-openapi/swag

Handling of names not starting with a letter (mismatches between GoType and model name)

This makes the pascalize and swag.ToGoName funcs work with similar rules.

* fixes #1937

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>