### PR TITLE
use slices for collecting parameters to retain ordering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,10 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/go-swagger/go-swagger
     docker:
       - image: goswagger/builder:20190630
     steps:
       - checkout
-      - run: GO111MODULE=on go mod vendor
 
       - run:
           name: Run unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,12 @@
 version: 2
 jobs:
   build:
+    working_directory: /go/src/github.com/go-swagger/go-swagger
     docker:
       - image: goswagger/builder:20190630
     steps:
       - checkout
+      - run: GO111MODULE=on go mod vendor
 
       - run:
           name: Run unit tests

--- a/codescan/application_test.go
+++ b/codescan/application_test.go
@@ -1,6 +1,8 @@
 package codescan
 
 import (
+	"encoding/json"
+	"log"
 	"sort"
 	"testing"
 
@@ -62,8 +64,8 @@ func TestAppScanner_NewSpec(t *testing.T) {
 	})
 	require.NoError(t, err)
 	if assert.NotNil(t, doc) {
-		// b, _ := json.MarshalIndent(doc, "", "  ")
-		// log.Println(string(b))
+		b, _ := json.MarshalIndent(doc.Responses, "", "  ")
+		log.Println(string(b))
 		verifyParsedPetStore(t, doc)
 	}
 }
@@ -98,14 +100,14 @@ func verifyParsedPetStore(t testing.TB, doc *spec.Swagger) {
 	verifyInfo(t, doc.Info)
 
 	if assert.NotNil(t, doc.Paths) {
-		assert.Len(t, doc.Paths.Paths, 4)
+		assert.Len(t, doc.Paths.Paths, 5)
 	}
 	var keys []string
 	for k := range doc.Definitions {
 		keys = append(keys, k)
 	}
 	assert.Len(t, keys, 3)
-	assert.Len(t, doc.Responses, 3)
+	assert.Len(t, doc.Responses, 4)
 
 	definitions := doc.Definitions
 	mod, ok := definitions["tag"]
@@ -224,6 +226,11 @@ func verifyParsedPetStore(t testing.TB, doc *spec.Swagger) {
 	assertProperty(t, resp.Schema, "integer", "code", "int32", "Code")
 	assertProperty(t, resp.Schema, "string", "message", "", "Message")
 	assertProperty(t, resp.Schema, "string", "field", "", "Field")
+
+	resp, ok = doc.Responses["MarkdownRender"]
+	assert.True(t, ok)
+	assert.NotNil(t, resp.Schema)
+	assert.True(t, resp.Schema.Type.Contains("string"))
 
 	paths := doc.Paths.Paths
 

--- a/codescan/application_test.go
+++ b/codescan/application_test.go
@@ -1,8 +1,6 @@
 package codescan
 
 import (
-	"encoding/json"
-	"log"
 	"sort"
 	"testing"
 
@@ -64,8 +62,8 @@ func TestAppScanner_NewSpec(t *testing.T) {
 	})
 	require.NoError(t, err)
 	if assert.NotNil(t, doc) {
-		b, _ := json.MarshalIndent(doc, "", "  ")
-		log.Println(string(b))
+		// b, _ := json.MarshalIndent(doc, "", "  ")
+		// log.Println(string(b))
 		verifyParsedPetStore(t, doc)
 	}
 }

--- a/codescan/parameters.go
+++ b/codescan/parameters.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"log"
 	"strings"
 
 	"golang.org/x/tools/go/ast/astutil"
@@ -162,7 +161,7 @@ func (p *parameterBuilder) Build(operations map[string]*spec.Operation) error {
 			operations[opid] = operation
 			operation.ID = opid
 		}
-		log.Println("building spec for", opid)
+		debugLog("building parameters for: %s", opid)
 
 		// analyze struct body for fields etc
 		// each exported struct field:

--- a/codescan/parameters_test.go
+++ b/codescan/parameters_test.go
@@ -12,10 +12,11 @@ const (
 	gcBadEnum = "bad_enum"
 )
 
-func getParameter(sctx *scanCtx, nm string) *Decl {
-	for k := range sctx.app.Parameters {
-		if k.Name == nm {
-			return sctx.app.Parameters[k]
+func getParameter(sctx *scanCtx, nm string) *entityDecl {
+	for _, v := range sctx.app.Parameters {
+		param := v
+		if v.Ident.Name == nm {
+			return param
 		}
 	}
 	return nil

--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -107,8 +107,8 @@ func (sv headerValidations) SetExample(val interface{}) { sv.current.Example = v
 
 type responseBuilder struct {
 	ctx       *scanCtx
-	decl      *Decl
-	postDecls []*Decl
+	decl      *entityDecl
+	postDecls []*entityDecl
 }
 
 func (r *responseBuilder) Build(responses map[string]spec.Response) error {
@@ -207,7 +207,7 @@ func (r *responseBuilder) buildFromType(otpe types.Type, resp *spec.Response, se
 	}
 }
 
-func (r *responseBuilder) buildFromStruct(decl *Decl, tpe *types.Struct, resp *spec.Response, seen map[string]bool) error {
+func (r *responseBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, resp *spec.Response, seen map[string]bool) error {
 	if tpe.NumFields() == 0 {
 		return nil
 	}

--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -225,8 +225,7 @@ func (r *responseBuilder) buildFromType(otpe types.Type, resp *spec.Response, se
 			return errors.Errorf("responses can only be structs, did you mean for %s to be the response body?", otpe.String())
 		}
 	default:
-		panic("unhandled type " + tpe.String())
-		// return errors.Errorf("unhandled type (%T): %s", otpe, tpe.String())
+		return errors.New("anonymous types are currently not supported for responses")
 	}
 }
 

--- a/codescan/responses_test.go
+++ b/codescan/responses_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getResponse(sctx *scanCtx, nm string) *Decl {
-	for k := range sctx.app.Responses {
-		if k.Name == nm {
-			return sctx.app.Responses[k]
+func getResponse(sctx *scanCtx, nm string) *entityDecl {
+	for _, v := range sctx.app.Responses {
+		if v.Ident.Name == nm {
+			return v
 		}
 	}
 	return nil

--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -97,12 +97,12 @@ func (sv schemaValidations) SetEnum(val string) {
 
 type schemaBuilder struct {
 	ctx        *scanCtx
-	decl       *Decl
+	decl       *entityDecl
 	GoName     string
 	Name       string
 	annotated  bool
-	discovered []*Decl
-	postDecls  []*Decl
+	discovered []*entityDecl
+	postDecls  []*entityDecl
 }
 
 func (s *schemaBuilder) inferNames() (goName string, name string) {
@@ -149,7 +149,7 @@ func (s *schemaBuilder) Build(definitions map[string]spec.Schema) error {
 	return nil
 }
 
-func (s *schemaBuilder) buildFromDecl(decl *Decl, schema *spec.Schema) error {
+func (s *schemaBuilder) buildFromDecl(decl *entityDecl, schema *spec.Schema) error {
 	// analyze doc comment for the model
 	sp := new(sectionedParser)
 	sp.setTitle = func(lines []string) { schema.Title = joinDropLast(lines) }
@@ -379,7 +379,7 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 	return nil
 }
 
-func (s *schemaBuilder) buildFromInterface(decl *Decl, it *types.Interface, schema *spec.Schema, seen map[string]string) error {
+func (s *schemaBuilder) buildFromInterface(decl *entityDecl, it *types.Interface, schema *spec.Schema, seen map[string]string) error {
 	if it.Empty() {
 		schema.Typed("object", "")
 		return nil
@@ -565,7 +565,7 @@ func (s *schemaBuilder) buildFromInterface(decl *Decl, it *types.Interface, sche
 	return nil
 }
 
-func (s *schemaBuilder) buildFromStruct(decl *Decl, st *types.Struct, schema *spec.Schema, seen map[string]string) error {
+func (s *schemaBuilder) buildFromStruct(decl *entityDecl, st *types.Struct, schema *spec.Schema, seen map[string]string) error {
 	// First check for all of schemas
 	var tgt *spec.Schema
 	hasAllOf := false
@@ -829,7 +829,7 @@ func (s *schemaBuilder) buildEmbedded(tpe types.Type, schema *spec.Schema, seen 
 	return nil
 }
 
-func (s *schemaBuilder) makeRef(decl *Decl, prop swaggerTypable) error {
+func (s *schemaBuilder) makeRef(decl *entityDecl, prop swaggerTypable) error {
 	nm, _ := decl.Names()
 	ref, err := spec.NewRef("#/definitions/" + nm)
 	if err != nil {

--- a/codescan/schema_test.go
+++ b/codescan/schema_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSchemaBuilder_Struct_Tag(t *testing.T) {
 	sctx := loadPetstorePkgsCtx(t)
-	var td *Decl
+	var td *entityDecl
 	for k := range sctx.app.Models {
 		if k.Name != "Tag" {
 			continue
@@ -34,7 +34,7 @@ func TestSchemaBuilder_Struct_Pet(t *testing.T) {
 	// defer func() { Debug = false }()
 
 	sctx := loadPetstorePkgsCtx(t)
-	var td *Decl
+	var td *entityDecl
 	for k := range sctx.app.Models {
 		if k.Name != "Pet" {
 			continue
@@ -57,7 +57,7 @@ func TestSchemaBuilder_Struct_Order(t *testing.T) {
 	// defer func() { Debug = false }()
 
 	sctx := loadPetstorePkgsCtx(t)
-	var td *Decl
+	var td *entityDecl
 	for k := range sctx.app.Models {
 		if k.Name != "Order" {
 			continue
@@ -934,7 +934,7 @@ func TestAddExtension(t *testing.T) {
 	assert.Equal(t, nil, ve.Extensions[key3])
 }
 
-func getClassificationModel(sctx *scanCtx, nm string) *Decl {
+func getClassificationModel(sctx *scanCtx, nm string) *entityDecl {
 	decl, ok := sctx.FindDecl("github.com/go-swagger/go-swagger/fixtures/goparsing/classification/models", nm)
 	if !ok {
 		return nil

--- a/codescan/spec.go
+++ b/codescan/spec.go
@@ -35,7 +35,7 @@ type specBuilder struct {
 	scanModels  bool
 	input       *spec.Swagger
 	ctx         *scanCtx
-	discovered  []*Decl
+	discovered  []*entityDecl
 	definitions map[string]spec.Schema
 	responses   map[string]spec.Response
 	operations  map[string]*spec.Operation
@@ -82,7 +82,7 @@ func (s *specBuilder) buildDiscovered() error {
 	// loop over discovered until all the items are in definitions
 	keepGoing := len(s.discovered) > 0
 	for keepGoing {
-		var queue []*Decl
+		var queue []*entityDecl
 		for _, d := range s.discovered {
 			nm, _ := d.Names()
 			if _, ok := s.definitions[nm]; !ok {
@@ -101,7 +101,7 @@ func (s *specBuilder) buildDiscovered() error {
 	return nil
 }
 
-func (s *specBuilder) buildDiscoveredSchema(decl *Decl) error {
+func (s *specBuilder) buildDiscoveredSchema(decl *entityDecl) error {
 	sb := &schemaBuilder{
 		ctx:        s.ctx,
 		decl:       decl,

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,14 +58,14 @@ wget https://bintray.com/go-swagger/goswagger-rpm/rpm -O bintray-go-swagger-gosw
 Install or update from current source master:
 
 ```
-go get -u github.com/go-swagger/go-swagger/cmd/swagger
+dir=$(mktemp -d) 
+git clone https://github.com/go-swagger/go-swagger "$dir" 
+cd "$dir"
+go install ./cmd/swagger
 ```
 
 You are welcome to clone this repo and start contributing:
 ```
-cd $GOPATH/src
-mkdir -p github.com/go-swagger
-cd github.com/go-swagger
 git clone https://github.com/go-swagger/go-swagger
 ```
 

--- a/fixtures/goparsing/petstore/rest/app.go
+++ b/fixtures/goparsing/petstore/rest/app.go
@@ -34,6 +34,7 @@ func ServeAPI() error {
 		mux.GET("/orders/:id", handlers.GetOrderDetails),
 		mux.POST("/orders", handlers.CreateOrder),
 		mux.PUT("/orders/:id", handlers.UpdateOrder),
+		mux.GET("/help", handlers.GetHelp),
 		mux.Handler("DELETE", "/orders/:id", handlers.CancelOrder),
 	}
 	handler, err := mux.Build(routes)

--- a/fixtures/goparsing/petstore/rest/handlers/orders.go
+++ b/fixtures/goparsing/petstore/rest/handlers/orders.go
@@ -100,3 +100,19 @@ func UpdateOrder(rw http.ResponseWriter, req *http.Request, params denco.Params)
 func CreateOrder(rw http.ResponseWriter, req *http.Request, params denco.Params) {
 	// some actual stuff should happen in here
 }
+
+// GetHelp swagger:route GET /help help
+//
+// Gets the help as markdown
+//
+// Responses:
+//    default: genericError
+//        200: MarkdownRender
+//        422: validationError
+func GetHelp(rw http.ResponseWriter, req *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// MarkdownRender is a rendered markdown document
+// swagger:response MarkdownRender
+type MarkdownRender string

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
-	golang.org/x/tools v0.0.0-20190703212419-2214986f1668
+	golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db
 	google.golang.org/genproto v0.0.0-20190701230453-710ae3a149df // indirect
 	google.golang.org/grpc v1.22.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ golang.org/x/tools v0.0.0-20190628222527-fb37f6ba8261 h1:KP5slYyJf3GFQbPLTWjQ0TC
 golang.org/x/tools v0.0.0-20190628222527-fb37f6ba8261/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190703212419-2214986f1668 h1:3LJOYcj2ObWSZJXX21oGIIPv5SaOoi5JkzQTWnCXRhg=
 golang.org/x/tools v0.0.0-20190703212419-2214986f1668/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db h1:9hRk1xeL9LTT3yX/941DqeBz87XgHAQuj+TbimYJuiw=
+golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
Use slices to store the decls for responses and parameters. 

fixes #1997 
fixes #2001

Signed-off-by: Ivan Porto Carrero <ivan@flanders.co.nz>