### PR TITLE
spec generation: added support for deprecated tag in route annotations

### DIFF
--- a/codescan/application_test.go
+++ b/codescan/application_test.go
@@ -242,6 +242,7 @@ func verifyParsedPetStore(t testing.TB, doc *spec.Swagger) {
 	assert.Equal(t, "By default it will only lists pets that are available for sale.\nThis can be changed with the status flag.", op.Get.Description)
 	assert.Equal(t, "listPets", op.Get.ID)
 	assert.EqualValues(t, []string{"pets"}, op.Get.Tags)
+	assert.True(t, op.Get.Deprecated)
 	var names namedParams
 	for i, v := range op.Get.Parameters {
 		names = append(names, namedParam{Index: i, Name: v.Name})

--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -1099,6 +1099,29 @@ func (su *setReadOnlySchema) Parse(lines []string) error {
 	return nil
 }
 
+type setDeprecatedOp struct {
+	tgt *spec.Operation
+}
+
+func (su *setDeprecatedOp) Matches(line string) bool {
+	return rxDeprecated.MatchString(line)
+}
+
+func (su *setDeprecatedOp) Parse(lines []string) error {
+	if len(lines) == 0 || (len(lines) == 1 && len(lines[0]) == 0) {
+		return nil
+	}
+	matches := rxDeprecated.FindStringSubmatch(lines[0])
+	if len(matches) > 1 && len(matches[1]) > 0 {
+		req, err := strconv.ParseBool(matches[1])
+		if err != nil {
+			return err
+		}
+		su.tgt.Deprecated = req
+	}
+	return nil
+}
+
 type setDiscriminator struct {
 	schema *spec.Schema
 	field  string

--- a/codescan/regexprs.go
+++ b/codescan/regexprs.go
@@ -89,5 +89,6 @@ var (
 	rxTOS             = regexp.MustCompile(`[Tt](:?erms)?\p{Zs}*-?[Oo]f?\p{Zs}*-?[Ss](?:ervice)?\p{Zs}*:`)
 	rxExtensions      = regexp.MustCompile(`[Ee]xtensions\p{Zs}*:`)
 	rxInfoExtensions  = regexp.MustCompile(`[In]nfo\p{Zs}*[Ee]xtensions:`)
+	rxDeprecated      = regexp.MustCompile(`[Dd]eprecated\p{Zs}*:\p{Zs}*(true|false)$`)
 	// currently unused: rxExample         = regexp.MustCompile(`[Ex]ample\p{Zs}*:\p{Zs}*(.*)$`)
 )

--- a/codescan/routes.go
+++ b/codescan/routes.go
@@ -70,6 +70,7 @@ func (r *routesBuilder) Build(tgt *spec.Paths) error {
 		newMultiLineTagParser("Security", newSetSecurity(rxSecuritySchemes, opSecurityDefsSetter(op)), false),
 		newMultiLineTagParser("Parameters", spa, false),
 		newMultiLineTagParser("Responses", sr, false),
+		newSingleLineTagParser("Deprecated", &setDeprecatedOp{op}),
 	}
 	if err := sp.Parse(r.route.Remaining); err != nil {
 		return fmt.Errorf("operation (%s): %v", op.ID, err)

--- a/fixtures/goparsing/petstore/rest/handlers/pets.go
+++ b/fixtures/goparsing/petstore/rest/handlers/pets.go
@@ -90,6 +90,7 @@ type PetBodyParams struct {
 // By default it will only lists pets that are available for sale.
 // This can be changed with the status flag.
 //
+// Deprecated: true
 // Responses:
 // 		default: genericError
 // 		    200: []pet


### PR DESCRIPTION
Signed-off-by: Frederic BIDON <fredbi@yahoo.com>

fixes  #2042 