### PR TITLE
Fixed regression on name generation for "+" or "-" enum values

### DIFF
--- a/fixtures/bugs/2050/.gitignore
+++ b/fixtures/bugs/2050/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/bugs/2050/fixture-2050.yaml
+++ b/fixtures/bugs/2050/fixture-2050.yaml
@@ -1,0 +1,37 @@
+---
+  swagger: "2.0"
+  info:
+    title: "enum with +,-"
+    version: "0.0.1"
+    description: "repro issue 2050"
+    license:
+      name: "Apache 2.0"
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  definitions:
+    modelEnum:
+      type: object
+      properties:
+        p0:
+          type: string
+          enum:
+            - '+1'
+            - '-1'
+            - '0'
+        p1:
+          type: string
+          enum:
+            - '+'
+            - '-'
+  paths:
+    /getRecords:
+      get:
+        operationId: getRecords
+        parameters:
+          - name: records
+            in: body
+            required: true
+            schema:
+              $ref: '#/definitions/modelEnum'
+        responses:
+          200:
+            description: "OK"

--- a/fixtures/bugs/2050/gen-fixtures.sh
+++ b/fixtures/bugs/2050/gen-fixtures.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="${testcases} fixture-2050.yaml"
+for opts in  "" "--with-expand" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    serverName="codegensrv"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Model generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    # 1>x.log 2>&1
+    #
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -1076,6 +1076,16 @@ func gatherOperations(specDoc *analysis.Spec, operationIDs []string) map[string]
 }
 
 func pascalize(arg string) string {
+	runes := []rune(arg)
+	switch len(runes) {
+	case 0:
+		return ""
+	case 1: // handle special case when we have a single rune that is not handled by swag.ToGoName
+		switch runes[0] {
+		case '+', '-', '#', '_': // those cases are handled differently than swag utility
+			return prefixForName(arg)
+		}
+	}
 	return swag.ToGoName(swag.ToGoName(arg)) // want to remove spaces
 }
 
@@ -1089,7 +1099,9 @@ func prefixForName(arg string) string {
 		return "Plus"
 	case '-':
 		return "Minus"
-		// other cases (#,@ etc..) handled by swag.ToGoName
+	case '#':
+		return "HashTag"
+		// other cases ($,@ etc..) handled by swag.ToGoName
 	}
 	return "Nr"
 }

--- a/generator/shared_test.go
+++ b/generator/shared_test.go
@@ -536,3 +536,33 @@ func TestShared_Issue1614(t *testing.T) {
 	_, err = validateAndFlattenSpec(&opts, specDoc)
 	assert.NoError(t, err)
 }
+
+func TestPascalize(t *testing.T) {
+	assert.Equal(t, "Plus1", pascalize("+1"))
+	assert.Equal(t, "Plus", pascalize("+"))
+	assert.Equal(t, "Minus1", pascalize("-1"))
+	assert.Equal(t, "Minus", pascalize("-"))
+	assert.Equal(t, "Nr8", pascalize("8"))
+
+	assert.Equal(t, "Hello", pascalize("+hello"))
+
+	// other values from swag rules
+	assert.Equal(t, "At8", pascalize("@8"))
+	assert.Equal(t, "AtHello", pascalize("@hello"))
+	assert.Equal(t, "Bang8", pascalize("!8"))
+	assert.Equal(t, "At", pascalize("@"))
+
+	// # values
+	assert.Equal(t, "Hello", pascalize("#hello"))
+	assert.Equal(t, "BangHello", pascalize("#!hello"))
+	assert.Equal(t, "HashTag8", pascalize("#8"))
+	assert.Equal(t, "HashTag", pascalize("#"))
+
+	// single '_'
+	assert.Equal(t, "Nr", pascalize("_"))
+	assert.Equal(t, "Hello", pascalize("_hello"))
+
+	// remove spaces
+	assert.Equal(t, "HelloWorld", pascalize("# hello world"))
+	assert.Equal(t, "HashTag8HelloWorld", pascalize("# 8 hello world"))
+}

--- a/generator/template_repo_test.go
+++ b/generator/template_repo_test.go
@@ -51,6 +51,11 @@ toPackage2={{ toPackage "a.a/b_c/d_e" }}
 toPackage3={{ toPackage "d_e" }}
 toPackage4={{ toPackage "d-e" }}
 toPackageName={{ toPackageName "d-e/f-g" }}
+PascalizeSpecialChar1={{ pascalize "+1" }}
+PascalizeSpecialChar2={{ pascalize "-1" }}
+PascalizeSpecialChar3={{ pascalize "1" }}
+PascalizeSpecialChar4={{ pascalize "-" }}
+PascalizeSpecialChar5={{ pascalize "+" }}
 `
 )
 
@@ -410,12 +415,16 @@ func TestTemplates_FuncMap(t *testing.T) {
 					assert.Contains(t, rendered.String(), "Snakize1=ending_in_os_name_linux_swagger\n")
 					assert.Contains(t, rendered.String(), "Snakize2=ending_in_arch_name_linux_amd64_swagger\n")
 					assert.Contains(t, rendered.String(), "Snakize3=ending_in_test_swagger\n")
-					//fmt.Println(rendered.String())
 					assert.Contains(t, rendered.String(), "toPackage1=a/b-c/d_e\n")
 					assert.Contains(t, rendered.String(), "toPackage2=a.a/b_c/d_e\n")
 					assert.Contains(t, rendered.String(), "toPackage3=d_e\n")
 					assert.Contains(t, rendered.String(), "toPackage4=d_e\n")
 					assert.Contains(t, rendered.String(), "toPackageName=f_g\n")
+					assert.Contains(t, rendered.String(), "PascalizeSpecialChar1=Plus1\n")
+					assert.Contains(t, rendered.String(), "PascalizeSpecialChar2=Minus1\n")
+					assert.Contains(t, rendered.String(), "PascalizeSpecialChar3=Nr1\n")
+					assert.Contains(t, rendered.String(), "PascalizeSpecialChar4=Minus\n")
+					assert.Contains(t, rendered.String(), "PascalizeSpecialChar5=Plus\n")
 				}
 			}
 		}

--- a/hack/codegen-nonreg.sh
+++ b/hack/codegen-nonreg.sh
@@ -159,6 +159,7 @@ fixtureDirs=(\
 "fixtures/bugs/1518" \
 "fixtures/bugs/1993" \
 "fixtures/bugs/1937" \
+"fixtures/bugs/2050" \
 )
 
 # there are several subspecs there: we just want a specific one


### PR DESCRIPTION
* fixes #2050
* added support for "#" prefix handling values like '#235'
* more unit testing on the pascalize function

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>