### PR TITLE
Provide example for configure command-line flags

### DIFF
--- a/examples/tutorials/todo-list/server-complete/restapi/configure_todo_list.go
+++ b/examples/tutorials/todo-list/server-complete/restapi/configure_todo_list.go
@@ -4,6 +4,7 @@ package restapi
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -148,6 +149,8 @@ func configureAPI(api *operations.TodoListAPI) http.Handler {
 	})
 
 	api.ServerShutdown = func() {}
+	println(exampleFlags.Example1)
+	println(exampleFlags.Example2)
 
 	return setupGlobalMiddleware(api.Serve(setupMiddlewares))
 }
@@ -162,6 +165,9 @@ func configureTLS(tlsConfig *tls.Config) {
 // This function can be called multiple times, depending on the number of serving schemes.
 // scheme value will be set accordingly: "http", "https" or "unix"
 func configureServer(s *http.Server, scheme, addr string) {
+	if exampleFlags.Example1 != "something" {
+		fmt.Print("example1 argument is not something")
+	}
 }
 
 // The middleware configuration is for the handler executors. These do not apply to the swagger.json document.

--- a/examples/tutorials/todo-list/server-complete/restapi/configure_todo_list.go
+++ b/examples/tutorials/todo-list/server-complete/restapi/configure_todo_list.go
@@ -18,7 +18,22 @@ import (
 	"github.com/go-swagger/go-swagger/examples/tutorials/todo-list/server-complete/restapi/operations/todos"
 )
 
-//go:generate swagger generate server --target .. --name TodoList --spec ../swagger.yml
+// This file is safe to edit. Once it exists it will not be overwritten
+
+var exampleFlags = struct {
+	Example1 string `long:"example1" description:"Sample for showing how to configure cmd-line flags"`
+	Example2 string `long:"example2" description:"Further info at https://github.com/jessevdk/go-flags"`
+}{}
+
+func configureFlags(api *operations.TodoListAPI) {
+	api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{
+		swag.CommandLineOptionsGroup{
+			ShortDescription: "Example Flags",
+			LongDescription:  "",
+			Options:          &exampleFlags,
+		},
+	}
+}
 
 var items = make(map[int64]*models.Item)
 var lastID int64
@@ -86,10 +101,6 @@ func allItems(since int64, limit int32) (result []*models.Item) {
 		}
 	}
 	return
-}
-
-func configureFlags(api *operations.TodoListAPI) {
-	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }
 }
 
 func configureAPI(api *operations.TodoListAPI) http.Handler {


### PR DESCRIPTION
this PR brings back command-line flag example from PR https://github.com/go-swagger/go-swagger/pull/573  which was later removed by https://github.com/go-swagger/go-swagger/commit/9e978bcf2fff35aff57c7af1360d8f8f3d045d59#diff-6da81f07c9f2d75a4f98a7f45a6f36a0

@casualjim can you take a look, I don't believe it was intended to remove flags example...  

Also adding "usage" of the flags for clarity...