### PR TITLE
added contrib to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk --no-cache add ca-certificates shared-mime-info mailcap git build-base &
   go get -u golang.org/x/net/context/ctxhttp
 
 ADD ./swagger-musl /usr/bin/swagger
+ADD ./generator/templates/contrib/ /templates/contrib/
 
 ENTRYPOINT ["/usr/bin/swagger"]
 CMD ["--help"]


### PR DESCRIPTION
This will allow using the --template-dir parameter when using the
go-swagger container