### PR TITLE
Update go-openapi/analysis

### DIFF
--- a/fixtures/bugs/2092/.gitignore
+++ b/fixtures/bugs/2092/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/bugs/2092/definitions/addresses.yaml
+++ b/fixtures/bugs/2092/definitions/addresses.yaml
@@ -1,0 +1,5 @@
+address:
+  type: object
+  properties:
+    id:
+      type: integer

--- a/fixtures/bugs/2092/definitions/response.yaml
+++ b/fixtures/bugs/2092/definitions/response.yaml
@@ -1,0 +1,7 @@
+ok:
+  type: object
+  required:
+    - "message"
+  properties:
+    message:
+      type: string

--- a/fixtures/bugs/2092/definitions/teams.yaml
+++ b/fixtures/bugs/2092/definitions/teams.yaml
@@ -1,0 +1,23 @@
+teamupdate:
+  type: object
+  properties:
+    id:
+      type: string
+    home_address:
+      $ref: './addresses.yaml#/address'
+    invoice_address:
+      $ref: './addresses.yaml#/address'
+    members:
+      type: array
+      items:
+        $ref: "./user.yaml#/user"
+    settings:
+      $ref: "./teams.yaml#/teampatchsettings"
+
+teampatchsettings:
+  type: object
+  properties:
+    a:
+      type: string
+    b:
+      type: string

--- a/fixtures/bugs/2092/definitions/user.yaml
+++ b/fixtures/bugs/2092/definitions/user.yaml
@@ -1,0 +1,7 @@
+user:
+  type: object
+  properties:
+    id:
+      type: integer
+      readOnly: true
+      x-order: 1

--- a/fixtures/bugs/2092/fixture-2092.yaml
+++ b/fixtures/bugs/2092/fixture-2092.yaml
@@ -1,0 +1,28 @@
+consumes:
+- application/json
+produces:
+- application/json
+schemes:
+- http
+- https
+swagger: "2.0"
+info:
+  description: Descr
+  title: Titl
+  version: 2.0.0
+paths:
+  /users:
+    get:
+      summary: dummy path, in order to have a path.
+      responses:
+        "200":
+          description: (empty)
+          schema:
+            $ref: '#/definitions/user'
+definitions:
+  ok:
+    $ref: ./definitions/response.yaml#/ok
+  teamupdate:
+    $ref: ./definitions/teams.yaml#/teamupdate
+  user:
+    $ref: ./definitions/user.yaml#/user

--- a/fixtures/bugs/2092/gen-fixtures.sh
+++ b/fixtures/bugs/2092/gen-fixtures.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="${testcases} fixture-2092.yaml"
+for opts in  "" "--with-expand" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    serverName="codegensrv"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Model generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    # 1>x.log 2>&1
+    #
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/generator/bindata.go
+++ b/generator/bindata.go
@@ -831,38 +831,69 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"templates/additionalpropertiesserializer.gotmpl":          templatesAdditionalpropertiesserializerGotmpl,
-	"templates/client/client.gotmpl":                           templatesClientClientGotmpl,
-	"templates/client/facade.gotmpl":                           templatesClientFacadeGotmpl,
-	"templates/client/parameter.gotmpl":                        templatesClientParameterGotmpl,
-	"templates/client/response.gotmpl":                         templatesClientResponseGotmpl,
-	"templates/contrib/stratoscale/client/client.gotmpl":       templatesContribStratoscaleClientClientGotmpl,
-	"templates/contrib/stratoscale/client/facade.gotmpl":       templatesContribStratoscaleClientFacadeGotmpl,
+	"templates/additionalpropertiesserializer.gotmpl": templatesAdditionalpropertiesserializerGotmpl,
+
+	"templates/client/client.gotmpl": templatesClientClientGotmpl,
+
+	"templates/client/facade.gotmpl": templatesClientFacadeGotmpl,
+
+	"templates/client/parameter.gotmpl": templatesClientParameterGotmpl,
+
+	"templates/client/response.gotmpl": templatesClientResponseGotmpl,
+
+	"templates/contrib/stratoscale/client/client.gotmpl": templatesContribStratoscaleClientClientGotmpl,
+
+	"templates/contrib/stratoscale/client/facade.gotmpl": templatesContribStratoscaleClientFacadeGotmpl,
+
 	"templates/contrib/stratoscale/server/configureapi.gotmpl": templatesContribStratoscaleServerConfigureapiGotmpl,
-	"templates/contrib/stratoscale/server/server.gotmpl":       templatesContribStratoscaleServerServerGotmpl,
-	"templates/docstring.gotmpl":                               templatesDocstringGotmpl,
-	"templates/header.gotmpl":                                  templatesHeaderGotmpl,
-	"templates/model.gotmpl":                                   templatesModelGotmpl,
-	"templates/modelvalidator.gotmpl":                          templatesModelvalidatorGotmpl,
-	"templates/schema.gotmpl":                                  templatesSchemaGotmpl,
-	"templates/schemabody.gotmpl":                              templatesSchemabodyGotmpl,
-	"templates/schematype.gotmpl":                              templatesSchematypeGotmpl,
-	"templates/schemavalidator.gotmpl":                         templatesSchemavalidatorGotmpl,
-	"templates/server/builder.gotmpl":                          templatesServerBuilderGotmpl,
-	"templates/server/configureapi.gotmpl":                     templatesServerConfigureapiGotmpl,
-	"templates/server/doc.gotmpl":                              templatesServerDocGotmpl,
-	"templates/server/main.gotmpl":                             templatesServerMainGotmpl,
-	"templates/server/operation.gotmpl":                        templatesServerOperationGotmpl,
-	"templates/server/parameter.gotmpl":                        templatesServerParameterGotmpl,
-	"templates/server/responses.gotmpl":                        templatesServerResponsesGotmpl,
-	"templates/server/server.gotmpl":                           templatesServerServerGotmpl,
-	"templates/server/urlbuilder.gotmpl":                       templatesServerUrlbuilderGotmpl,
-	"templates/structfield.gotmpl":                             templatesStructfieldGotmpl,
-	"templates/swagger_json_embed.gotmpl":                      templatesSwagger_json_embedGotmpl,
-	"templates/tupleserializer.gotmpl":                         templatesTupleserializerGotmpl,
-	"templates/validation/customformat.gotmpl":                 templatesValidationCustomformatGotmpl,
-	"templates/validation/primitive.gotmpl":                    templatesValidationPrimitiveGotmpl,
-	"templates/validation/structfield.gotmpl":                  templatesValidationStructfieldGotmpl,
+
+	"templates/contrib/stratoscale/server/server.gotmpl": templatesContribStratoscaleServerServerGotmpl,
+
+	"templates/docstring.gotmpl": templatesDocstringGotmpl,
+
+	"templates/header.gotmpl": templatesHeaderGotmpl,
+
+	"templates/model.gotmpl": templatesModelGotmpl,
+
+	"templates/modelvalidator.gotmpl": templatesModelvalidatorGotmpl,
+
+	"templates/schema.gotmpl": templatesSchemaGotmpl,
+
+	"templates/schemabody.gotmpl": templatesSchemabodyGotmpl,
+
+	"templates/schematype.gotmpl": templatesSchematypeGotmpl,
+
+	"templates/schemavalidator.gotmpl": templatesSchemavalidatorGotmpl,
+
+	"templates/server/builder.gotmpl": templatesServerBuilderGotmpl,
+
+	"templates/server/configureapi.gotmpl": templatesServerConfigureapiGotmpl,
+
+	"templates/server/doc.gotmpl": templatesServerDocGotmpl,
+
+	"templates/server/main.gotmpl": templatesServerMainGotmpl,
+
+	"templates/server/operation.gotmpl": templatesServerOperationGotmpl,
+
+	"templates/server/parameter.gotmpl": templatesServerParameterGotmpl,
+
+	"templates/server/responses.gotmpl": templatesServerResponsesGotmpl,
+
+	"templates/server/server.gotmpl": templatesServerServerGotmpl,
+
+	"templates/server/urlbuilder.gotmpl": templatesServerUrlbuilderGotmpl,
+
+	"templates/structfield.gotmpl": templatesStructfieldGotmpl,
+
+	"templates/swagger_json_embed.gotmpl": templatesSwagger_json_embedGotmpl,
+
+	"templates/tupleserializer.gotmpl": templatesTupleserializerGotmpl,
+
+	"templates/validation/customformat.gotmpl": templatesValidationCustomformatGotmpl,
+
+	"templates/validation/primitive.gotmpl": templatesValidationPrimitiveGotmpl,
+
+	"templates/validation/structfield.gotmpl": templatesValidationStructfieldGotmpl,
 }
 
 // AssetDir returns the file names below a certain

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-swagger/go-swagger
 
-go 1.12
+go 1.13
 
 replace github.com/golang/lint => golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
 
@@ -9,7 +9,7 @@ require (
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/go-openapi/analysis v0.19.5
+	github.com/go-openapi/analysis v0.19.6
 	github.com/go-openapi/errors v0.19.2
 	github.com/go-openapi/inflect v0.19.0
 	github.com/go-openapi/loads v0.19.3

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/fredbi/analysis v0.19.5-0.20191028193618-dc649f9e9896 h1:4ZUBSO9/Y4AHLuK9nKfR9Y9MmJ8lJexQaQfc7UF7HVU=
+github.com/fredbi/analysis v0.19.5-0.20191028193618-dc649f9e9896/go.mod h1:hkEAkxagaIvIP7VTn8ygJNkd4kAYON2rCu0v0ObL0AU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -49,10 +51,10 @@ github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70t
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.19.2/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
-github.com/go-openapi/analysis v0.19.4 h1:1TjOzrWkj+9BrjnM1yPAICbaoC0FyfD49oVkTBrSSa0=
 github.com/go-openapi/analysis v0.19.4/go.mod h1:3P1osvZa9jKjb8ed2TPng3f0i/UY9snX6gxi44djMjk=
-github.com/go-openapi/analysis v0.19.5 h1:8b2ZgKfKIUTVQpTb77MoRDIMEIwvDVw40o3aOXdfYzI=
 github.com/go-openapi/analysis v0.19.5/go.mod h1:hkEAkxagaIvIP7VTn8ygJNkd4kAYON2rCu0v0ObL0AU=
+github.com/go-openapi/analysis v0.19.6 h1:5Z7zgx/EAmE9bf7cuTU1hkGQlZGzGDf9a1m57xRfNZk=
+github.com/go-openapi/analysis v0.19.6/go.mod h1:hkEAkxagaIvIP7VTn8ygJNkd4kAYON2rCu0v0ObL0AU=
 github.com/go-openapi/errors v0.17.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
 github.com/go-openapi/errors v0.18.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
 github.com/go-openapi/errors v0.19.2 h1:a2kIyV3w+OS3S97zxUndRVD46+FhGOUBDFY7nmu4CsY=

--- a/hack/codegen-nonreg.sh
+++ b/hack/codegen-nonreg.sh
@@ -171,6 +171,7 @@ singleFixtures=(\
 "fixtures/bugs/1260/test3-swagger.yaml fixtures/bugs/1260/test3-bis-swagger.yaml" \
 "fixtures/bugs/1260/test3-ter-swagger.yaml fixtures/bugs/1260/test3-ter-swagger-flat.json" \
 "fixtures/bugs/1851/fixture-1851.yaml" \
+"fixtures/bugs/2092/fixture-2092.yaml" \
 )
 
 if [[ "$1" == "--circleci" ]] ; then


### PR DESCRIPTION
Updates go-openapi/analysis to v0.19.6
(with https://github.com/go-openapi/analysis/pull/50)

* fixes #2092
* onboards fixture for #2092 in CI codegen tests

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>