### PR TITLE
codescan: Natively support json.RawMessage

### DIFF
--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -263,6 +263,10 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 			tgt.Typed("string", "date-time")
 			return nil
 		}
+		if pkg.PkgPath == "encoding/json" && tio.Name() == "RawMessage" {
+			tgt.Typed("object", "")
+			return nil
+		}
 		cmt, hasComments := s.ctx.FindComments(pkg, tio.Name())
 		if !hasComments {
 			cmt = new(ast.CommentGroup)


### PR DESCRIPTION
Before this patch, `encoding/json.RawMessage` would be interpreted as []uint8, which `encoding/json` is incapable of decoding. This patch addresses that by checking if a type's name is `encoding/json.RawMessage` and if so, sets `type: object`.

In #1622 it was suggested to use `type: string` with `format: binary` which is however not the correct use, because this is not an serialized JSON object but a deserialized JSON object.

If my understanding is correct, `type: string` with `fromat: binary` would expect something like:

```
{ "foo": "[\"bar\"]" }
```

for

```
type f struct { Foo json.RawMessage `json:"foo"` }
```

whereas `json.RawMessage` actually implies:

```
{ "foo": ["bar"] }
```

I've tried to mess around with `x-go-type`

```go
			tgt.AddExtension("x-go-type", map[string]interface{}{
				"import": map[string]interface{}{
					"alias":   "json",
					"package": "encoding/json",
				},
				"type": "RawMessage",
			})
```

but that yielded no result when generating the client code but I believe it to be the right extension here, it does seem however that its applicability is limited as discussed in: https://github.com/go-swagger/go-swagger/issues/1879#issuecomment-462347371

I do understand that `json.RawMessage` can be any defined JSON type, and that this is just a workaround for now, but it's better than what we have so far. I think a `oneOf` would be the appropriate setting here but I'm not sure how to implement that in this particular location. Happy for any pointers though.

Closes #1622 

Related #1879