### PR TITLE
Fix for path parameters parsing

### DIFF
--- a/codescan/route_params.go
+++ b/codescan/route_params.go
@@ -152,6 +152,11 @@ func (s *setOpParams) finalizeParam(param *spec.Parameter, data map[string]strin
 		return
 	}
 
+	// don't use schema with in:path params
+	if param.In == "path" {
+		param.Schema = nil
+	}
+
 	processSchema(data, param)
 
 	// schema is only allowed for parameters in "body"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-swagger/go-swagger
+module github.com/emreu/go-swagger
 
 go 1.24.0
 


### PR DESCRIPTION
Fixed parameters parsing for swagger:route annotation.
Previously invalid specification were generated due to parameters defined for path were setting "schema" field (only "type" field should be set). Now "schema" is dropped for in:path parameters.