### PR TITLE
Fixed x-omitempty in the case of $ref'ed schemas

### DIFF
--- a/fixtures/bugs/2116/.gitignore
+++ b/fixtures/bugs/2116/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/bugs/2116/fixture-2116.yaml
+++ b/fixtures/bugs/2116/fixture-2116.yaml
@@ -10,7 +10,6 @@ paths:
         200:
           description: ""
 definitions:
-
   Case-1--Fail--omitempty-false-not-hoisted-by-ref:
     type: object
     properties:
@@ -63,3 +62,62 @@ definitions:
       Data:
         type: object
     x-nullable: false
+
+  arrayWithNullable:
+    type: array
+    items:
+      type: string
+    x-nullable: true
+
+  arrayWithNullableItems:
+    type: array
+    items:
+      type: string
+      x-nullable: true
+
+  arrayWithDefault:
+    type: array
+    items:
+      type: string
+
+  arrayWithOmitEmpty:
+    type: array
+    items:
+      type: string
+    x-omitempty: true
+
+  arrayWithNoOmitEmpty:
+    type: array
+    items:
+      type: string
+    x-omitempty: false
+
+  arrayWithOmitEmptyItems:
+    type: array
+    items:
+      type: string
+      x-omitempty: false
+
+  objectWithArrays:
+    type: object
+    properties:
+      array0: # <- expect property to be omit empty
+        $ref: '#/definitions/arrayWithDefault'
+      array1: # <- expect property to be no omit empty
+        type: array
+        items:
+          type: string
+        x-omitempty: false
+      array11: # <- expect property to be omit empty
+        type: array
+        items:
+          type: string
+        x-omitempty: true
+      array12: # <- expect property to be no omit empty
+        type: array
+        items:
+          type: string
+      array2: # <- expect property to be omit empty
+        $ref: '#/definitions/arrayWithOmitEmpty'
+      array3: # <- expect property to be no omit empty
+        $ref: '#/definitions/arrayWithNoOmitEmpty'

--- a/fixtures/bugs/2116/fixture-2116.yaml
+++ b/fixtures/bugs/2116/fixture-2116.yaml
@@ -1,0 +1,65 @@
+swagger: "2.0"
+info:
+  title: ""
+  version: ""
+paths:
+  /:
+    get:
+      description: ""
+      responses:
+        200:
+          description: ""
+definitions:
+
+  Case-1--Fail--omitempty-false-not-hoisted-by-ref:
+    type: object
+    properties:
+      Body:
+        $ref: '#/definitions/Object-with-omitempty-false'
+
+  Case-2--Fail--omitempty-false-not-overridden-by-ref-sibling:
+    type: object
+    properties:
+      Body:
+        $ref: '#/definitions/Object-with-omitempty-true'
+        x-omitempty: false
+
+  Case-3--Pass--object-nullable-false-hoisted-by-ref:
+    type: object
+    properties:
+      Body:
+        $ref: '#/definitions/Object-with-nullable-false'
+
+  Case-4--Pass--object-nullable-false-overriden-by-ref-sibling:
+    type: object
+    properties:
+      Body:
+        $ref: '#/definitions/Object-with-nullable-true'
+        x-nullable: false
+
+  Object-with-omitempty-true:
+    type: object
+    properties:
+      Data:
+        type: object
+
+  Object-with-omitempty-false:
+    type: object
+    properties:
+      Data:
+        type: object
+    x-omitempty: false
+
+  Object-with-nullable-true:
+    type: object
+    properties:
+      Data:
+        type: object
+    x-nullable: true
+
+  Object-with-nullable-false:
+    type: object
+    properties:
+      Data:
+        type: object
+    x-nullable: false

--- a/fixtures/bugs/2116/gen-fixtures.sh
+++ b/fixtures/bugs/2116/gen-fixtures.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="${testcases} fixture-2116.yaml"
+for opts in  "" "--with-expand" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    serverName="codegensrv"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Model generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    # 1>x.log 2>&1
+    #
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/fixtures/enhancements/1623/swagger.yml
+++ b/fixtures/enhancements/1623/swagger.yml
@@ -49,10 +49,10 @@ definitions:
         x-omitempty: false
       generalNoOmitEmpty:
         type: string
-      refHasOmitEmptyTrue:
+      refHasOmitEmptyTrue: # <- discarded ($ref siblings are ignored, however, true is the default)
         x-omitempty: true
         $ref: "#/definitions/bar"
-      refHasOmitEmptyFalse:
+      refHasOmitEmptyFalse:  # <- discarded ($ref siblings are ignored)
         x-omitempty: false
         $ref: "#/definitions/bar"
       refNoOmitEmpty:

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -2487,7 +2487,7 @@ func TestGenModel_Issue1623(t *testing.T) {
 	assertInCode(t, "GeneralHasOmitEmptyFalse string `json:\"generalHasOmitEmptyFalse\"`", res)
 	assertInCode(t, "GeneralHasOmitEmptyTrue string `json:\"generalHasOmitEmptyTrue,omitempty\"`", res)
 	assertInCode(t, "GeneralNoOmitEmpty string `json:\"generalNoOmitEmpty,omitempty\"`", res)
-	assertInCode(t, "RefHasOmitEmptyFalse Bar `json:\"refHasOmitEmptyFalse\"`", res)
+	assertInCode(t, "RefHasOmitEmptyFalse Bar `json:\"refHasOmitEmptyFalse,omitempty\"`", res)
 	assertInCode(t, "RefHasOmitEmptyTrue Bar `json:\"refHasOmitEmptyTrue,omitempty\"`", res)
 	assertInCode(t, "RefNoOmitEmpty Bar `json:\"refNoOmitEmpty,omitempty\"`", res)
 	assertInCode(t, "IntHasJSONString int64 `json:\"intHasJsonString,omitempty,string\"`", res)

--- a/generator/moreschemavalidation_fixtures_test.go
+++ b/generator/moreschemavalidation_fixtures_test.go
@@ -6064,7 +6064,7 @@ func initTodolistSchemavalidation() {
 	// load expectations for model: array_multi_validations.go
 	flattenRun.AddExpectations("array_multi_validations.go", []string{
 		`type ArrayMultiValidations struct {`,
-		"	Args ArrayMultiValidationsArgs `json:\"args,omitempty\"`",
+		"	Args ArrayMultiValidationsArgs `json:\"args\"`", // arrays not omitempt-ied by default
 		`func (m *ArrayMultiValidations) Validate(formats strfmt.Registry) error {`,
 		`		return errors.CompositeValidationError(res...`,
 	},
@@ -7292,7 +7292,7 @@ func initTodolistSchemavalidation() {
 	// load expectations for model: array_additional_validations.go
 	flattenRun.AddExpectations("array_additional_validations.go", []string{
 		`type ArrayAdditionalValidations struct {`,
-		"	Args ArrayAdditionalValidationsArgs `json:\"args,omitempty\"`",
+		"	Args ArrayAdditionalValidationsArgs `json:\"args\"`", // arrays not omit-emptied by default
 		`func (m *ArrayAdditionalValidations) Validate(formats strfmt.Registry) error {`,
 		`	if err := m.validateArgs(formats); err != nil {`,
 		`		return errors.CompositeValidationError(res...`,

--- a/generator/moreschemavalidation_fixtures_test.go
+++ b/generator/moreschemavalidation_fixtures_test.go
@@ -14,6 +14,76 @@
 
 package generator
 
+func initFixture2116() {
+	f := newModelFixture("../fixtures/bugs/2116/fixture-2116.yaml", "check x-omitempty and x-nullable with $ref")
+	flattenRun := f.AddRun(false).WithMinimalFlatten(true)
+
+	flattenRun.AddExpectations("case1_fail_omitempty_false_not_hoisted_by_ref.go", []string{
+		"Body *ObjectWithOmitemptyFalse `json:\"Body\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("case2_fail_omitempty_false_not_overridden_by_ref_sibling.go", []string{
+		"Body *ObjectWithOmitemptyTrue `json:\"Body,omitempty\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("case3_pass_object_nullable_false_hoisted_by_ref.go", []string{
+		"Body ObjectWithNullableFalse `json:\"Body,omitempty\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("case4_pass_object_nullable_false_overriden_by_ref_sibling.go", []string{
+		"Body *ObjectWithNullableTrue `json:\"Body,omitempty\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("array_with_default.go", []string{
+		"type ArrayWithDefault []string",
+	}, append(todo, "omitempty"), noLines, noLines)
+
+	flattenRun.AddExpectations("array_with_no_omit_empty.go", []string{
+		"type ArrayWithNoOmitEmpty []string",
+	}, append(todo, "omitempty"), noLines, noLines)
+
+	flattenRun.AddExpectations("array_with_nullable.go", []string{
+		"type ArrayWithNullable []string",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("array_with_nullable_items.go", []string{
+		"type ArrayWithNullableItems []*string",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("array_with_omit_empty.go", []string{
+		"type ArrayWithOmitEmpty []string",
+	}, append(todo, "omitempty"), noLines, noLines)
+
+	flattenRun.AddExpectations("object_with_arrays.go", []string{
+		"Array0 ArrayWithDefault `json:\"array0,omitempty\"`",
+		"Array1 []string `json:\"array1\"`",
+		"Array11 []string `json:\"array11,omitempty\"`",
+		"Array12 []string `json:\"array12\"`",
+		"Array2 ArrayWithOmitEmpty `json:\"array2,omitempty\"`",
+		"Array3 ArrayWithNoOmitEmpty `json:\"array3\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("object_with_nullable_false.go", []string{
+		"Data interface{} `json:\"Data,omitempty\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("object_with_nullable_true.go", []string{
+		"Data interface{} `json:\"Data,omitempty\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("object_with_omitempty_false.go", []string{
+		"Data interface{} `json:\"Data,omitempty\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("object_with_omitempty_true.go", []string{
+		"Data interface{} `json:\"Data,omitempty\"`",
+	}, todo, noLines, noLines)
+
+	flattenRun.AddExpectations("array_with_omit_empty_items.go", []string{
+		"type ArrayWithOmitEmptyItems []string",
+	}, append(todo, "omitempty"), noLines, noLines)
+}
+
 func initFixture2071() {
 	f := newModelFixture("../fixtures/bugs/2071/fixture-2071.yaml", "check allOf serializer when x-go-name is present")
 	flattenRun := f.AddRun(false).WithMinimalFlatten(true)
@@ -6064,7 +6134,7 @@ func initTodolistSchemavalidation() {
 	// load expectations for model: array_multi_validations.go
 	flattenRun.AddExpectations("array_multi_validations.go", []string{
 		`type ArrayMultiValidations struct {`,
-		"	Args ArrayMultiValidationsArgs `json:\"args\"`", // arrays not omitempt-ied by default
+		"	Args ArrayMultiValidationsArgs `json:\"args,omitempty\"`",
 		`func (m *ArrayMultiValidations) Validate(formats strfmt.Registry) error {`,
 		`		return errors.CompositeValidationError(res...`,
 	},
@@ -7292,7 +7362,7 @@ func initTodolistSchemavalidation() {
 	// load expectations for model: array_additional_validations.go
 	flattenRun.AddExpectations("array_additional_validations.go", []string{
 		`type ArrayAdditionalValidations struct {`,
-		"	Args ArrayAdditionalValidationsArgs `json:\"args\"`", // arrays not omit-emptied by default
+		"	Args ArrayAdditionalValidationsArgs `json:\"args,omitempty\"`",
 		`func (m *ArrayAdditionalValidations) Validate(formats strfmt.Registry) error {`,
 		`	if err := m.validateArgs(formats); err != nil {`,
 		`		return errors.CompositeValidationError(res...`,

--- a/generator/moreschemavalidation_test.go
+++ b/generator/moreschemavalidation_test.go
@@ -206,6 +206,9 @@ func initModelFixtures() {
 
 	// allOf marshallers
 	initFixture2071()
+
+	// x-omitempty
+	initFixture2116()
 }
 
 /* Template initTxxx() to prepare and load a fixture:
@@ -338,7 +341,8 @@ func TestMoreModelValidations(t *testing.T) {
 						// please do not inject fixtures with case conflicts on defs...
 						// this one is just easier to retrieve model back from file names when capturing
 						// the generated code.
-						if strings.EqualFold(def, k) {
+						mangled := swag.ToJSONName(def)
+						if strings.EqualFold(mangled, k) {
 							schema = &s
 							definitionName = def
 							break


### PR DESCRIPTION
**ATTENTION: there is a subtle change in here that SHOULD be discussed before blindly merging!!!**

* fixes #2116
* tests are embedded with existing testcase for #1623 (added by #1751)
* ensure arrays _of primitives_ are not omitempty-ed by default, including arrays declared as properties
* arrays as aliased types used as properties remain empty-omitted by default (this may be altered with the x-omitempty extension)

@zhuangqh this brings some slight changes to your PR #1751. Visible outcome is:
- extensions declared as siblings to $ref are ignored
- properties which _are_ arrays are not always empty-omitted by default: to avoid introducing breaking changes I adopted the rule array of primitive vs aliased array

@zhuangqh since you brought in that change in the first place, I'd like to have your opinion on the second point

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>