### PR TITLE
Speedup 'swagger generate' by not re-parsing schemas many times

### DIFF
--- a/generator/operation.go
+++ b/generator/operation.go
@@ -274,6 +274,7 @@ type codeGenOpBuilder struct {
 	Target              string
 	Operation           spec.Operation
 	Doc                 *loads.Document
+	PristineDoc         *loads.Document
 	Analyzed            *analysis.Spec
 	DefaultImports      []string
 	Imports             map[string]string
@@ -1015,7 +1016,10 @@ func (b *codeGenOpBuilder) cloneSchema(schema *spec.Schema) *spec.Schema {
 // This uses a deep clone the spec document to construct a type resolver which knows about definitions when the making of this operation started,
 // and only these definitions. We are not interested in the "original spec", but in the already transformed spec.
 func (b *codeGenOpBuilder) saveResolveContext(resolver *typeResolver, schema *spec.Schema) (*typeResolver, *spec.Schema) {
-	rslv := newTypeResolver(b.GenOpts.LanguageOpts.ManglePackageName(resolver.ModelsPackage, "models"), b.Doc.Pristine())
+	if b.PristineDoc == nil {
+		b.PristineDoc = b.Doc.Pristine()
+	}
+	rslv := newTypeResolver(b.GenOpts.LanguageOpts.ManglePackageName(resolver.ModelsPackage, "models"), b.PristineDoc)
 
 	return rslv, b.cloneSchema(schema)
 }


### PR DESCRIPTION
b.Doc.Pristine() is surprisingly slow, so keep it once it is produced.

This change speeds up `swagger generate` on one YAML file from 7.9s to 3.9s.
