### PR TITLE
Fix processing type declarations

### DIFF
--- a/codescan/application.go
+++ b/codescan/application.go
@@ -483,12 +483,12 @@ func (a *typeIndex) processDecl(pkg *packages.Package, file *ast.File, n node, g
 			def, ok := pkg.TypesInfo.Defs[ts.Name]
 			if !ok {
 				debugLog("couldn't find type info for %s", ts.Name)
-				//continue
+				continue
 			}
 			nt, isNamed := def.Type().(*types.Named)
 			if !isNamed {
 				debugLog("%s is not a named type but a %T", ts.Name, def.Type())
-				//continue
+				continue
 			}
 			decl := &entityDecl{
 				Comments: gd.Doc,


### PR DESCRIPTION
When `codescan/application.go` was created, the continues in
(*typeIndex).processDecl() were commented out. This led to issues if
there were structs declared in the package that were unrelated to the
swagger api (no swagger declaration type).

Signed-off-by: Pat Long <pllong@arista.com>