### PR TITLE
CLI: refactored CLI commands to introduce command groups

### DIFF
--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -20,57 +20,51 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
+type clientOptions struct {
+	ClientPackage string `long:"client-package" short:"c" description:"the package to save the client specific code" default:"client"`
+}
+
+func (co clientOptions) apply(opts *generator.GenOpts) {
+	opts.ClientPackage = co.ClientPackage
+}
+
 // Client the command to generate a swagger client
 type Client struct {
-	shared
-	Name            string   `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
-	Operations      []string `long:"operation" short:"O" description:"specify an operation to include, repeat for multiple"`
-	Tags            []string `long:"tags" description:"the tags to include, if not specified defaults to all"`
-	Principal       string   `long:"principal" short:"P" description:"the model to use for the security principal"`
-	Models          []string `long:"model" short:"M" description:"specify a model to include, repeat for multiple"`
-	DefaultScheme   string   `long:"default-scheme" description:"the default scheme for this client" default:"http"`
-	DefaultProduces string   `long:"default-produces" description:"the default mime type that API operations produce" default:"application/json"`
-	SkipModels      bool     `long:"skip-models" description:"no models will be generated when this flag is specified"`
-	SkipOperations  bool     `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
-	DumpData        bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
-	SkipValidation  bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
+	WithShared
+	WithModels
+	WithOperations
+
+	clientOptions
+	schemeOptions
+	mediaOptions
+
+	SkipModels     bool `long:"skip-models" description:"no models will be generated when this flag is specified"`
+	SkipOperations bool `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
+
+	Name string `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
 }
 
-func (c *Client) getOpts() (*generator.GenOpts, error) {
-	return &generator.GenOpts{
-		Spec: string(c.Spec),
+func (c Client) apply(opts *generator.GenOpts) {
+	c.Shared.apply(opts)
+	c.Models.apply(opts)
+	c.Operations.apply(opts)
+	c.clientOptions.apply(opts)
+	c.schemeOptions.apply(opts)
+	c.mediaOptions.apply(opts)
 
-		Target:                string(c.Target),
-		APIPackage:            c.APIPackage,
-		ModelPackage:          c.ModelPackage,
-		ServerPackage:         c.ServerPackage,
-		ClientPackage:         c.ClientPackage,
-		Principal:             c.Principal,
-		DefaultScheme:         c.DefaultScheme,
-		DefaultProduces:       c.DefaultProduces,
-		IncludeModel:          !c.SkipModels,
-		IncludeValidator:      !c.SkipModels,
-		IncludeHandler:        !c.SkipOperations,
-		IncludeParameters:     !c.SkipOperations,
-		IncludeResponses:      !c.SkipOperations,
-		ValidateSpec:          !c.SkipValidation,
-		Tags:                  c.Tags,
-		IncludeSupport:        true,
-		Template:              c.Template,
-		TemplateDir:           string(c.TemplateDir),
-		DumpData:              c.DumpData,
-		ExistingModels:        c.ExistingModels,
-		AllowTemplateOverride: c.AllowTemplateOverride,
-		IsClient:              true,
-	}, nil
-}
+	opts.IncludeModel = !c.SkipModels
+	opts.IncludeValidator = !c.SkipModels
+	opts.IncludeHandler = !c.SkipOperations
+	opts.IncludeParameters = !c.SkipOperations
+	opts.IncludeResponses = !c.SkipOperations
+	opts.Name = c.Name
 
-func (c *Client) getShared() *shared {
-	return &c.shared
+	opts.IsClient = true
+	opts.IncludeSupport = true
 }
 
 func (c *Client) generate(opts *generator.GenOpts) error {
-	return generator.GenerateClient(c.Name, c.Models, c.Operations, opts)
+	return generator.GenerateClient(c.Name, c.Models.Models, c.Operations.Operations, opts)
 }
 
 func (c *Client) log(rp string) {

--- a/cmd/swagger/commands/generate/client_test.go
+++ b/cmd/swagger/commands/generate/client_test.go
@@ -36,7 +36,7 @@ func TestGenerateClient(t *testing.T) {
 			spec:      "todolist.simplequery.yml",
 			wantError: false,
 			prepare: func(c *generate.Client) {
-				c.CopyrightFile = flags.Filename(filepath.Join(base, "LICENSE"))
+				c.Shared.CopyrightFile = flags.Filename(filepath.Join(base, "LICENSE"))
 			},
 		},
 		{
@@ -66,9 +66,9 @@ func TestGenerateClient(t *testing.T) {
 			}()
 			m := &generate.Client{}
 			_, _ = flags.Parse(m)
-			m.Spec = flags.Filename(path)
-			m.Target = flags.Filename(generated)
-			m.Template = tt.template
+			m.Shared.Spec = flags.Filename(path)
+			m.Shared.Target = flags.Filename(generated)
+			m.Shared.Template = tt.template
 
 			if tt.prepare != nil {
 				tt.prepare(m)
@@ -90,7 +90,7 @@ func TestGenerateClient_Check(t *testing.T) {
 
 	m := &generate.Client{}
 	_, _ = flags.Parse(m)
-	m.CopyrightFile = "nullePart"
+	m.Shared.CopyrightFile = "nullePart"
 	err := m.Execute([]string{})
 	assert.Error(t, err)
 }

--- a/cmd/swagger/commands/generate/contrib.go
+++ b/cmd/swagger/commands/generate/contrib.go
@@ -6,6 +6,7 @@ import (
 
 // contribOptionsOverride gives contributed templates the ability to override the options if they need
 func contribOptionsOverride(opts *generator.GenOpts) {
+	// nolint: gocritic
 	switch opts.Template {
 	case "stratoscale":
 		// Stratoscale template needs to regenerate the configureapi on every run.

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -17,37 +17,78 @@ package generate
 import (
 	"errors"
 	"log"
+
+	"github.com/go-swagger/go-swagger/generator"
 )
+
+type modelOptions struct {
+	ModelPackage               string   `long:"model-package" short:"m" description:"the package to save the models" default:"models"`
+	Models                     []string `long:"model" short:"M" description:"specify a model to include in generation, repeat for multiple (defaults to all)"`
+	ExistingModels             string   `long:"existing-models" description:"use pre-generated models e.g. github.com/foobar/model"`
+	StrictAdditionalProperties bool     `long:"strict-additional-properties" description:"disallow extra properties when additionalProperties is set to false"`
+	KeepSpecOrder              bool     `long:"keep-spec-order" description:"keep schema properties order identical to spec file"`
+}
+
+func (mo modelOptions) apply(opts *generator.GenOpts) {
+	opts.ModelPackage = mo.ModelPackage
+	opts.Models = mo.Models
+	opts.ExistingModels = mo.ExistingModels
+	opts.StrictAdditionalProperties = mo.StrictAdditionalProperties
+	opts.PropertiesSpecOrder = mo.KeepSpecOrder
+}
+
+// WithModels adds the model options group
+type WithModels struct {
+	Models modelOptions `group:"Options for model generation"`
+}
 
 // Model the generate model file command
 type Model struct {
-	shared
-	Name           []string `long:"name" short:"n" description:"the model to generate"`
-	NoStruct       bool     `long:"skip-struct" description:"when present will not generate the model struct"`
-	DumpData       bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
-	SkipValidation bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
+	WithShared
+	WithModels
+
+	NoStruct bool `long:"skip-struct" description:"when present will not generate the model struct"`
+
+	Name []string `long:"name" short:"n" description:"the model to generate, repeat for multiple (defaults to all). Same as --models"`
+}
+
+func (m Model) apply(opts *generator.GenOpts) {
+	m.Shared.apply(opts)
+	m.Models.apply(opts)
+
+	opts.IncludeModel = !m.NoStruct
+	opts.IncludeValidator = !m.NoStruct
+}
+
+func (m Model) log(rp string) {
+	log.Printf(`Generation completed!
+
+For this generation to compile you need to have some packages in your GOPATH:
+
+	* github.com/go-openapi/validate
+	* github.com/go-openapi/strfmt
+
+You can get these now with: go get -u -f %s/...
+`, rp)
+}
+
+func (m *Model) generate(opts *generator.GenOpts) error {
+	// NOTE: at the moment, the model generator (generator.GenerateDefinition)
+	// is not standalone: use server generator as a proxy
+	opts.IncludeSupport = false
+	opts.IncludeMain = false
+	return generator.GenerateServer("", append(m.Name, m.Models.Models...), nil, opts)
 }
 
 // Execute generates a model file
 func (m *Model) Execute(args []string) error {
 
-	if m.DumpData && len(m.Name) > 1 {
+	if m.Shared.DumpData && (len(m.Name) > 1 || len(m.Models.Models) > 1) {
 		return errors.New("only 1 model at a time is supported for dumping data")
 	}
 
-	if m.ExistingModels != "" {
+	if m.Models.ExistingModels != "" {
 		log.Println("warning: Ignoring existing-models flag when generating models.")
 	}
-	s := &Server{
-		shared:         m.shared,
-		Models:         m.Name,
-		DumpData:       m.DumpData,
-		ExcludeMain:    true,
-		ExcludeSpec:    true,
-		SkipSupport:    true,
-		SkipOperations: true,
-		SkipModels:     m.NoStruct,
-		SkipValidation: m.SkipValidation,
-	}
-	return s.Execute(args)
+	return createSwagger(m)
 }

--- a/cmd/swagger/commands/generate/model_test.go
+++ b/cmd/swagger/commands/generate/model_test.go
@@ -41,10 +41,10 @@ func TestGenerateModel(t *testing.T) {
 			m := &generate.Model{}
 			_, _ = flags.Parse(m)
 			if i == 0 {
-				m.ExistingModels = "nonExisting"
+				m.Models.ExistingModels = "nonExisting"
 			}
-			m.Spec = flags.Filename(path)
-			m.Target = flags.Filename(generated)
+			m.Shared.Spec = flags.Filename(path)
+			m.Shared.Target = flags.Filename(generated)
 
 			if err := m.Execute([]string{}); err != nil {
 				t.Error(err)
@@ -59,7 +59,7 @@ func TestGenerateModel_Check(t *testing.T) {
 
 	m := &generate.Model{}
 	_, _ = flags.Parse(m)
-	m.DumpData = true
+	m.Shared.DumpData = true
 	m.Name = []string{"model1", "model2"}
 	err := m.Execute([]string{})
 	assert.Error(t, err)

--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -21,51 +21,60 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
+type operationOptions struct {
+	Operations []string `long:"operation" short:"O" description:"specify an operation to include, repeat for multiple (defaults to all)"`
+	Tags       []string `long:"tags" description:"the tags to include, if not specified defaults to all" group:"operations"`
+	APIPackage string   `long:"api-package" short:"a" description:"the package to save the operations" default:"operations"`
+}
+
+func (oo operationOptions) apply(opts *generator.GenOpts) {
+	opts.Operations = oo.Operations
+	opts.Tags = oo.Tags
+	opts.APIPackage = oo.APIPackage
+}
+
+// WithOperations adds the operations options group
+type WithOperations struct {
+	Operations operationOptions `group:"Options for operation generation"`
+}
+
 // Operation the generate operation files command
 type Operation struct {
-	shared
-	Name           []string `long:"name" short:"n" required:"true" description:"the operations to generate, repeat for multiple"`
-	Tags           []string `long:"tags" description:"the tags to include, if not specified defaults to all"`
-	Principal      string   `short:"P" long:"principal" description:"the model to use for the security principal"`
-	DefaultScheme  string   `long:"default-scheme" description:"the default scheme for this API" default:"http"`
-	NoHandler      bool     `long:"skip-handler" description:"when present will not generate an operation handler"`
-	NoStruct       bool     `long:"skip-parameters" description:"when present will not generate the parameter model struct"`
-	NoResponses    bool     `long:"skip-responses" description:"when present will not generate the response model struct"`
-	NoURLBuilder   bool     `long:"skip-url-builder" description:"when present will not generate a URL builder"`
-	DumpData       bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
-	SkipValidation bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
+	WithShared
+	WithOperations
+
+	clientOptions
+	serverOptions
+	schemeOptions
+	mediaOptions
+
+	NoHandler    bool `long:"skip-handler" description:"when present will not generate an operation handler"`
+	NoStruct     bool `long:"skip-parameters" description:"when present will not generate the parameter model struct"`
+	NoResponses  bool `long:"skip-responses" description:"when present will not generate the response model struct"`
+	NoURLBuilder bool `long:"skip-url-builder" description:"when present will not generate a URL builder"`
+
+	Name []string `long:"name" short:"n" required:"true" description:"the operations to generate, repeat for multiple (defaults to all). Same as --operations"`
 }
 
-func (o *Operation) getOpts() (*generator.GenOpts, error) {
-	return &generator.GenOpts{
-		Spec:              string(o.Spec),
-		Target:            string(o.Target),
-		APIPackage:        o.APIPackage,
-		ModelPackage:      o.ModelPackage,
-		ServerPackage:     o.ServerPackage,
-		ClientPackage:     o.ClientPackage,
-		Principal:         o.Principal,
-		DumpData:          o.DumpData,
-		DefaultScheme:     o.DefaultScheme,
-		TemplateDir:       string(o.TemplateDir),
-		IncludeHandler:    !o.NoHandler,
-		IncludeResponses:  !o.NoResponses,
-		IncludeParameters: !o.NoStruct,
-		IncludeURLBuilder: !o.NoURLBuilder,
-		Tags:              o.Tags,
-		ValidateSpec:      !o.SkipValidation,
-	}, nil
-}
+func (o Operation) apply(opts *generator.GenOpts) {
+	o.Shared.apply(opts)
+	o.Operations.apply(opts)
+	o.clientOptions.apply(opts)
+	o.serverOptions.apply(opts)
+	o.schemeOptions.apply(opts)
+	o.mediaOptions.apply(opts)
 
-func (o *Operation) getShared() *shared {
-	return &o.shared
+	opts.IncludeHandler = !o.NoHandler
+	opts.IncludeResponses = !o.NoResponses
+	opts.IncludeParameters = !o.NoStruct
+	opts.IncludeURLBuilder = !o.NoURLBuilder
 }
 
 func (o *Operation) generate(opts *generator.GenOpts) error {
-	return generator.GenerateServerOperation(o.Name, opts)
+	return generator.GenerateServerOperation(append(o.Name, o.Operations.Operations...), opts)
 }
 
-func (o *Operation) log(rp string) {
+func (o Operation) log(rp string) {
 
 	log.Printf(`Generation completed!
 
@@ -79,7 +88,7 @@ You can get these now with: go get -u -f %s/...
 
 // Execute generates a model file
 func (o *Operation) Execute(args []string) error {
-	if o.DumpData && len(o.Name) > 1 {
+	if o.Shared.DumpData && (len(o.Name) > 1 || len(o.Operations.Operations) > 1) {
 		return errors.New("only 1 operation at a time is supported for dumping data")
 	}
 

--- a/cmd/swagger/commands/generate/operation_test.go
+++ b/cmd/swagger/commands/generate/operation_test.go
@@ -33,11 +33,11 @@ func TestGenerateOperation(t *testing.T) {
 			}()
 			m := &generate.Operation{}
 			if i == 0 {
-				m.CopyrightFile = flags.Filename(filepath.Join(base, "LICENSE"))
+				m.Shared.CopyrightFile = flags.Filename(filepath.Join(base, "LICENSE"))
 			}
 			_, _ = flags.ParseArgs(m, []string{"--name=listTasks"})
-			m.Spec = flags.Filename(path)
-			m.Target = flags.Filename(generated)
+			m.Shared.Spec = flags.Filename(path)
+			m.Shared.Target = flags.Filename(generated)
 
 			if err := m.Execute([]string{}); err != nil {
 				t.Error(err)
@@ -52,7 +52,7 @@ func TestGenerateOperation_Check(t *testing.T) {
 
 	m := &generate.Operation{}
 	_, _ = flags.ParseArgs(m, []string{"--name=op1", "--name=op2"})
-	m.DumpData = true
+	m.Shared.DumpData = true
 	m.Name = []string{"op1", "op2"}
 	err := m.Execute([]string{})
 	assert.Error(t, err)

--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -21,87 +21,79 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
-// Server the command to generate an entire server application
-type Server struct {
-	shared
-	Name                       string   `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
-	Operations                 []string `long:"operation" short:"O" description:"specify an operation to include, repeat for multiple"`
-	Tags                       []string `long:"tags" description:"the tags to include, if not specified defaults to all"`
-	Principal                  string   `long:"principal" short:"P" description:"the model to use for the security principal"`
-	DefaultScheme              string   `long:"default-scheme" description:"the default scheme for this API" default:"http"`
-	Models                     []string `long:"model" short:"M" description:"specify a model to include, repeat for multiple"`
-	SkipModels                 bool     `long:"skip-models" description:"no models will be generated when this flag is specified"`
-	SkipOperations             bool     `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
-	SkipSupport                bool     `long:"skip-support" description:"no supporting files will be generated when this flag is specified"`
-	ExcludeMain                bool     `long:"exclude-main" description:"exclude main function, so just generate the library"`
-	ExcludeSpec                bool     `long:"exclude-spec" description:"don't embed the swagger specification"`
-	WithContext                bool     `long:"with-context" description:"handlers get a context as first arg (deprecated)"`
-	DumpData                   bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
-	FlagStrategy               string   `long:"flag-strategy" description:"the strategy to provide flags for the server" default:"go-flags" choice:"go-flags" choice:"pflag" choice:"flag"`
-	CompatibilityMode          string   `long:"compatibility-mode" description:"the compatibility mode for the tls server" default:"modern" choice:"modern" choice:"intermediate"`
-	SkipValidation             bool     `long:"skip-validation" description:"skips validation of spec prior to generation"`
-	RegenerateConfigureAPI     bool     `long:"regenerate-configureapi" description:"Force regeneration of configureapi.go"`
-	KeepSpecOrder              bool     `long:"keep-spec-order" description:"Keep schema properties order identical to spec file"`
-	StrictAdditionalProperties bool     `long:"strict-additional-properties" description:"disallow extra properties when additionalProperties is set to false"`
+type serverOptions struct {
+	ServerPackage string `long:"server-package" short:"s" description:"the package to save the server specific code" default:"restapi"`
 }
 
-func (s *Server) getOpts() (*generator.GenOpts, error) {
-	// warning: deprecation
+func (cs serverOptions) apply(opts *generator.GenOpts) {
+	opts.ServerPackage = cs.ServerPackage
+}
+
+// Server the command to generate an entire server application
+type Server struct {
+	WithShared
+	WithModels
+	WithOperations
+
+	serverOptions
+	schemeOptions
+	mediaOptions
+
+	SkipModels             bool   `long:"skip-models" description:"no models will be generated when this flag is specified"`
+	SkipOperations         bool   `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
+	SkipSupport            bool   `long:"skip-support" description:"no supporting files will be generated when this flag is specified"`
+	ExcludeMain            bool   `long:"exclude-main" description:"exclude main function, so just generate the library"`
+	ExcludeSpec            bool   `long:"exclude-spec" description:"don't embed the swagger specification"`
+	FlagStrategy           string `long:"flag-strategy" description:"the strategy to provide flags for the server" default:"go-flags" choice:"go-flags" choice:"pflag" choice:"flag"` // nolint: staticcheck
+	CompatibilityMode      string `long:"compatibility-mode" description:"the compatibility mode for the tls server" default:"modern" choice:"modern" choice:"intermediate"`          // nolint: staticcheck
+	RegenerateConfigureAPI bool   `long:"regenerate-configureapi" description:"Force regeneration of configureapi.go"`
+
+	Name string `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
+	// TODO(fredbi): CmdName string `long:"cmd-name" short:"A" description:"the name of the server command, when main is generated (defaults to {name}-server)"`
+
+	//deprecated flags
+	WithContext bool `long:"with-context" description:"handlers get a context as first arg (deprecated)"`
+}
+
+func (s Server) apply(opts *generator.GenOpts) {
 	if s.WithContext {
 		log.Printf("warning: deprecated option --with-context is ignored")
 	}
 
-	return &generator.GenOpts{
-		Spec:                       string(s.Spec),
-		Target:                     string(s.Target),
-		APIPackage:                 s.APIPackage,
-		ModelPackage:               s.ModelPackage,
-		ServerPackage:              s.ServerPackage,
-		ClientPackage:              s.ClientPackage,
-		Principal:                  s.Principal,
-		DefaultScheme:              s.DefaultScheme,
-		IncludeModel:               !s.SkipModels,
-		IncludeValidator:           !s.SkipModels,
-		IncludeHandler:             !s.SkipOperations,
-		IncludeParameters:          !s.SkipOperations,
-		IncludeResponses:           !s.SkipOperations,
-		IncludeURLBuilder:          !s.SkipOperations,
-		IncludeMain:                !s.ExcludeMain,
-		IncludeSupport:             !s.SkipSupport,
-		PropertiesSpecOrder:        s.KeepSpecOrder,
-		ValidateSpec:               !s.SkipValidation,
-		ExcludeSpec:                s.ExcludeSpec,
-		StrictAdditionalProperties: s.StrictAdditionalProperties,
-		Template:                   s.Template,
-		RegenerateConfigureAPI:     s.RegenerateConfigureAPI,
-		TemplateDir:                string(s.TemplateDir),
-		DumpData:                   s.DumpData,
-		Models:                     s.Models,
-		Operations:                 s.Operations,
-		Tags:                       s.Tags,
-		Name:                       s.Name,
-		FlagStrategy:               s.FlagStrategy,
-		CompatibilityMode:          s.CompatibilityMode,
-		ExistingModels:             s.ExistingModels,
-		AllowTemplateOverride:      s.AllowTemplateOverride,
-	}, nil
-}
+	s.Shared.apply(opts)
+	s.Models.apply(opts)
+	s.Operations.apply(opts)
+	s.serverOptions.apply(opts)
+	s.schemeOptions.apply(opts)
+	s.mediaOptions.apply(opts)
 
-func (s *Server) getShared() *shared {
-	return &s.shared
+	opts.IncludeModel = !s.SkipModels
+	opts.IncludeValidator = !s.SkipModels
+	opts.IncludeHandler = !s.SkipOperations
+	opts.IncludeParameters = !s.SkipOperations
+	opts.IncludeResponses = !s.SkipOperations
+	opts.IncludeURLBuilder = !s.SkipOperations
+	opts.IncludeSupport = !s.SkipSupport
+	opts.IncludeMain = !s.ExcludeMain
+	opts.FlagStrategy = s.FlagStrategy
+	opts.CompatibilityMode = s.CompatibilityMode
+	opts.RegenerateConfigureAPI = s.RegenerateConfigureAPI
+
+	opts.Name = s.Name
 }
 
 func (s *Server) generate(opts *generator.GenOpts) error {
-	return generator.GenerateServer(s.Name, s.Models, s.Operations, opts)
+	return generator.GenerateServer(s.Name, s.Models.Models, s.Operations.Operations, opts)
 }
 
-func (s *Server) log(rp string) {
+func (s Server) log(rp string) {
 	var flagsPackage string
-	if strings.HasPrefix(s.FlagStrategy, "pflag") {
+	switch {
+	case strings.HasPrefix(s.FlagStrategy, "pflag"):
 		flagsPackage = "github.com/spf13/pflag"
-	} else if strings.HasPrefix(s.FlagStrategy, "flag") {
+	case strings.HasPrefix(s.FlagStrategy, "flag"):
 		flagsPackage = "flag"
-	} else {
+	default:
 		flagsPackage = "github.com/jessevdk/go-flags"
 	}
 

--- a/cmd/swagger/commands/generate/server_internal_test.go
+++ b/cmd/swagger/commands/generate/server_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-swagger/go-swagger/generator"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +17,6 @@ func TestDeprecated(t *testing.T) {
 	s := Server{
 		WithContext: true,
 	}
-	_, err := s.getOpts()
-	assert.NoError(t, err)
+	s.apply(new(generator.GenOpts))
 	assert.Contains(t, buf.String(), "warning")
 }

--- a/cmd/swagger/commands/generate/server_test.go
+++ b/cmd/swagger/commands/generate/server_test.go
@@ -17,6 +17,7 @@ func TestGenerateServer(t *testing.T) {
 	specs := []string{
 		"billforward.discriminators.yml",
 		"todolist.simplequery.yml",
+		"todolist.simplequery.yml",
 	}
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)
@@ -35,13 +36,16 @@ func TestGenerateServer(t *testing.T) {
 			m := &generate.Server{}
 			_, _ = flags.Parse(m)
 			if i == 0 {
-				m.CopyrightFile = flags.Filename(filepath.Join(base, "LICENSE"))
+				m.Shared.CopyrightFile = flags.Filename(filepath.Join(base, "LICENSE"))
 			}
-			if i == 1 {
+			switch i {
+			case 1:
 				m.FlagStrategy = "pflag"
+			case 2:
+				m.FlagStrategy = "flag"
 			}
-			m.Spec = flags.Filename(path)
-			m.Target = flags.Filename(generated)
+			m.Shared.Spec = flags.Filename(path)
+			m.Shared.Target = flags.Filename(generated)
 
 			if err := m.Execute([]string{}); err != nil {
 				t.Error(err)
@@ -56,7 +60,7 @@ func TestGenerateServer_Checks(t *testing.T) {
 
 	m := &generate.Server{}
 	_, _ = flags.Parse(m)
-	m.CopyrightFile = "nowhere"
+	m.Shared.CopyrightFile = "nowhere"
 	err := m.Execute([]string{})
 	assert.Error(t, err)
 }

--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -15,8 +16,8 @@ import (
 
 // FlattenCmdOptions determines options to the flatten spec preprocessing
 type FlattenCmdOptions struct {
-	WithExpand  bool     `long:"with-expand" description:"expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)"`
-	WithFlatten []string `long:"with-flatten" description:"flattens all $ref's in spec prior to generation" choice:"minimal" choice:"full" choice:"expand" choice:"verbose" choice:"noverbose" choice:"remove-unused" default:"minimal" default:"verbose"`
+	WithExpand  bool     `long:"with-expand" description:"expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)"  group:"shared"`
+	WithFlatten []string `long:"with-flatten" description:"flattens all $ref's in spec prior to generation" choice:"minimal" choice:"full" choice:"expand" choice:"verbose" choice:"noverbose" choice:"remove-unused" default:"minimal" default:"verbose" group:"shared"` // nolint: staticcheck
 }
 
 // SetFlattenOptions builds flatten options from command line args
@@ -30,138 +31,154 @@ func (f *FlattenCmdOptions) SetFlattenOptions(dflt *analysis.FlattenOpts) (res *
 	}
 	verboseIsSet := false
 	minimalIsSet := false
-	//removeUnusedIsSet := false
 	expandIsSet := false
 	if f.WithExpand {
 		res.Expand = true
 		expandIsSet = true
 	}
 	for _, opt := range f.WithFlatten {
-		if opt == "verbose" {
+		switch opt {
+		case "verbose":
 			res.Verbose = true
 			verboseIsSet = true
-		}
-		if opt == "noverbose" && !verboseIsSet {
-			// verbose flag takes precedence
-			res.Verbose = false
-			verboseIsSet = true
-		}
-		if opt == "remove-unused" {
+		case "noverbose":
+			if !verboseIsSet {
+				// verbose flag takes precedence
+				res.Verbose = false
+				verboseIsSet = true
+			}
+		case "remove-unused":
 			res.RemoveUnused = true
-			//removeUnusedIsSet = true
-		}
-		if opt == "expand" {
+		case "expand":
 			res.Expand = true
 			expandIsSet = true
-		}
-		if opt == "full" && !minimalIsSet && !expandIsSet {
-			// minimal flag takes precedence
-			res.Minimal = false
-			minimalIsSet = true
-		}
-		if opt == "minimal" && !expandIsSet {
-			// expand flag takes precedence
-			res.Minimal = true
-			minimalIsSet = true
+		case "full":
+			if !minimalIsSet && !expandIsSet {
+				// minimal flag takes precedence
+				res.Minimal = false
+				minimalIsSet = true
+			}
+		case "minimal":
+			if !expandIsSet {
+				// expand flag takes precedence
+				res.Minimal = true
+				minimalIsSet = true
+			}
 		}
 	}
 	return
 }
 
-type shared struct {
-	Spec                  flags.Filename `long:"spec" short:"f" description:"the spec file to use (default swagger.{json,yml,yaml})"`
-	APIPackage            string         `long:"api-package" short:"a" description:"the package to save the operations" default:"operations"`
-	ModelPackage          string         `long:"model-package" short:"m" description:"the package to save the models" default:"models"`
-	ServerPackage         string         `long:"server-package" short:"s" description:"the package to save the server specific code" default:"restapi"`
-	ClientPackage         string         `long:"client-package" short:"c" description:"the package to save the client specific code" default:"client"`
-	Target                flags.Filename `long:"target" short:"t" default:"./" description:"the base directory for generating the files"`
-	Template              string         `long:"template" description:"Load contributed templates" choice:"stratoscale"`
-	TemplateDir           flags.Filename `long:"template-dir" short:"T" description:"alternative template override directory"`
-	ConfigFile            flags.Filename `long:"config-file" short:"C" description:"configuration file to use for overriding template options"`
-	CopyrightFile         flags.Filename `long:"copyright-file" short:"r" description:"copyright file used to add copyright header"`
-	ExistingModels        string         `long:"existing-models" description:"use pre-generated models e.g. github.com/foobar/model"`
-	AdditionalInitialisms []string       `long:"additional-initialism" description:"consecutive capitals that should be considered intialisms"`
-	AllowTemplateOverride bool           `long:"allow-template-override" description:"allows overriding protected templates"`
-	FlattenCmdOptions
-}
-
 type sharedCommand interface {
-	getOpts() (*generator.GenOpts, error)
-	getShared() *shared
-	getConfigFile() flags.Filename
-	getAdditionalInitialisms() []string
+	apply(*generator.GenOpts)
+	getConfigFile() string
 	generate(*generator.GenOpts) error
 	log(string)
 }
 
-func (s *shared) getConfigFile() flags.Filename {
-	return s.ConfigFile
+type schemeOptions struct {
+	Principal     string `short:"P" long:"principal" description:"the model to use for the security principal"`
+	DefaultScheme string `long:"default-scheme" description:"the default scheme for this API" default:"http"`
 }
 
-func (s *shared) getAdditionalInitialisms() []string {
-	return s.AdditionalInitialisms
+func (so schemeOptions) apply(opts *generator.GenOpts) {
+	opts.Principal = so.Principal
+	opts.DefaultScheme = so.DefaultScheme
 }
 
-func (s *shared) setCopyright() (string, error) {
-	var copyrightstr string
-	copyrightfile := string(s.CopyrightFile)
-	if copyrightfile != "" {
-		//Read the Copyright from file path in opts
-		bytebuffer, err := ioutil.ReadFile(copyrightfile)
-		if err != nil {
-			return "", err
-		}
-		copyrightstr = string(bytebuffer)
-	} else {
-		copyrightstr = ""
+type mediaOptions struct {
+	DefaultProduces string `long:"default-produces" description:"the default mime type that API operations produce" default:"application/json"`
+	DefaultConsumes string `long:"default-consumes" description:"the default mime type that API operations consume" default:"application/json"`
+}
+
+func (m mediaOptions) apply(opts *generator.GenOpts) {
+	opts.DefaultProduces = m.DefaultProduces
+	opts.DefaultConsumes = m.DefaultConsumes
+}
+
+// WithShared adds the shared options group
+type WithShared struct {
+	Shared sharedOptions `group:"Options common to all code generation commands"`
+}
+
+func (w WithShared) getConfigFile() string {
+	return string(w.Shared.ConfigFile)
+}
+
+type sharedOptions struct {
+	Spec                  flags.Filename `long:"spec" short:"f" description:"the spec file to use (default swagger.{json,yml,yaml})" group:"shared"`
+	Target                flags.Filename `long:"target" short:"t" default:"./" description:"the base directory for generating the files" group:"shared"`
+	Template              string         `long:"template" description:"load contributed templates" choice:"stratoscale" group:"shared"`
+	TemplateDir           flags.Filename `long:"template-dir" short:"T" description:"alternative template override directory" group:"shared"`
+	ConfigFile            flags.Filename `long:"config-file" short:"C" description:"configuration file to use for overriding template options" group:"shared"`
+	CopyrightFile         flags.Filename `long:"copyright-file" short:"r" description:"copyright file used to add copyright header" group:"shared"`
+	AdditionalInitialisms []string       `long:"additional-initialism" description:"consecutive capitals that should be considered intialisms" group:"shared"`
+	AllowTemplateOverride bool           `long:"allow-template-override" description:"allows overriding protected templates" group:"shared"`
+	SkipValidation        bool           `long:"skip-validation" description:"skips validation of spec prior to generation" group:"shared"`
+	DumpData              bool           `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files" group:"shared"`
+	FlattenCmdOptions
+}
+
+func (s sharedOptions) apply(opts *generator.GenOpts) {
+	opts.Spec = string(s.Spec)
+	opts.Target = string(s.Target)
+	opts.Template = s.Template
+	opts.TemplateDir = string(s.TemplateDir)
+	opts.AllowTemplateOverride = s.AllowTemplateOverride
+	opts.ValidateSpec = !s.SkipValidation
+	opts.DumpData = s.DumpData
+	opts.FlattenOpts = s.FlattenCmdOptions.SetFlattenOptions(opts.FlattenOpts)
+	opts.Copyright = string(s.CopyrightFile)
+
+	swag.AddInitialisms(s.AdditionalInitialisms...)
+}
+
+func setCopyright(copyrightFile string) (string, error) {
+	// read the Copyright from file path in opts
+	if copyrightFile == "" {
+		return "", nil
 	}
-	return copyrightstr, nil
+	bytebuffer, err := ioutil.ReadFile(copyrightFile)
+	if err != nil {
+		return "", err
+	}
+	return string(bytebuffer), nil
 }
 
 func createSwagger(s sharedCommand) error {
-	cfg, erc := readConfig(string(s.getConfigFile()))
-	if erc != nil {
-		return erc
+	cfg, err := readConfig(s.getConfigFile())
+	if err != nil {
+		return err
 	}
-	setDebug(cfg)
+	setDebug(cfg) // viper config Debug
 
-	opts, ero := s.getOpts()
-	if ero != nil {
-		return ero
+	opts := new(generator.GenOpts)
+	s.apply(opts)
+
+	opts.Copyright, err = setCopyright(opts.Copyright)
+	if err != nil {
+		return fmt.Errorf("could not load copyright file: %v", err)
 	}
 
 	if opts.Template != "" {
 		contribOptionsOverride(opts)
 	}
 
-	if err := opts.EnsureDefaults(); err != nil {
+	if err = opts.EnsureDefaults(); err != nil {
 		return err
 	}
 
-	if err := configureOptsFromConfig(cfg, opts); err != nil {
+	if err = configureOptsFromConfig(cfg, opts); err != nil {
 		return err
 	}
 
-	swag.AddInitialisms(s.getAdditionalInitialisms()...)
-
-	if sharedOpts := s.getShared(); sharedOpts != nil {
-		// process shared options
-		opts.FlattenOpts = sharedOpts.FlattenCmdOptions.SetFlattenOptions(opts.FlattenOpts)
-
-		copyrightStr, erc := sharedOpts.setCopyright()
-		if erc != nil {
-			return erc
-		}
-		opts.Copyright = copyrightStr
-	}
-
-	if err := s.generate(opts); err != nil {
+	if err = s.generate(opts); err != nil {
 		return err
 	}
 
-	basepath, era := filepath.Abs(".")
-	if era != nil {
-		return era
+	basepath, err := filepath.Abs(".")
+	if err != nil {
+		return err
 	}
 
 	targetAbs, err := filepath.Abs(opts.Target)
@@ -204,11 +221,12 @@ func configureOptsFromConfig(cfg *viper.Viper, opts *generator.GenOpts) error {
 }
 
 func setDebug(cfg *viper.Viper) {
+	// viper config debug
 	if os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != "" {
 		if cfg != nil {
 			cfg.Debug()
 		} else {
-			log.Println("NO config read")
+			log.Println("No config read")
 		}
 	}
 }

--- a/cmd/swagger/commands/generate/shared_test.go
+++ b/cmd/swagger/commands/generate/shared_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-openapi/analysis"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func resetDefaultOpts() *analysis.FlattenOpts {
@@ -117,4 +118,60 @@ func Test_Shared_SetFlattenOptions(t *testing.T) {
 }
 
 func Test_Shared_ReadConfig(t *testing.T) {
+	tmpFile, errio := ioutil.TempFile("", "tmp-config*.yaml")
+	require.NoError(t, errio)
+	defer func() {
+		_ = os.Remove(tmpFile.Name())
+	}()
+	tmpConfig := tmpFile.Name()
+	errio = ioutil.WriteFile(tmpConfig, []byte(`param: 123
+other: abc
+`), 0644)
+	require.NoError(t, errio)
+	_ = tmpFile.Close()
+
+	for _, toPin := range []struct {
+		Name        string
+		Filename    string
+		ExpectError bool
+		Expected    map[string]interface{}
+	}{
+		{
+			Name:     "empty",
+			Filename: "",
+		},
+		{
+			Name:        "no file",
+			Filename:    "nowhere",
+			ExpectError: true,
+		},
+		{
+			Name:     "happy path",
+			Filename: tmpConfig,
+			Expected: map[string]interface{}{
+				"param": 123,
+				"other": "abc",
+			},
+		},
+	} {
+		testCase := toPin
+		t.Run(testCase.Name, func(t *testing.T) {
+			v, err := readConfig(testCase.Filename)
+			if testCase.ExpectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if testCase.Expected == nil {
+				require.Nil(t, v)
+				return
+			}
+			require.NotNil(t, v)
+			m := v.AllSettings()
+			for k, expectedValue := range testCase.Expected {
+				require.Contains(t, m, k)
+				assert.EqualValues(t, expectedValue, m[k])
+			}
+		})
+	}
 }

--- a/cmd/swagger/commands/generate/support.go
+++ b/cmd/swagger/commands/generate/support.go
@@ -22,40 +22,33 @@ import (
 
 // Support generates the supporting files
 type Support struct {
-	shared
-	Name          string   `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
-	Operations    []string `long:"operation" short:"O" description:"specify an operation to include, repeat for multiple"`
-	Principal     string   `long:"principal" description:"the model to use for the security principal"`
-	Models        []string `long:"model" short:"M" description:"specify a model to include, repeat for multiple"`
-	DumpData      bool     `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files"`
-	DefaultScheme string   `long:"default-scheme" description:"the default scheme for this API" default:"http"`
+	WithShared
+	WithModels
+	WithOperations
+
+	clientOptions
+	serverOptions
+	schemeOptions
+	mediaOptions
+
+	Name string `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
 }
 
-func (s *Support) getOpts() (*generator.GenOpts, error) {
-	return &generator.GenOpts{
-		Spec:          string(s.Spec),
-		Target:        string(s.Target),
-		APIPackage:    s.APIPackage,
-		ModelPackage:  s.ModelPackage,
-		ServerPackage: s.ServerPackage,
-		ClientPackage: s.ClientPackage,
-		Principal:     s.Principal,
-		DumpData:      s.DumpData,
-		DefaultScheme: s.DefaultScheme,
-		Template:      s.Template,
-		TemplateDir:   string(s.TemplateDir),
-	}, nil
-}
-
-func (s *Support) getShared() *shared {
-	return &s.shared
+func (s *Support) apply(opts *generator.GenOpts) {
+	s.Shared.apply(opts)
+	s.Models.apply(opts)
+	s.Operations.apply(opts)
+	s.clientOptions.apply(opts)
+	s.serverOptions.apply(opts)
+	s.schemeOptions.apply(opts)
+	s.mediaOptions.apply(opts)
 }
 
 func (s *Support) generate(opts *generator.GenOpts) error {
-	return generator.GenerateSupport(s.Name, nil, nil, opts)
+	return generator.GenerateSupport(s.Name, s.Models.Models, s.Operations.Operations, opts)
 }
 
-func (s *Support) log(rp string) {
+func (s Support) log(rp string) {
 
 	log.Printf(`Generation completed!
 

--- a/cmd/swagger/commands/generate/support_test.go
+++ b/cmd/swagger/commands/generate/support_test.go
@@ -31,11 +31,11 @@ func TestGenerateSupport(t *testing.T) {
 			}()
 			m := &generate.Support{}
 			if i == 0 {
-				m.CopyrightFile = flags.Filename(filepath.Join(base, "LICENSE"))
+				m.Shared.CopyrightFile = flags.Filename(filepath.Join(base, "LICENSE"))
 			}
 			_, _ = flags.Parse(m)
-			m.Spec = flags.Filename(path)
-			m.Target = flags.Filename(generated)
+			m.Shared.Spec = flags.Filename(path)
+			m.Shared.Target = flags.Filename(generated)
 
 			if err := m.Execute([]string{}); err != nil {
 				t.Error(err)

--- a/docs/generate/client.md
+++ b/docs/generate/client.md
@@ -18,32 +18,40 @@ Help Options:
   -h, --help                                                                      Show this help message
 
 [client command options]
-      -f, --spec=                                                                 the spec file to use (default swagger.{json,yml,yaml})
-      -a, --api-package=                                                          the package to save the operations (default: operations)
-      -m, --model-package=                                                        the package to save the models (default: models)
-      -s, --server-package=                                                       the package to save the server specific code (default: restapi)
       -c, --client-package=                                                       the package to save the client specific code (default: client)
-      -t, --target=                                                               the base directory for generating the files (default: ./)
-          --template=[stratoscale]                                                Load contributed templates
-      -T, --template-dir=                                                         alternative template override directory
-          --allow-template-override                                               allows overriding protected templates
-      -C, --config-file=                                                          configuration file to use for overriding template options
-      -r, --copyright-file=                                                       copyright file used to add copyright header
-          --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
-          --additional-initialism=                                                consecutive capitals that should be considered intialisms
-          --with-expand                                                           expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
-          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in spec prior to generation (default: minimal, verbose)
-      -A, --name=                                                                 the name of the application, defaults to a mangled value of info.title
-      -O, --operation=                                                            specify an operation to include, repeat for multiple
-          --tags=                                                                 the tags to include, if not specified defaults to all
       -P, --principal=                                                            the model to use for the security principal
-      -M, --model=                                                                specify a model to include, repeat for multiple
-          --default-scheme=                                                       the default scheme for this client (default: http)
+          --default-scheme=                                                       the default scheme for this API (default: http)
           --default-produces=                                                     the default mime type that API operations produce (default: application/json)
+          --default-consumes=                                                     the default mime type that API operations consume (default: application/json)
           --skip-models                                                           no models will be generated when this flag is specified
           --skip-operations                                                       no operations will be generated when this flag is specified
-          --dump-data                                                             when present dumps the json for the template generator instead of generating files
+      -A, --name=                                                                 the name of the application, defaults to a mangled value of info.title
+
+    Options common to all code generation commands:
+      -f, --spec=                                                                 the spec file to use (default swagger.{json,yml,yaml})
+      -t, --target=                                                               the base directory for generating the files (default: ./)
+          --template=[stratoscale]                                                load contributed templates
+      -T, --template-dir=                                                         alternative template override directory
+      -C, --config-file=                                                          configuration file to use for overriding template options
+      -r, --copyright-file=                                                       copyright file used to add copyright header
+          --additional-initialism=                                                consecutive capitals that should be considered intialisms
+          --allow-template-override                                               allows overriding protected templates
           --skip-validation                                                       skips validation of spec prior to generation
+          --dump-data                                                             when present dumps the json for the template generator instead of generating files
+          --with-expand                                                           expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
+          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in spec prior to generation (default: minimal, verbose)
+
+    Options for model generation:
+      -m, --model-package=                                                        the package to save the models (default: models)
+      -M, --model=                                                                specify a model to include in generation, repeat for multiple (defaults to all)
+          --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
+          --strict-additional-properties                                          disallow extra properties when additionalProperties is set to false
+          --keep-spec-order                                                       keep schema properties order identical to spec file
+
+    Options for operation generation:
+      -O, --operation=                                                            specify an operation to include, repeat for multiple (defaults to all)
+          --tags=                                                                 the tags to include, if not specified defaults to all
+      -a, --api-package=                                                          the package to save the operations (default: operations)
 ```
 
 ### Build a client

--- a/docs/generate/model.md
+++ b/docs/generate/model.md
@@ -15,25 +15,29 @@ Help Options:
   -h, --help                                                                      Show this help message
 
 [model command options]
+          --skip-struct                                                           when present will not generate the model struct
+      -n, --name=                                                                 the model to generate, repeat for multiple (defaults to all). Same as --models
+
+    Options common to all code generation commands:
       -f, --spec=                                                                 the spec file to use (default swagger.{json,yml,yaml})
-      -a, --api-package=                                                          the package to save the operations (default: operations)
-      -m, --model-package=                                                        the package to save the models (default: models)
-      -s, --server-package=                                                       the package to save the server specific code (default: restapi)
-      -c, --client-package=                                                       the package to save the client specific code (default: client)
       -t, --target=                                                               the base directory for generating the files (default: ./)
-          --template=[stratoscale]                                                Load contributed templates
+          --template=[stratoscale]                                                load contributed templates
       -T, --template-dir=                                                         alternative template override directory
-          --allow-template-override                                               allows overriding protected templates
       -C, --config-file=                                                          configuration file to use for overriding template options
       -r, --copyright-file=                                                       copyright file used to add copyright header
-          --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
           --additional-initialism=                                                consecutive capitals that should be considered intialisms
+          --allow-template-override                                               allows overriding protected templates
+          --skip-validation                                                       skips validation of spec prior to generation
+          --dump-data                                                             when present dumps the json for the template generator instead of generating files
           --with-expand                                                           expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
           --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in spec prior to generation (default: minimal, verbose)
-      -n, --name=                                                                 the model to generate
-          --skip-struct                                                           when present will not generate the model struct
-          --dump-data                                                             when present dumps the json for the template generator instead of generating files
-          --skip-validation                                                       skips validation of spec prior to generation
+
+    Options for model generation:
+      -m, --model-package=                                                        the package to save the models (default: models)
+      -M, --model=                                                                specify a model to include in generation, repeat for multiple (defaults to all)
+          --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
+          --strict-additional-properties                                          disallow extra properties when additionalProperties is set to false
+          --keep-spec-order                                                       keep schema properties order identical to spec file
 ```
 
 Schema generation rules are detailed [here](../use/model.md).

--- a/docs/generate/server.md
+++ b/docs/generate/server.md
@@ -27,40 +27,47 @@ Help Options:
   -h, --help                                                                      Show this help message
 
 [server command options]
-      -f, --spec=                                                                 the spec file to use (default swagger.{json,yml,yaml})
-      -a, --api-package=                                                          the package to save the operations (default: operations)
-      -m, --model-package=                                                        the package to save the models (default: models)
       -s, --server-package=                                                       the package to save the server specific code (default: restapi)
-      -c, --client-package=                                                       the package to save the client specific code (default: client)
-      -t, --target=                                                               the base directory for generating the files (default: ./)
-          --template=[stratoscale]                                                Load contributed templates
-      -T, --template-dir=                                                         alternative template override directory
-          --allow-template-override                                               allows overriding protected templates
-      -C, --config-file=                                                          configuration file to use for overriding template options
-      -r, --copyright-file=                                                       copyright file used to add copyright header
-          --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
-          --additional-initialism=                                                consecutive capitals that should be considered intialisms
-          --with-expand                                                           expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
-          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in spec prior to generation (default: minimal, verbose)
-      -A, --name=                                                                 the name of the application, defaults to a mangled value of info.title
-      -O, --operation=                                                            specify an operation to include, repeat for multiple
-          --tags=                                                                 the tags to include, if not specified defaults to all
       -P, --principal=                                                            the model to use for the security principal
           --default-scheme=                                                       the default scheme for this API (default: http)
-      -M, --model=                                                                specify a model to include, repeat for multiple
+          --default-produces=                                                     the default mime type that API operations produce (default: application/json)
+          --default-consumes=                                                     the default mime type that API operations consume (default: application/json)
           --skip-models                                                           no models will be generated when this flag is specified
           --skip-operations                                                       no operations will be generated when this flag is specified
           --skip-support                                                          no supporting files will be generated when this flag is specified
           --exclude-main                                                          exclude main function, so just generate the library
           --exclude-spec                                                          don't embed the swagger specification
-          --with-context                                                          handlers get a context as first arg (deprecated)
-          --dump-data                                                             when present dumps the json for the template generator instead of generating files
           --flag-strategy=[go-flags|pflag|flag]                                   the strategy to provide flags for the server (default: go-flags)
           --compatibility-mode=[modern|intermediate]                              the compatibility mode for the tls server (default: modern)
-          --skip-validation                                                       skips validation of spec prior to generation
           --regenerate-configureapi                                               Force regeneration of configureapi.go
-          --keep-spec-order                                                       Keep schema properties order identical to spec file
+      -A, --name=                                                                 the name of the application, defaults to a mangled value of info.title
+          --with-context                                                          handlers get a context as first arg (deprecated)
+
+    Options common to all code generation commands:
+      -f, --spec=                                                                 the spec file to use (default swagger.{json,yml,yaml})
+      -t, --target=                                                               the base directory for generating the files (default: ./)
+          --template=[stratoscale]                                                load contributed templates
+      -T, --template-dir=                                                         alternative template override directory
+      -C, --config-file=                                                          configuration file to use for overriding template options
+      -r, --copyright-file=                                                       copyright file used to add copyright header
+          --additional-initialism=                                                consecutive capitals that should be considered intialisms
+          --allow-template-override                                               allows overriding protected templates
+          --skip-validation                                                       skips validation of spec prior to generation
+          --dump-data                                                             when present dumps the json for the template generator instead of generating files
+          --with-expand                                                           expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
+          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in spec prior to generation (default: minimal, verbose)
+
+    Options for model generation:
+      -m, --model-package=                                                        the package to save the models (default: models)
+      -M, --model=                                                                specify a model to include in generation, repeat for multiple (defaults to all)
+          --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
           --strict-additional-properties                                          disallow extra properties when additionalProperties is set to false
+          --keep-spec-order                                                       keep schema properties order identical to spec file
+
+    Options for operation generation:
+      -O, --operation=                                                            specify an operation to include, repeat for multiple (defaults to all)
+          --tags=                                                                 the tags to include, if not specified defaults to all
+      -a, --api-package=                                                          the package to save the operations (default: operations)
 ```
 
 ### Build a server
@@ -70,12 +77,26 @@ The server application gets generated with all the handlers stubbed out with a n
 The generated server allows for a number of command line parameters to customize it.
 
 ```
---host=            the IP to listen on (default: localhost) [$HOST]
---port=            the port to listen on for insecure connections, defaults to a random value [$PORT]
---tls-host=        the IP to listen on for tls, when not specified it's the same as --host [$TLS_HOST]
---tls-port=        the port to listen on for secure connections, defaults to a random value [$TLS_PORT]
---tls-certificate= the certificate to use for secure connections [$TLS_CERTIFICATE]
---tls-key=         the private key to use for secure connections [$TLS_PRIVATE_KEY]
+      --cleanup-timeout duration     grace period for which to wait before killing idle connections (default 10s)
+      --graceful-timeout duration    grace period for which to wait before shutting down the server (default 15s)
+      --host string                  the IP to listen on (default "localhost")
+      --keep-alive duration          sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download) (default 3m0s)
+      --listen-limit int             limit the number of outstanding requests
+      --max-header-size byte-size    controls the maximum number of bytes the server will read parsing the request header's keys and values, including the request line. It does not limit the size of the request body (default 1MB)
+      --port int                     the port to listen on for insecure connections, defaults to a random value
+      --read-timeout duration        maximum duration before timing out read of the request (default 30s)
+      --scheme strings               the listeners to enable, this can be repeated and defaults to the schemes in the swagger spec (default [http,https,unix])
+      --socket-path string           the unix socket to listen on (default "/var/run/todo-list.sock")
+      --tls-ca string                the certificate authority certificate file to be used with mutual tls auth
+      --tls-certificate string       the certificate file to use for secure connections
+      --tls-host string              the IP to listen on (default "localhost")
+      --tls-keep-alive duration      sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download) (default 3m0s)
+      --tls-key string               the private key file to use for secure connections (without passphrase)
+      --tls-listen-limit int         limit the number of outstanding requests
+      --tls-port int                 the port to listen on for secure connections, defaults to a random value
+      --tls-read-timeout duration    maximum duration before timing out read of the request (default 30s)
+      --tls-write-timeout duration   maximum duration before timing out write of the response (default 30s)
+      --write-timeout duration       maximum duration before timing out write of the response (default 30s)
 ```
 
 The server takes care of a number of things when a request arrives:

--- a/generator/build_test.go
+++ b/generator/build_test.go
@@ -77,15 +77,13 @@ func TestGenerateAndBuild(t *testing.T) {
 }
 
 func newTestClient(input, output string) *generate.Client {
-	c := &generate.Client{
-		DefaultScheme:   "http",
-		DefaultProduces: "application/json",
-	}
-	c.Spec = flags.Filename(input)
-	c.Target = flags.Filename(output)
-	c.APIPackage = defaultAPIPackage
-	c.ModelPackage = defaultModelPackage
-	c.ServerPackage = defaultServerPackage
+	c := &generate.Client{}
+	c.DefaultScheme = "http"
+	c.DefaultProduces = "application/json"
+	c.Shared.Spec = flags.Filename(input)
+	c.Shared.Target = flags.Filename(output)
+	c.Operations.APIPackage = defaultAPIPackage
+	c.Models.ModelPackage = defaultModelPackage
 	c.ClientPackage = defaultClientPackage
 	return c
 }

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -675,11 +675,13 @@ func (g *GenOpts) EnsureDefaults() error {
 		g.LanguageOpts = GoLangOpts()
 	}
 	// set defaults for flattening options
-	g.FlattenOpts = &analysis.FlattenOpts{
-		Minimal:      true,
-		Verbose:      true,
-		RemoveUnused: false,
-		Expand:       false,
+	if g.FlattenOpts == nil {
+		g.FlattenOpts = &analysis.FlattenOpts{
+			Minimal:      true,
+			Verbose:      true,
+			RemoveUnused: false,
+			Expand:       false,
+		}
 	}
 	g.defaultsEnsured = true
 	return nil


### PR DESCRIPTION
* introduced flags groups in CLI for more readable usage text
* refactored CLI to simplify the process of transforming input flags into GenOpts

Sample help from CLI:
```
Usage:
  swagger [OPTIONS] generate model [model-OPTIONS]

generate one or more models from the swagger spec

Application Options:
  -q, --quiet                                                                     silence logs
      --log-output=LOG-FILE                                                       redirect logs to file

Help Options:
  -h, --help                                                                      Show this help message

[model command options]
          --skip-struct                                                           when present will not generate the model struct
      -n, --name=                                                                 the model to generate, repeat for multiple (defaults to all). Same as --models

    Options common to all code generation commands:
      -f, --spec=                                                                 the spec file to use (default swagger.{json,yml,yaml})
      -t, --target=                                                               the base directory for generating the files (default: ./)
          --template=[stratoscale]                                                load contributed templates
      -T, --template-dir=                                                         alternative template override directory
      -C, --config-file=                                                          configuration file to use for overriding template options
      -r, --copyright-file=                                                       copyright file used to add copyright header
          --additional-initialism=                                                consecutive capitals that should be considered intialisms
          --allow-template-override                                               allows overriding protected templates
          --skip-validation                                                       skips validation of spec prior to generation
          --dump-data                                                             when present dumps the json for the template generator instead of generating files
          --with-expand                                                           expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in spec prior to generation (default: minimal, verbose)

    Options for model generation:
      -m, --model-package=                                                        the package to save the models (default: models)
      -M, --model=                                                                specify a model to include in generation, repeat for multiple (defaults to all)
          --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
          --strict-additional-properties                                          disallow extra properties when additionalProperties is set to false
          --keep-spec-order                                                       keep schema properties order identical to spec file

```
Signed-off-by: Frederic BIDON <fredbi@yahoo.com>