### PR TITLE
Feature/morlays enum

### DIFF
--- a/codescan/application_test.go
+++ b/codescan/application_test.go
@@ -156,6 +156,7 @@ func verifyParsedPetStore(t testing.TB, doc *spec.Swagger) {
 	prop, ok = mod.Properties["status"]
 	assert.True(t, ok)
 	assert.Equal(t, "The current status of the pet in the store.", prop.Description)
+	assert.Equal(t, []interface{}{"available", "pending", "sold"}, prop.Enum)
 
 	assertProperty(t, &mod, "string", "birthday", "date", "Birthday")
 	prop, ok = mod.Properties["birthday"]
@@ -253,6 +254,7 @@ func verifyParsedPetStore(t testing.TB, doc *spec.Swagger) {
 	assert.Equal(t, "query", sparam.In)
 	assert.Equal(t, "string", sparam.Type)
 	assert.Equal(t, "", sparam.Format)
+	assert.Equal(t, []interface{}{"available", "pending", "sold"}, sparam.Enum)
 	assert.False(t, sparam.Required)
 	assert.Equal(t, "Status", sparam.Extensions["x-go-name"])
 	assert.Equal(t, "#/responses/genericError", op.Get.Responses.Default.Ref.String())

--- a/codescan/enum.go
+++ b/codescan/enum.go
@@ -1,0 +1,23 @@
+package codescan
+
+import (
+	"go/ast"
+	"strconv"
+	"strings"
+)
+
+func getEnumBasicLitValue(basicLit *ast.BasicLit) interface{} {
+	switch basicLit.Kind.String() {
+	case "INT":
+		if result, err := strconv.ParseInt(basicLit.Value, 10, 64); err == nil {
+			return result
+		}
+	case "FLOAT":
+		if result, err := strconv.ParseFloat(basicLit.Value, 64); err == nil {
+			return result
+		}
+	default:
+		return strings.Trim(basicLit.Value, "\"")
+	}
+	return nil
+}

--- a/codescan/enum_test.go
+++ b/codescan/enum_test.go
@@ -1,0 +1,38 @@
+package codescan
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getEnumBasicLitValue(t *testing.T) {
+
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.INT, Value: "0"}, int64(0))
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.INT, Value: "-1"}, int64(-1))
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.INT, Value: "42"}, int64(42))
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.INT, Value: ""}, nil)
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.INT, Value: "word"}, nil)
+
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.FLOAT, Value: "0"}, float64(0))
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.FLOAT, Value: "-1"}, float64(-1))
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.FLOAT, Value: "42"}, float64(42))
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.FLOAT, Value: "1.1234"}, float64(1.1234))
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.FLOAT, Value: "1.9876"}, float64(1.9876))
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.FLOAT, Value: ""}, nil)
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.FLOAT, Value: "word"}, nil)
+
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.STRING, Value: "Foo"}, "Foo")
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.STRING, Value: ""}, "")
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.STRING, Value: "0"}, "0")
+	verifyGetEnumBasicLitValue(t, ast.BasicLit{Kind: token.STRING, Value: "1.1"}, "1.1")
+
+}
+
+func verifyGetEnumBasicLitValue(t *testing.T, basicLit ast.BasicLit, expected interface{}) {
+	actual := getEnumBasicLitValue(&basicLit)
+
+	assert.Equal(t, expected, actual)
+}

--- a/codescan/parameters.go
+++ b/codescan/parameters.go
@@ -59,6 +59,10 @@ func (pt paramTypable) AddExtension(key string, value interface{}) {
 	}
 }
 
+func (pt paramTypable) WithEnum(values ...interface{}) {
+	pt.param.WithEnum(values...)
+}
+
 type itemsTypable struct {
 	items *spec.Items
 	level int
@@ -88,6 +92,10 @@ func (pt itemsTypable) Items() swaggerTypable {
 
 func (pt itemsTypable) AddExtension(key string, value interface{}) {
 	pt.items.AddExtension(key, value)
+}
+
+func (pt itemsTypable) WithEnum(values ...interface{}) {
+	pt.items.WithEnum(values...)
 }
 
 type paramValidations struct {

--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -200,6 +200,7 @@ type swaggerTypable interface {
 	Schema() *spec.Schema
 	Level() int
 	AddExtension(key string, value interface{})
+	WithEnum(...interface{})
 }
 
 // Map all Go builtin types that have Json representation to Swagger/Json types.

--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -72,11 +72,17 @@ func (ht responseTypable) Schema() *spec.Schema {
 func (ht responseTypable) SetSchema(schema *spec.Schema) {
 	ht.response.Schema = schema
 }
+
 func (ht responseTypable) CollectionOf(items *spec.Items, format string) {
 	ht.header.CollectionOf(items, format)
 }
+
 func (ht responseTypable) AddExtension(key string, value interface{}) {
 	ht.response.AddExtension(key, value)
+}
+
+func (ht responseTypable) WithEnum(values ...interface{}) {
+	ht.header.WithEnum(values)
 }
 
 type headerValidations struct {

--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -65,9 +65,15 @@ func (st schemaTypable) AdditionalProperties() swaggerTypable {
 	st.schema.Typed("object", "")
 	return schemaTypable{st.schema.AdditionalProperties.Schema, st.level + 1}
 }
+
 func (st schemaTypable) Level() int { return st.level }
+
 func (st schemaTypable) AddExtension(key string, value interface{}) {
 	addExtension(&st.schema.VendorExtensible, key, value)
+}
+
+func (st schemaTypable) WithEnum(values ...interface{}) {
+	st.schema.WithEnum(values...)
 }
 
 type schemaValidations struct {
@@ -302,7 +308,12 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 			}
 
 			if enumName, ok := enumName(cmt); ok {
-				debugLog(enumName)
+				enumValues, _ := s.ctx.FindEnumValues(pkg, enumName)
+				if len(enumValues) > 0 {
+					tgt.WithEnum(enumValues...)
+					enumTypeName := reflect.TypeOf(enumValues[0]).String()
+					_ = swaggerSchemaForType(enumTypeName, tgt)
+				}
 				return nil
 			}
 

--- a/fixtures/goparsing/petstore/enums/status.go
+++ b/fixtures/goparsing/petstore/enums/status.go
@@ -1,0 +1,25 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enums
+
+// pet status in the store
+// swagger:enum Status
+type Status string
+
+const (
+	STATUS_AVAILABLE Status = "available"
+	STATUS_PENDING   Status = "pending"
+	STATUS_SOLD      Status = "sold"
+)

--- a/fixtures/goparsing/petstore/models/pet.go
+++ b/fixtures/goparsing/petstore/models/pet.go
@@ -14,7 +14,11 @@
 
 package models
 
-import "time"
+import (
+	"time"
+
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore/enums"
+)
 
 // A Pet is the main product in the store.
 // It is used to describe the animals available in the store.
@@ -41,7 +45,7 @@ type Pet struct {
 	PhotoURLs []string `json:"photoUrls,omitempty"`
 
 	// The current status of the pet in the store.
-	Status string `json:"status,omitempty"`
+	Status enums.Status `json:"status,omitempty"`
 
 	// Extra bits of information attached to this pet.
 	//

--- a/fixtures/goparsing/petstore/rest/handlers/pets.go
+++ b/fixtures/goparsing/petstore/rest/handlers/pets.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/runtime/middleware/denco"
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore/enums"
 	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore/models"
 )
 
@@ -51,7 +52,7 @@ type ValidationError struct {
 // swagger:parameters listPets
 type PetQueryFlags struct {
 	// Status
-	Status string `json:"status"`
+	Status enums.Status `json:"status"`
 
 	// Birthday
 	//

--- a/scan/enum.go
+++ b/scan/enum.go
@@ -1,0 +1,81 @@
+package scan
+
+import (
+	"go/ast"
+	"strconv"
+	"unicode"
+	"strings"
+)
+
+func upperSnakeCase(s string) string {
+	in := []rune(s)
+	isLower := func(idx int) bool {
+		return idx >= 0 && idx < len(in) && unicode.IsLower(in[idx])
+	}
+
+	out := make([]rune, 0, len(in) + len(in) / 2)
+
+	for i, r := range in {
+		if unicode.IsUpper(r) {
+			r = unicode.ToLower(r)
+			if i > 0 && in[i - 1] != '_' && (isLower(i - 1) || isLower(i + 1)) {
+				out = append(out, '_')
+			}
+		}
+		out = append(out, r)
+	}
+
+	return strings.ToUpper(string(out))
+}
+
+func getEnumBasicLitValue(basicLit *ast.BasicLit) interface{} {
+	switch(basicLit.Kind.String()){
+	case "INT":
+		if result, err := strconv.ParseInt(basicLit.Value, 10, 64); err == nil {
+			return result
+		}
+	case "FLOAT":
+		if result, err := strconv.ParseFloat(basicLit.Value, 64); err == nil {
+			return result
+		}
+	default:
+		return strings.Trim(basicLit.Value, "\"")
+	}
+	return nil;
+}
+
+func getEnumValues(file *ast.File, typeName string) (list []interface{}) {
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+
+		if !ok {
+			continue
+		}
+
+		if (genDecl.Tok.String() == "const") {
+			for _, spec := range genDecl.Specs {
+				if valueSpec, ok := spec.(*ast.ValueSpec); ok {
+					switch valueSpec.Type.(type) {
+					case *ast.Ident:
+						if (valueSpec.Type.(*ast.Ident).Name == typeName) {
+							if basicLit, ok := valueSpec.Values[0].(*ast.BasicLit); ok {
+								list = append(list, getEnumBasicLitValue(basicLit))
+							}
+						}
+					default:
+						var name = valueSpec.Names[0].Name
+						if (strings.HasPrefix(name, upperSnakeCase(typeName))) {
+							var values = strings.SplitN(name, "__", 2);
+							if (len(values) == 2) {
+								list = append(list, values[1])
+							}
+						}
+					}
+
+				}
+
+			}
+		}
+	}
+	return
+}

--- a/scan/enum.go
+++ b/scan/enum.go
@@ -1,10 +1,12 @@
+// +build !go1.11
+
 package scan
 
 import (
 	"go/ast"
 	"strconv"
-	"unicode"
 	"strings"
+	"unicode"
 )
 
 func upperSnakeCase(s string) string {
@@ -13,12 +15,12 @@ func upperSnakeCase(s string) string {
 		return idx >= 0 && idx < len(in) && unicode.IsLower(in[idx])
 	}
 
-	out := make([]rune, 0, len(in) + len(in) / 2)
+	out := make([]rune, 0, len(in)+len(in)/2)
 
 	for i, r := range in {
 		if unicode.IsUpper(r) {
 			r = unicode.ToLower(r)
-			if i > 0 && in[i - 1] != '_' && (isLower(i - 1) || isLower(i + 1)) {
+			if i > 0 && in[i-1] != '_' && (isLower(i-1) || isLower(i+1)) {
 				out = append(out, '_')
 			}
 		}
@@ -29,7 +31,7 @@ func upperSnakeCase(s string) string {
 }
 
 func getEnumBasicLitValue(basicLit *ast.BasicLit) interface{} {
-	switch(basicLit.Kind.String()){
+	switch basicLit.Kind.String() {
 	case "INT":
 		if result, err := strconv.ParseInt(basicLit.Value, 10, 64); err == nil {
 			return result
@@ -41,7 +43,7 @@ func getEnumBasicLitValue(basicLit *ast.BasicLit) interface{} {
 	default:
 		return strings.Trim(basicLit.Value, "\"")
 	}
-	return nil;
+	return nil
 }
 
 func getEnumValues(file *ast.File, typeName string) (list []interface{}) {
@@ -52,21 +54,21 @@ func getEnumValues(file *ast.File, typeName string) (list []interface{}) {
 			continue
 		}
 
-		if (genDecl.Tok.String() == "const") {
+		if genDecl.Tok.String() == "const" {
 			for _, spec := range genDecl.Specs {
 				if valueSpec, ok := spec.(*ast.ValueSpec); ok {
 					switch valueSpec.Type.(type) {
 					case *ast.Ident:
-						if (valueSpec.Type.(*ast.Ident).Name == typeName) {
+						if valueSpec.Type.(*ast.Ident).Name == typeName {
 							if basicLit, ok := valueSpec.Values[0].(*ast.BasicLit); ok {
 								list = append(list, getEnumBasicLitValue(basicLit))
 							}
 						}
 					default:
 						var name = valueSpec.Names[0].Name
-						if (strings.HasPrefix(name, upperSnakeCase(typeName))) {
-							var values = strings.SplitN(name, "__", 2);
-							if (len(values) == 2) {
+						if strings.HasPrefix(name, upperSnakeCase(typeName)) {
+							var values = strings.SplitN(name, "__", 2)
+							if len(values) == 2 {
 								list = append(list, values[1])
 							}
 						}

--- a/scan/parameters.go
+++ b/scan/parameters.go
@@ -40,6 +40,10 @@ func (pt paramTypable) Typed(tpe, format string) {
 	pt.param.Typed(tpe, format)
 }
 
+func (pt paramTypable) WithEnum(values ...interface{}) {
+	pt.param.WithEnum(values...);
+}
+
 func (pt paramTypable) SetRef(ref spec.Ref) {
 	pt.param.Ref = ref
 }
@@ -81,6 +85,10 @@ func (pt itemsTypable) Typed(tpe, format string) {
 
 func (pt itemsTypable) SetRef(ref spec.Ref) {
 	pt.items.Ref = ref
+}
+
+func (pt itemsTypable) WithEnum(values ...interface{}) {
+	pt.items.WithEnum(values...);
 }
 
 func (pt itemsTypable) Schema() *spec.Schema {

--- a/scan/parameters.go
+++ b/scan/parameters.go
@@ -72,6 +72,10 @@ func (pt paramTypable) Schema() *spec.Schema {
 	return pt.param.Schema
 }
 
+func (pt paramTypable) WithEnum(values ...interface{}) {
+	pt.param.WithEnum(values...)
+}
+
 type itemsTypable struct {
 	items *spec.Items
 	level int
@@ -101,6 +105,10 @@ func (pt itemsTypable) Items() swaggerTypable {
 	}
 	pt.items.Type = "array"
 	return itemsTypable{pt.items.Items, pt.level + 1}
+}
+
+func (pt itemsTypable) WithEnum(values ...interface{}) {
+	pt.items.WithEnum(values...)
 }
 
 type paramValidations struct {

--- a/scan/responses.go
+++ b/scan/responses.go
@@ -38,6 +38,10 @@ func (ht responseTypable) Typed(tpe, format string) {
 	ht.header.Typed(tpe, format)
 }
 
+func (ht responseTypable) WithEnum(values ...interface{}) {
+	ht.header.WithEnum(values)
+}
+
 func bodyTypable(in string, schema *spec.Schema) (swaggerTypable, *spec.Schema) {
 	if in == "body" {
 		// get the schema for items on the schema property

--- a/scan/responses.go
+++ b/scan/responses.go
@@ -89,8 +89,13 @@ func (ht responseTypable) Schema() *spec.Schema {
 func (ht responseTypable) SetSchema(schema *spec.Schema) {
 	ht.response.Schema = schema
 }
+
 func (ht responseTypable) CollectionOf(items *spec.Items, format string) {
 	ht.header.CollectionOf(items, format)
+}
+
+func (ht responseTypable) WithEnum(values ...interface{}) {
+	ht.header.WithEnum(values)
 }
 
 type headerValidations struct {

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -471,6 +471,7 @@ type swaggerTypable interface {
 	Typed(string, string)
 	SetRef(spec.Ref)
 	Items() swaggerTypable
+	WithEnum(...interface{})
 	Schema() *spec.Schema
 	Level() int
 }

--- a/scan/scanner.go
+++ b/scan/scanner.go
@@ -474,6 +474,7 @@ type swaggerTypable interface {
 	WithEnum(...interface{})
 	Schema() *spec.Schema
 	Level() int
+	WithEnum(...interface{})
 }
 
 // Map all Go builtin types that have Json representation to Swagger/Json types.

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -50,6 +50,10 @@ func (st schemaTypable) Typed(tpe, format string) {
 	st.schema.Typed(tpe, format)
 }
 
+func (st schemaTypable) WithEnum(values ...interface{}) {
+	st.schema.WithEnum(values...);
+}
+
 func (st schemaTypable) SetRef(ref spec.Ref) {
 	st.schema.Ref = ref
 }
@@ -246,6 +250,18 @@ func (scp *schemaParser) parseDecl(definitions map[string]spec.Schema, decl *sch
 		} else {
 			if err := scp.parseNamedType(decl.File, tpe, prop); err != nil {
 				return err
+			}
+		}
+		if enumName, ok := enumName(decl.Decl.Doc); ok {
+			var enumValues = getEnumValues(decl.File, enumName);
+			if (len(enumValues) > 0) {
+				var typeName = reflect.TypeOf(enumValues[0]).String()
+				prop.WithEnum(enumValues...);
+
+				err := swaggerSchemaForType(typeName, prop)
+				if err != nil {
+					return fmt.Errorf("file %s, error is: %v", decl.File.Name, err)
+				}
 			}
 		}
 	case *ast.SelectorExpr:
@@ -1025,7 +1041,15 @@ func (scp *schemaParser) parseIdentProperty(pkg *loader.PackageInfo, expr *ast.I
 	}
 
 	if enumName, ok := enumName(gd.Doc); ok {
-		log.Println(enumName)
+		var enumValues = getEnumValues(file, enumName);
+		if (len(enumValues) > 0) {
+			prop.WithEnum(enumValues...);
+			var typeName = reflect.TypeOf(enumValues[0]).String()
+			err := swaggerSchemaForType(typeName, prop)
+			if err != nil {
+				return fmt.Errorf("file %s, error is: %v", file.Name, err)
+			}
+		}
 		return nil
 	}
 

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -50,10 +50,6 @@ func (st schemaTypable) Typed(tpe, format string) {
 	st.schema.Typed(tpe, format)
 }
 
-func (st schemaTypable) WithEnum(values ...interface{}) {
-	st.schema.WithEnum(values...);
-}
-
 func (st schemaTypable) SetRef(ref spec.Ref) {
 	st.schema.Ref = ref
 }
@@ -85,7 +81,12 @@ func (st schemaTypable) AdditionalProperties() swaggerTypable {
 	st.schema.Typed("object", "")
 	return schemaTypable{st.schema.AdditionalProperties.Schema, st.level + 1}
 }
+
 func (st schemaTypable) Level() int { return st.level }
+
+func (st schemaTypable) WithEnum(values ...interface{}) {
+	st.schema.WithEnum(values...)
+}
 
 type schemaValidations struct {
 	current *spec.Schema
@@ -253,10 +254,10 @@ func (scp *schemaParser) parseDecl(definitions map[string]spec.Schema, decl *sch
 			}
 		}
 		if enumName, ok := enumName(decl.Decl.Doc); ok {
-			var enumValues = getEnumValues(decl.File, enumName);
-			if (len(enumValues) > 0) {
+			var enumValues = getEnumValues(decl.File, enumName)
+			if len(enumValues) > 0 {
 				var typeName = reflect.TypeOf(enumValues[0]).String()
-				prop.WithEnum(enumValues...);
+				prop.WithEnum(enumValues...)
 
 				err := swaggerSchemaForType(typeName, prop)
 				if err != nil {
@@ -1041,16 +1042,15 @@ func (scp *schemaParser) parseIdentProperty(pkg *loader.PackageInfo, expr *ast.I
 	}
 
 	if enumName, ok := enumName(gd.Doc); ok {
-		var enumValues = getEnumValues(file, enumName);
-		if (len(enumValues) > 0) {
-			prop.WithEnum(enumValues...);
+		var enumValues = getEnumValues(file, enumName)
+		if len(enumValues) > 0 {
+			prop.WithEnum(enumValues...)
 			var typeName = reflect.TypeOf(enumValues[0]).String()
 			err := swaggerSchemaForType(typeName, prop)
 			if err != nil {
 				return fmt.Errorf("file %s, error is: %v", file.Name, err)
 			}
 		}
-		return nil
 	}
 
 	if defaultName, ok := defaultName(gd.Doc); ok {


### PR DESCRIPTION
This is a continuation of #744 

This spike provides the support for the schema generation of enums


```go
// swagger:enum Level
type Level string

const (
	LEVEL_1 Level = "ONE"
	LEVEL_2 Level = "TWO"
	LEVEL_3 Level = "THREE"
)

// swagger:enum LevelInt
type LevelInt int

const (
	LEVEL_INT_1 LevelInt = 1
	LEVEL_INT_2 LevelInt = 2
	LEVEL_INT_3 LevelInt = 3
)

// swagger:model
type Model struct {
	level    Level
	levelInt LevelInt
}
```

will be

```yaml
definitions:
  Model:
    type: "object"
    properties:
      level: 
        type: "string"
        enum: 
          - "ONE"
          - "TWO"
          - "THREE"
      levelInt: 
        type: "integer"
        enum: 
          - 1
          - 2
          - 3
```
