### PR TITLE
Fixed release Dockerfiles

### DIFF
--- a/Dockerfile.alpine.ci
+++ b/Dockerfile.alpine.ci
@@ -13,7 +13,7 @@ RUN set -e -x \
   && go get -u -t github.com/cee-dub/go-junit-report \
   && go get -u github.com/aktau/github-release \
   && go get -u github.com/mitchellh/gox \
-  && gem install --no-ri --no-rdoc fpm etc \
+  && gem install --no-document fpm etc \
   && gem sources -c
 
 VOLUME /usr/share/coverage

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -18,7 +18,7 @@ RUN set -e -x \
   && go get -u github.com/aktau/github-release \
   && go get -u github.com/mitchellh/gox \
   && go get -u gotest.tools/gotestsum \
-  && gem install --no-ri --no-rdoc fpm etc \
+  && gem install --no-document fpm etc \
   && gem sources -c
 
 VOLUME /usr/share/coverage


### PR DESCRIPTION
* replaced deprecated gem install options, which are no more supported by gem

Trying to address this CI failure:
https://app.circleci.com/jobs/github/go-swagger/go-swagger/4135

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>