### PR TITLE
Throttle memory in codegen CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
 
       - run:
           name: Test codegen builds
-          command: go test -v -timeout 60m -parallel 4 hack/codegen_nonreg_test.go -args -fixture-file codegen-fixtures.yaml -skip-models -skip-full-flatten
+          command: go test -v -timeout 20m -parallel 3 hack/codegen_nonreg_test.go -args -fixture-file codegen-fixtures.yaml -skip-models -skip-full-flatten
           no_output_timeout: 30m
 
   canary_tests:
@@ -246,7 +246,7 @@ jobs:
 
       - run:
           name: Test canary builds
-          command: go test -v -timeout 60m hack/codegen_nonreg_test.go -args -fixture-file canary-fixtures.yaml -skip-models -skip-full-flatten -skip-expand
+          command: go test -v -timeout 20m hack/codegen_nonreg_test.go -args -fixture-file canary-fixtures.yaml -skip-models -skip-full-flatten -skip-expand
           no_output_timeout: 30m
 
   publish_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
 
       - run:
           name: Test codegen builds
-          command: go test -v -timeout 60m hack/codegen_nonreg_test.go -args -fixture-file codegen-fixtures.yaml -skip-models -skip-full-flatten
+          command: go test -v -timeout 60m -parallel 4 hack/codegen_nonreg_test.go -args -fixture-file codegen-fixtures.yaml -skip-models -skip-full-flatten
           no_output_timeout: 30m
 
   canary_tests:

--- a/hack/codegen_nonreg_test.go
+++ b/hack/codegen_nonreg_test.go
@@ -134,6 +134,12 @@ func gobuild(t *testing.T, runOpts ...icmd.CmdOp) {
 	started := measure(t, nil)
 	cmd := icmd.Command("go", "build")
 	res := icmd.RunCmd(cmd, runOpts...)
+	if res.ExitCode == 127 {
+		// assume a transient error (e.g. memory): retry
+		warn(t, "build failure, assuming transitory issue and retrying")
+		time.Sleep(2 * time.Second)
+		res = icmd.RunCmd(cmd, runOpts...)
+	}
 	if !assert.Equal(t, 0, res.ExitCode) {
 		failure(t, "go build failed")
 		t.Log(res.Stderr())


### PR DESCRIPTION
Codegen test in CI is running parallel code generation jobs. This
may be memory consuming, and whenever several large specs are
picked in parallel, may fail on memory limits (4 GB on circleCI VM).

This fix throttles the number of concurrent codegen jobs, trading
speed for memory.

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>