### PR TITLE
add option in model generation to output all definitions regardless of usage

### DIFF
--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -27,6 +27,7 @@ type modelOptions struct {
 	ExistingModels             string   `long:"existing-models" description:"use pre-generated models e.g. github.com/foobar/model"`
 	StrictAdditionalProperties bool     `long:"strict-additional-properties" description:"disallow extra properties when additionalProperties is set to false"`
 	KeepSpecOrder              bool     `long:"keep-spec-order" description:"keep schema properties order identical to spec file"`
+	AllDefinitions             bool     `long:"all-definitions" description:"generate all model definitions regardless of usage in operations"`
 }
 
 func (mo modelOptions) apply(opts *generator.GenOpts) {
@@ -35,6 +36,7 @@ func (mo modelOptions) apply(opts *generator.GenOpts) {
 	opts.ExistingModels = mo.ExistingModels
 	opts.StrictAdditionalProperties = mo.StrictAdditionalProperties
 	opts.PropertiesSpecOrder = mo.KeepSpecOrder
+	opts.IgnoreOperations = mo.AllDefinitions
 }
 
 // WithModels adds the model options group

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -262,6 +262,7 @@ type GenOpts struct {
 	Copyright              string
 	SkipTagPackages        bool
 	MainPackage            string
+	IgnoreOperations       bool
 }
 
 // CheckOpts carries out some global consistency checks on options.

--- a/generator/support.go
+++ b/generator/support.go
@@ -70,7 +70,7 @@ func newAppGenerator(name string, modelNames, operationIDs []string, opts *GenOp
 
 	operations := gatherOperations(analyzed, operationIDs)
 
-	if len(operations) == 0 {
+	if len(operations) == 0 && !opts.IgnoreOperations {
 		return nil, errors.New("no operations were selected")
 	}
 


### PR DESCRIPTION
Attempt at solving #1679

I have manually tested this will output all the expected go code for definitions defined in a swagger spec where `paths: {}`.

This is my first contribution, so apologies if I've missed anything. I'm guessing I might need to add some tests, any pointers into that would be appreciated.

Signed-off-by: dan-j <5727701+dan-j@users.noreply.github.com>