### PR TITLE
Fix #2206: Change project name for go-netbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ To name but a few... (feel free to sign in there if you are using this project):
 [CheckR](https://github.com/checkr/flagr)  
 [Cilium](https://github.com/cilium/cilium)  
 [CoreOS](https://github.com/coreos/go-quay)  
-[DigitalOcean](https://github.com/digitalocean/go-netbox)  
+[NetBox Community](https://github.com/netbox-community/go-netbox)  
 [EVE Central](https://github.com/evecentral)  
 Iron.io
 [JaegerTracing](https://github.com/jaegertracing/jaeger)  

--- a/docs/README.md
+++ b/docs/README.md
@@ -201,7 +201,7 @@ To name but a few... (feel free to sign in there if you are using this project):
 [CheckR](https://github.com/checkr/flagr)  
 [Cilium](https://github.com/cilium/cilium)  
 [CoreOS](https://github.com/coreos/go-quay)  
-[DigitalOcean](https://github.com/digitalocean/go-netbox)  
+[NetBox Community](https://github.com/netbox-community/go-netbox)  
 [EVE Central](https://github.com/evecentral)  
 Iron.io
 [JaegerTracing](https://github.com/jaegertracing/jaeger)  


### PR DESCRIPTION
* fixes  #2206

This changes the name of project for go-netbox in docs