### PR TITLE
fix go-swagger#2066 issue

### DIFF
--- a/codescan/application.go
+++ b/codescan/application.go
@@ -291,7 +291,7 @@ func (s *scanCtx) FindModel(pkgPath, name string) (*entityDecl, bool) {
 		}
 	}
 	if decl, found := s.FindDecl(pkgPath, name); found {
-		s.app.Models[decl.Ident] = decl
+		s.app.ExtraModels[decl.Ident] = decl
 		return decl, true
 	}
 	return nil, false
@@ -390,6 +390,7 @@ func newTypeIndex(pkgs []*packages.Package,
 	ac := &typeIndex{
 		AllPackages: make(map[string]*packages.Package),
 		Models:      make(map[*ast.Ident]*entityDecl),
+		ExtraModels: make(map[*ast.Ident]*entityDecl),
 		excludeDeps: excludeDeps,
 		includeTags: includeTags,
 		excludeTags: excludeTags,
@@ -405,6 +406,7 @@ func newTypeIndex(pkgs []*packages.Package,
 type typeIndex struct {
 	AllPackages map[string]*packages.Package
 	Models      map[*ast.Ident]*entityDecl
+	ExtraModels map[*ast.Ident]*entityDecl
 	Meta        []metaSection
 	Routes      []parsedPathContent
 	Operations  []parsedPathContent

--- a/codescan/spec.go
+++ b/codescan/spec.go
@@ -1,6 +1,8 @@
 package codescan
 
 import (
+	"go/ast"
+
 	"github.com/go-openapi/spec"
 )
 
@@ -193,11 +195,37 @@ func (s *specBuilder) buildModels() error {
 	if !s.scanModels {
 		return nil
 	}
+
 	for _, decl := range s.ctx.app.Models {
 		if err := s.buildDiscoveredSchema(decl); err != nil {
 			return err
 		}
 	}
+
+	s.joinExtraModels()
+
+	return nil
+}
+
+func (s *specBuilder) joinExtraModels() error {
+	tmp := make(map[*ast.Ident]*entityDecl, len(s.ctx.app.ExtraModels))
+	for k, v := range s.ctx.app.ExtraModels {
+		tmp[k] = v
+		s.ctx.app.Models[k] = v
+		delete(s.ctx.app.ExtraModels, k)
+	}
+
+	// process extra models and see if there is any reference to a new extra one
+	for _, decl := range tmp {
+		if err := s.buildDiscoveredSchema(decl); err != nil {
+			return err
+		}
+	}
+
+	if len(s.ctx.app.ExtraModels) > 0 {
+		return s.joinExtraModels()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
@fredbi @casualjim instead of copying the map  before iteration I removed the place where `Models` is being modified, I think that was wrong, at this stage model should be known and embedded should not be added as a "standalone" model. Does that make sens to you? I updated related tests too.

Please take a look, thanks.

EDIT: I changed approach, to be sure that all models are processed (with extra ones), I added a new map `ExtraModels` which is joined later to `Models`. `Models` cannot be updated during iteration.