### PR TITLE
[DOCKER] don't run swagger with "root"

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,7 @@ docker pull quay.io/goswagger/swagger
 #### For Mac And Linux users:
 
 ```bash
-alias swagger="docker run --rm -it -e GOPATH=$HOME/go:/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger"
+alias swagger="docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=$HOME/go:/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger"
 swagger version
 ```
 


### PR DESCRIPTION
documentation update:

run swagger on current user uid:guid instead of root

-> no more file owned by root :-)