### PR TITLE
Improvements for XML support

### DIFF
--- a/docs/generate/client.md
+++ b/docs/generate/client.md
@@ -172,3 +172,50 @@ func main() {
   fmt.Printf("%#v\n", resp.Payload)
 }
 ```
+
+### Consuming an XML API
+
+In order to enable XML support, you need to set the command options `--default-consumes` or `--default-produces` to an XML mime type like `application/xml` when generating the client:
+
+```
+swagger generate client -f [http-url|filepath] -A [application-name] --default-consumes application/xml
+```
+
+This is necessary regardless of whether your swagger specification already specifies XML in the consumes and produces properties.
+
+An example using the generated client with default Bearer authentication:
+
+```go
+import (
+  "os"
+
+  "github.com/go-openapi/strfmt"
+  "github.com/go-openapi/runtime"
+
+  apiclient "github.com/myproject/client"
+  httptransport "github.com/go-openapi/runtime/client"
+)
+
+func main() {
+  r := httptransport.New(apiclient.DefaultHost, apiclient.DefaultBasePath, apiclient.DefaultSchemes)
+  r.DefaultAuthentication = httptransport.BearerToken(os.Getenv("API_ACCESS_TOKEN"))
+  /*
+  r.DefaultMediaType = runtime.XMLMime
+  r.Consumers = map[string]runtime.Consumer{
+    runtime.XMLMime: runtime.XMLConsumer(),
+  }
+  r.Producers = map[string]runtime.Producer{
+    "application/xhtml+xml": runtime.XMLProducer(),
+  }
+  */
+  client := apiclient.New(r, strfmt.Default)
+
+  resp, err := client.Operations.MyGreatEndpoint()
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Printf("%#v\n", resp.Payload)
+}
+```
+
+It can under certain circumstances be necessary to manually set the DefaultMediaType and the Consumers and Producers similar to the commented-out code above, particularly if you're using special mime types like `application/xhtml+xml`.

--- a/docs/generate/server.md
+++ b/docs/generate/server.md
@@ -208,6 +208,8 @@ func configureAPI(api *operations.ToDoListAPI) http.Handler {
 When you look at the code for the configureAPI method then you'll notice that the api object has properties for consumers.
 A consumer is an object that can marshal things from a wireformat to an object.  Consumers and their counterpart producers who write objects get their names generated from the consumes and produces properties on a swagger specification.
 
+Often, this will be JSON. If you want to use XML, additionally you have to enable XML compatible models when generating the server. For that, you have to set the command options `--default-consumes` or `--default-produces` to an XML mime type like `application/xml`. For more details on using XML, also see the [client generation](client.md).
+
 The interface definitions for consumers and producers look like this:
 
 ```go


### PR DESCRIPTION
For starters, at least some documentation, see #2256.

I decided to primarily put it into the client.md, because I had an example ready. And who would voluntarily _provide_ an XML API anyways ;)

Maybe the generate client documentation needs an update in general, also see #2243. For me it was trial and error as well, maybe someone can shed some light on that.