### PR TITLE
Set struct tags on generator options

### DIFF
--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -38,6 +38,7 @@ func (mo modelOptions) apply(opts *generator.GenOpts) {
 	opts.StrictAdditionalProperties = mo.StrictAdditionalProperties
 	opts.PropertiesSpecOrder = mo.KeepSpecOrder
 	opts.IgnoreOperations = mo.AllDefinitions
+	opts.StructTags = mo.StructTags
 }
 
 // WithModels adds the model options group


### PR DESCRIPTION
Bugfix for #2281.

I'm not sure what happened but this line got lost when I created the previous PR, so the struct tags were never passed from the command line options to the generator.