### PR TITLE
re-enacted CI-based linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
             - go-mod-v1-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
-          command: go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+          command: go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
       - run:
           name: Run unit tests
           command: golangci-lint run --timeout 2m --new-from-rev master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,12 @@ workflows:
 
   build_and_test:
     jobs:
+      - lint
       - build
 
       - test:
           requires:
+            - lint
             - build
           filters:
             tags:
@@ -78,6 +80,7 @@ workflows:
 
       - codegen_tests:
           requires:
+            - lint
             - build
           filters:
             tags:
@@ -88,6 +91,7 @@ workflows:
             tags:
               only: /^v.*/
           requires:
+            - lint
             - build
 
       - publish_dev:
@@ -123,6 +127,22 @@ workflows:
               ignore: /.*/
 
 jobs:
+  lint:
+    docker:
+      - image: goswagger/builder:debian
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+      - run:
+          name: Install golangci-lint
+          command: go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+      - run:
+          name: Run unit tests
+          command: golangci-lint run --timeout 2m --new-from-rev master
+          no_output_timeout: 2m
+
   build:
     docker:
       - image: goswagger/builder:debian


### PR DESCRIPTION
* fixes #2257

**NOTE**:
golangci hosted service has closed. We have to run it from CI.
I haven't tried github's super-linter yet: just wanted to lint our golang code again and not to
re-lint the entire repo with Dockerfiles, sh scripts etc.

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>