### PR TITLE
fix(cli): filter out empty args passed by CLI to select operations

### DIFF
--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -59,7 +59,7 @@ type Operation struct {
 	NoResponses  bool `long:"skip-responses" description:"when present will not generate the response model struct"`
 	NoURLBuilder bool `long:"skip-url-builder" description:"when present will not generate a URL builder"`
 
-	Name []string `long:"name" short:"n" required:"true" description:"the operations to generate, repeat for multiple (defaults to all). Same as --operations"`
+	Name []string `long:"name" short:"n" description:"the operations to generate, repeat for multiple (defaults to all). Same as --operations"`
 }
 
 func (o Operation) apply(opts *generator.GenOpts) {
@@ -94,7 +94,7 @@ You can get these now with: go get -u -f %s/...
 
 // Execute generates a model file
 func (o *Operation) Execute(args []string) error {
-	if o.Shared.DumpData && (len(o.Name) > 1 || len(o.Operations.Operations) > 1) {
+	if o.Shared.DumpData && len(append(o.Name, o.Operations.Operations...)) > 1 {
 		return errors.New("only 1 operation at a time is supported for dumping data")
 	}
 

--- a/generator/bindata.go
+++ b/generator/bindata.go
@@ -58,7 +58,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %w", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -66,7 +66,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %w", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -1018,9 +1018,6 @@ var _bindata = map[string]func() (*asset, error){
 	"templates/validation/primitive.gotmpl":                       templatesValidationPrimitiveGotmpl,
 	"templates/validation/structfield.gotmpl":                     templatesValidationStructfieldGotmpl,
 }
-
-// AssetDebug is true if the assets were built with the debug flag enabled.
-const AssetDebug = false
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -53,7 +53,8 @@ func sortedResponses(input map[int]spec.Response) responses {
 	return res
 }
 
-// GenerateServerOperation generates a parameter model, parameter validator, http handler implementations for a given operation
+// GenerateServerOperation generates a parameter model, parameter validator, http handler implementations for a given operation.
+//
 // It also generates an operation handler interface that uses the parameter model for handling a valid request.
 // Allows for specifying a list of tags to include only certain tags for the generation
 func GenerateServerOperation(operationNames []string, opts *GenOpts) error {

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -714,6 +714,7 @@ func fileExists(target, name string) bool {
 }
 
 func gatherModels(specDoc *loads.Document, modelNames []string) (map[string]spec.Schema, error) {
+	modelNames = pruneEmpty(modelNames)
 	models, mnc := make(map[string]spec.Schema), len(modelNames)
 	defs := specDoc.Spec().Definitions
 
@@ -779,6 +780,7 @@ func (o opRefs) Swap(i, j int)      { o[i], o[j] = o[j], o[i] }
 func (o opRefs) Less(i, j int) bool { return o[i].Key < o[j].Key }
 
 func gatherOperations(specDoc *analysis.Spec, operationIDs []string) map[string]opRef {
+	operationIDs = pruneEmpty(operationIDs)
 	var oprefs opRefs
 
 	for method, pathItem := range specDoc.Operations() {

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -403,13 +403,20 @@ func (g GenStatusCodeResponses) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 func (g GenStatusCodeResponses) Less(i, j int) bool { return g[i].Code < g[j].Code }
 
 // MarshalJSON marshals these responses to json
+//
+// This is used by DumpData.
 func (g GenStatusCodeResponses) MarshalJSON() ([]byte, error) {
 	if g == nil {
 		return nil, nil
 	}
+	responses := make(GenStatusCodeResponses, len(g))
+	copy(responses, g)
+	// order marshalled output
+	sort.Sort(responses)
+
 	var buf bytes.Buffer
 	buf.WriteRune('{')
-	for i, v := range g {
+	for i, v := range responses {
 		rb, err := json.Marshal(v)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
* Also fixed similar issue with selected models

* fixes #2280

Also in this commit:
* ordered operations in dump data

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>