### PR TITLE
Enhanced generate model CLI: accepts definitions only specs, deprecates some options

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,24 +221,14 @@ Iron.io
 
 ## Note to users migrating from older releases
 
-### Using 0.5.0
+### Migrating from 0.24 to [master]
 
-Because 0.5.0 and master have diverged significantly, you should checkout the tag 0.5.0 for go-swagger when you use the currently released version.
+The options for `generate model --all-definitions` and `--skip-struct` are marked for deprecation. 
 
-### Migrating from 0.5.0 to 0.6.0
+For now, the CLI continues to accept these options. They will be removed in a future version.
 
-You will have to rename some imports:
-
-```
-github.com/go-swagger/go-swagger/httpkit/validate to github.com/go-openapi/validate
-github.com/go-swagger/go-swagger/httpkit to github.com/go-openapi/runtime
-github.com/naoina/denco to github.com/go-openapi/runtime/middleware/denco
-github.com/go-swagger/go-swagger to github.com/go-openapi
-```
-
-### Migrating from 0.12 to 0.13
-
-Spec flattening and $ref resolution brought breaking changes in model generation, since all complex things generate their own definitions.
+Generating all definitions is now the default behavior when no other option filters the generation scope.
+The `--skip-struct` option had no effect.
 
 ### Migrating from 0.14 to 0.15
 
@@ -252,3 +242,22 @@ Spec flattening now defaults to minimal changes to models and should be workable
 Users who prefer to stick to 0.13 and 0.14 default flattening mode may now use the `--with-flatten=full` option.
 
 Note that the `--skip-flatten` option has been phased out and replaced by the more explicit `--with-expand` option.
+
+### Migrating from 0.12 to 0.13
+
+Spec flattening and $ref resolution brought breaking changes in model generation, since all complex things generate their own definitions.
+
+### Migrating from 0.5.0 to 0.6.0
+
+You will have to rename some imports:
+
+```
+github.com/go-swagger/go-swagger/httpkit/validate to github.com/go-openapi/validate
+github.com/go-swagger/go-swagger/httpkit to github.com/go-openapi/runtime
+github.com/naoina/denco to github.com/go-openapi/runtime/middleware/denco
+github.com/go-swagger/go-swagger to github.com/go-openapi
+```
+
+### Using 0.5.0
+
+Because 0.5.0 and master have diverged significantly, you should checkout the tag 0.5.0 for go-swagger when you use the currently released version.

--- a/docs/generate/model.md
+++ b/docs/generate/model.md
@@ -15,8 +15,8 @@ Help Options:
   -h, --help                                                                      Show this help message
 
 [model command options]
-          --skip-struct                                                           when present will not generate the model struct
       -n, --name=                                                                 the model to generate, repeat for multiple (defaults to all). Same as --models
+          --accept-definitions-only                                               accepts a partial swagger spec wih only the definitions key
 
     Options common to all code generation commands:
       -f, --spec=                                                                 the spec file to use (default swagger.{json,yml,yaml})
@@ -29,6 +29,7 @@ Help Options:
           --allow-template-override                                               allows overriding protected templates
           --skip-validation                                                       skips validation of spec prior to generation
           --dump-data                                                             when present dumps the json for the template generator instead of generating files
+          --strict-responders                                                     Use strict type for the handler return value
           --with-expand                                                           expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
           --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in spec prior to generation (default: minimal, verbose)
 
@@ -38,6 +39,7 @@ Help Options:
           --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
           --strict-additional-properties                                          disallow extra properties when additionalProperties is set to false
           --keep-spec-order                                                       keep schema properties order identical to spec file
+          --struct-tags=                                                          the struct tags to generate, repeat for multiple (defaults to json)
 ```
 
 Schema generation rules are detailed [here](../use/model.md).

--- a/fixtures/enhancements/2333/fixture-definitions.yaml
+++ b/fixtures/enhancements/2333/fixture-definitions.yaml
@@ -1,0 +1,13 @@
+definitions:
+  modelInterface:
+    type: object
+    additionalProperties: true
+  recordsModel:
+    type: array
+    items:
+      type: object
+  recordsModelWithMax:
+    type: array
+    maxItems: 10
+    items:
+      type: object

--- a/generator/model.go
+++ b/generator/model.go
@@ -47,7 +47,23 @@ Every action that happens tracks the path which is a linked list of refs
 
 */
 
-// GenerateDefinition generates a model file for a schema definition.
+// GenerateModels generates all model files for some schema definitions
+func GenerateModels(modelNames []string, opts *GenOpts) error {
+	// overide any default or incompatible options setting
+	opts.IncludeModel = true
+	opts.IgnoreOperations = true
+	opts.ExistingModels = ""
+	opts.IncludeHandler = false
+	opts.IncludeMain = false
+	opts.IncludeSupport = false
+	generator, err := newAppGenerator("", modelNames, nil, opts)
+	if err != nil {
+		return err
+	}
+	return generator.Generate()
+}
+
+// GenerateDefinition generates a single model file for some schema definitions
 func GenerateDefinition(modelNames []string, opts *GenOpts) error {
 	if err := opts.CheckOpts(); err != nil {
 		return err
@@ -62,6 +78,7 @@ func GenerateDefinition(modelNames []string, opts *GenOpts) error {
 		return err
 	}
 
+	modelNames = pruneEmpty(modelNames)
 	if len(modelNames) == 0 {
 		for k := range specDoc.Spec().Definitions {
 			modelNames = append(modelNames, k)

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -100,7 +100,7 @@ func GenerateServerOperation(operationNames []string, opts *GenOpts) error {
 			IncludeHandler:       opts.IncludeHandler,
 			IncludeParameters:    opts.IncludeParameters,
 			IncludeResponses:     opts.IncludeResponses,
-			IncludeValidator:     true, // we no more support the CLI option to disable validation
+			IncludeValidator:     opts.IncludeValidator,
 			DumpData:             opts.DumpData,
 			DefaultScheme:        opts.DefaultScheme,
 			DefaultProduces:      opts.DefaultProduces,
@@ -1074,7 +1074,7 @@ func (b *codeGenOpBuilder) buildOperationSchema(schemaPath, containerName, schem
 		TypeResolver:               rslv,
 		Named:                      false,
 		IncludeModel:               true,
-		IncludeValidator:           true,
+		IncludeValidator:           b.GenOpts.IncludeValidator,
 		StrictAdditionalProperties: b.GenOpts.StrictAdditionalProperties,
 		ExtraSchemas:               make(map[string]GenSchema),
 		StructTags:                 b.GenOpts.StructTags,

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -267,6 +267,7 @@ type GenOpts struct {
 	IgnoreOperations       bool
 	AllowEnumCI            bool
 	StrictResponders       bool
+	AcceptDefinitionsOnly  bool
 }
 
 // CheckOpts carries out some global consistency checks on options.
@@ -396,7 +397,7 @@ func (g *GenOpts) EnsureDefaults() error {
 	}
 
 	// always include validator with models
-	g.IncludeValidator = g.IncludeModel
+	g.IncludeValidator = true
 
 	if g.Principal == "" {
 		g.Principal = iface

--- a/generator/spec.go
+++ b/generator/spec.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -11,6 +12,7 @@ import (
 	"github.com/go-openapi/analysis"
 	swaggererrors "github.com/go-openapi/errors"
 	"github.com/go-openapi/loads"
+	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
@@ -22,6 +24,14 @@ func (g *GenOpts) validateAndFlattenSpec() (*loads.Document, error) {
 	specDoc, err := loads.Spec(g.Spec)
 	if err != nil {
 		return nil, err
+	}
+
+	// If accepts definitions only, add dummy swagger header to pass validation
+	if g.AcceptDefinitionsOnly {
+		specDoc, err = applyDefaultSwagger(specDoc)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Validate if needed
@@ -212,4 +222,27 @@ func WithAutoXOrder(specPath string) string {
 		panic(err)
 	}
 	return tmpFile.Name()
+}
+
+func applyDefaultSwagger(doc *loads.Document) (*loads.Document, error) {
+	// bake a minimal swagger spec to pass validation
+	swspec := doc.Spec()
+	if swspec.Swagger == "" {
+		swspec.Swagger = "2.0"
+	}
+	if swspec.Info == nil {
+		info := new(spec.Info)
+		info.Version = "0.0.0"
+		info.Title = "minimal"
+		swspec.Info = info
+	}
+	if swspec.Paths == nil {
+		swspec.Paths = &spec.Paths{}
+	}
+	// rewrite the document with the new addition
+	jazon, err := json.Marshal(swspec)
+	if err != nil {
+		return nil, err
+	}
+	return loads.Analyzed(jazon, swspec.Swagger)
 }

--- a/generator/support.go
+++ b/generator/support.go
@@ -144,7 +144,7 @@ func (a *appGenerator) Generate() error {
 		log.Printf("rendering %d models", len(app.Models))
 		for _, mod := range app.Models {
 			mod.IncludeModel = true
-			mod.IncludeValidator = true // we systematically include model validation code (previous CLI flag to skip this is gone)
+			mod.IncludeValidator = a.GenOpts.IncludeValidator
 			if err := a.GenOpts.renderDefinition(&mod); err != nil {
 				return err
 			}
@@ -272,7 +272,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 			Operation:        *o,
 			Method:           opp.Method,
 			Path:             opp.Path,
-			IncludeValidator: true,
+			IncludeValidator: a.GenOpts.IncludeValidator,
 			APIPackage:       a.APIPackage, // defaults to main operations package
 			DefaultProduces:  a.DefaultProduces,
 			DefaultConsumes:  a.DefaultConsumes,


### PR DESCRIPTION
Feature
* added --accept-definitions-only option to generate model from a spec with only definitions (not the complete swagger spec)

Deprecated CLI options
* deprecated generate model option: --skip-struct (was inoperant)
* deprecated generate model option: --all-definitions (now the default behavior, as previously documented)
* updated usage doc for generate model CLI
* added deprecation notice to README (no breaking change introduced on CLI)

Refactoring
* refactored generate model command to use standalone model codegen func generator.GenerateModels (now in line with other commands)
* refactored places where GenOpts.IncludeValidator is hard-coded to true, in order to drive this parameter from one single place (unused, but might come back)
* refactored test for full server codegen, essentially to share test code with the new GenerateModels func

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>