### PR TITLE
fix edge case with panic in models because of invalid additionalProperties or AllOf schema

### DIFF
--- a/fixtures/bugs/2161/fixture-2161-panic.json
+++ b/fixtures/bugs/2161/fixture-2161-panic.json
@@ -1,0 +1,29009 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "VeloCloud Orchestrator API",
+    "version": "3.3.2",
+    "contact": {
+      "name": "VMware SD-WAN by VeloCloud",
+      "email": "support@velocloud.net",
+      "url": "https://www.vmware.com/products/sd-wan-by-velocloud.html"
+    }
+  },
+  "basePath": "/portal/rest",
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/login/operatorLogin": {
+      "post": {
+        "operationId": "login_operator_login",
+        "summary": "Authenticate operator user",
+        "description": "Authenticates an operator user and, upon successful login, returns a velocloud.session cookie. Pass this session cookie in the authentication header in subsequent VCO calls.\n If you are using an HTTP client (e.g. Postman) that is configured to automatically follow HTTP redirects, a successful authentication request will cause your client to follow an HTTP 302 redirect to the portal 'Home' web page. Your session cookie can then be used to make VCO API calls. \n Note that session cookies expire after a period of time specified in the VCO configuration (default is 24 hours).",
+        "tags": [
+          "all",
+          "login"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/auth_param"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "If you are using an HTTP client that is configured to automatically follow HTTP redirects (e.g. Postman), a successful authentication request will cause your client to follow a HTTP 302 redirect to the portal 'Home' web page. Your session cookie may then be used to make API calls."
+          },
+          "302": {
+            "description": "An HTTP 302 response is returned on both successful and failed authentication attempts. If the response includes a Set-Cookie header specifying a non-empty velocloud.session cookie, authentication was successful and this cookie may be used to make API calls."
+          }
+        }
+      }
+    },
+    "/login/enterpriseLogin": {
+      "post": {
+        "operationId": "login_enterprise_login",
+        "summary": "Authenticate enterprise or partner (MSP) user",
+        "description": "Authenticates an enterprise or partner (MSP) user and, upon successful login, returns a velocloud.session cookie. Pass this session cookie in the authentication header in subsequent VCO calls.\n If you are using an HTTP client (e.g. Postman) that is configured to automatically follow HTTP redirects, a successful authentication request will cause your client to follow an HTTP 302 redirect to the portal 'Home' web page. Your session cookie can then be used to make VCO API calls.\n Note that session cookies expire after a period of time specified in the VCO configuration (default is 24 hours).",
+        "tags": [
+          "all",
+          "login"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/auth_param"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "If you are using an HTTP client that is configured to automatically follow HTTP redirects (e.g. Postman), a successful authentication request will cause your client to follow an HTTP 302 redirect to the portal 'Home' web page. Your session cookie may then be used to make API calls."
+          },
+          "302": {
+            "description": "An HTTP 302 response is returned on both successful and failed authentication attempts. If the response includes a Set-Cookie header specifying a non-empty velocloud.session cookie, authentication was successful and this cookie may be used to make API calls."
+          }
+        }
+      }
+    },
+    "/logout": {
+      "post": {
+        "operationId": "logout",
+        "summary": "Logout and invalidate authorization session cookie",
+        "description": "Logs out the VCO API user and invalidates the session cookie.",
+        "tags": [
+          "all",
+          "login"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "If you are using an HTTP client that is configured to automatically follow HTTP redirects (e.g. Postman), a successful logout request will cause your client to follow an HTTP 302 redirect to the portal login web page."
+          },
+          "302": {
+            "description": "An HTTP 302 (redirect) response is returned on both successful and failed logout attempts."
+          }
+        }
+      }
+    },
+    "/meta/{apiPath}": {
+      "post": {
+        "deprecated": true,
+        "operationId": "meta",
+        "summary": "Get Swagger specification for any VCO API call",
+        "description": "Gets the Swagger specification for any VCO API call.",
+        "tags": [
+          "all",
+          "meta"
+        ],
+        "parameters": [
+          {
+            "name": "apiPath",
+            "in": "path",
+            "description": "the path to another api method, starting after /rest/",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "privileges": {
+                  "type": "object"
+                },
+                "swagger": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          }
+        }
+      }
+    },
+    "/clientDevice/setClientDeviceHostName": {
+      "post": {
+        "summary": "Set hostname for client device",
+        "description": "Sets the `hostName` for client device\n\nPrivileges required:\n\n`UPDATE` `CLIENT_DEVICE`",
+        "tags": [
+          "clientDevice",
+          "all"
+        ],
+        "operationId": "set_client_device_host_name",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "CLIENT_DEVICE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "title": "set_client_device_host_name",
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "clientDeviceId": {
+                  "type": "integer"
+                },
+                "hostName": {
+                  "type": "string"
+                },
+                "macAddress": {
+                  "type": "string"
+                },
+                "ipAddress": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enterpriseId",
+                "hostName"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/set_client_device_host_name_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/cloneAndConvertConfiguration": {
+      "post": {
+        "summary": "Create new segment-based profile from existing network-based profile",
+        "description": "Clones and converts the specified network configuration (by `configurationId`). Accepts an `enterpriseId` or `networkId` to associate the new configuration with an enterprise or network. On success, returns the ID of the newly created configuration object.\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE_PROFILE`, or\n\n`CREATE` `OPERATOR_PROFILE`",
+        "tags": [
+          "configuration",
+          "all"
+        ],
+        "operationId": "configuration_clone_and_convert_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "CREATE",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_clone_and_convert_configuration",
+              "properties": {
+                "configurationId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "guestVLANSegmentObjectId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "configurationId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_clone_and_convert_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/cloneConfiguration": {
+      "post": {
+        "summary": "Clone configuration profile",
+        "description": "Clones the specified configuration (by `configurationId`) and all associated configuration modules. Accepts an `enterpriseId` or `networkId` to associate the new configuration with an enterprise or network. Select modules may also be specified. On success, returns the `id` of the newly created configuration object.\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE_PROFILE`, or\n\n`CREATE` `OPERATOR_PROFILE`",
+        "tags": [
+          "configuration",
+          "all"
+        ],
+        "operationId": "configuration_clone_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "CREATE",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_clone_configuration",
+              "properties": {
+                "configurationId": {
+                  "type": "integer"
+                },
+                "networkId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "configurationId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_clone_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/cloneEnterpriseTemplate": {
+      "post": {
+        "summary": "Clone default enterprise configuration profile",
+        "description": "Creates a new enterprise configuration from the enterprise default configuration. On success, returns the `id` of the newly created configuration object.\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE_PROFILE`, or\n\n`CREATE` `OPERATOR_PROFILE`",
+        "tags": [
+          "all",
+          "configuration"
+        ],
+        "operationId": "configuration_clone_enterprise_template",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "CREATE",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_clone_enterprise_template",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer",
+                  "description": "Required if called from the operator or MSP context, identifies the target enterprise of the API call."
+                },
+                "configurationType": {
+                  "type": "string",
+                  "enum": [
+                    "SEGMENT_BASED",
+                    "NETWORK_BASED"
+                  ],
+                  "description": "If both network and segment based functionality is granted to the enterprise, chose which template type to clone. If not specified the type of the operator profile assigned to the enterprise will be used."
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_clone_enterprise_template_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/deleteConfiguration": {
+      "post": {
+        "summary": "Delete configuration profile",
+        "description": "Deletes the specified configuration profile (by `id`). On success, returns an object indicating the number of objects (rows) deleted (1 or 0).\n\nPrivileges required:\n\n`DELETE` `ENTERPRISE_PROFILE`, or\n\n`DELETE` `OPERATOR_PROFILE`",
+        "tags": [
+          "all",
+          "configuration"
+        ],
+        "operationId": "configuration_delete_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "DELETE",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_delete_configuration",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_delete_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/getConfiguration": {
+      "post": {
+        "summary": "Get configuration profile",
+        "description": "Gets the specified configuration profile, optionally with module details.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_PROFILE`, or\n\n`READ` `OPERATOR_PROFILE`",
+        "tags": [
+          "all",
+          "configuration"
+        ],
+        "operationId": "configuration_get_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "READ",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_get_configuration",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "modules",
+                      "edgeCount",
+                      "enterprises",
+                      "enterpriseCount",
+                      "counts"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_get_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/getConfigurationModules": {
+      "post": {
+        "summary": "Get configuration profile modules",
+        "description": "Gets all configuration modules for the specified configuration profile.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_PROFILE`, or\n\n`READ` `OPERATOR_PROFILE`",
+        "tags": [
+          "configuration",
+          "all"
+        ],
+        "operationId": "configuration_get_configuration_modules",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "READ",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_get_configuration_modules",
+              "properties": {
+                "configurationId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "noData": {
+                  "type": "boolean"
+                },
+                "modules": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "imageUpdate",
+                      "controlPlane",
+                      "managementPlane",
+                      "firewall",
+                      "QOS",
+                      "deviceSettings",
+                      "WAN",
+                      "metaData",
+                      "properties"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "configurationId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "configuration_get_configuration_modules_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/configuration_get_configuration_modules_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/getIdentifiableApplications": {
+      "post": {
+        "summary": "Get the applications that are identifiable through DPI.",
+        "description": "Gets all applications that are identifiable through DPI. If called from an operator or MSP context, then `enterpriseId` is required.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_PROFILE`",
+        "tags": [
+          "all",
+          "configuration"
+        ],
+        "operationId": "configuration_get_identifiable_applications",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_get_identifiable_applications",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_get_identifiable_applications_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/getRoutableApplications": {
+      "post": {
+        "summary": "Get first packet routable applications",
+        "description": "Gets all applications that are first packet routable. If called from an operator or MSP context, then `enterpriseId` is required.Optionally, specify `edgeId` to get the map for a specific Edge.\n\nPrivileges required:\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "configuration"
+        ],
+        "operationId": "configuration_get_routable_applications",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "VIEW_FLOW_STATS",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_get_routable_applications",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_get_routable_applications_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/insertConfigurationModule": {
+      "post": {
+        "summary": "Create configuration module",
+        "description": "Creates a new configuration module for the specified configuration profile.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_PROFILE`, or\n\n`UPDATE` `OPERATOR_PROFILE`",
+        "tags": [
+          "configuration",
+          "all"
+        ],
+        "operationId": "configuration_insert_configuration_module",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "UPDATE",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_insert_configuration_module",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string",
+                  "enum": [
+                    "imageUpdate",
+                    "controlPlane",
+                    "managementPlane",
+                    "firewall",
+                    "QOS",
+                    "deviceSettings",
+                    "WAN",
+                    "metaData",
+                    "properties"
+                  ]
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ENTERPRISE",
+                    "OPERATOR",
+                    "GATEWAY"
+                  ]
+                },
+                "description": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "object"
+                },
+                "configurationId": {
+                  "type": "integer"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "data",
+                "configurationId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_insert_configuration_module_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/updateConfiguration": {
+      "post": {
+        "summary": "Update configuration profile",
+        "description": "Updates the specified configuration profile record according to the attribute:value mappings specified in the `_update` object.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_PROFILE`, or\n\n`UPDATE` `OPERATOR_PROFILE`",
+        "tags": [
+          "configuration",
+          "all"
+        ],
+        "operationId": "configuration_update_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "UPDATE",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_update_configuration",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "_update": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "effective": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "_update"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/rows_modified_confirmation"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/configuration/updateConfigurationModule": {
+      "post": {
+        "summary": "Update configuration module",
+        "description": "Updates the specified configuration module. Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_PROFILE`, or\n\n`UPDATE` `OPERATOR_PROFILE`",
+        "tags": [
+          "configuration",
+          "all"
+        ],
+        "operationId": "configuration_update_configuration_module",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_PROFILE",
+              "sufficient": true
+            },
+            {
+              "action": "UPDATE",
+              "object": "OPERATOR_PROFILE",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "configuration_update_configuration_module",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "basic": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "_update": {
+                  "$ref": "#/definitions/configuration_module_base_type"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/configuration_update_configuration_module_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/disasterRecovery/configureActiveForReplication": {
+      "post": {
+        "summary": "Configure current VCO for disaster recovery",
+        "tags": [
+          "all",
+          "disasterRecovery"
+        ],
+        "description": "Configures the current Orchestrator to be active and the specified Orchestrator to be standby for Orchestrator disaster recovery replication. Required attributes: 1) `standbyList`, a single-entry array containing the `standbyAddress` and `standbyUuid`, 2) `drVCOUser`, a Orchestrator super user available on both the active and standby VCOs, and 3) `drVCOPassword`, the password of `drVCOUser` on the standby Orchestrator (unless the `autoConfigStandby` option is specified as `false`). The call sets up the active Orchestrator to allow replication from the standby and then (unless `autoConfigStandby` is `false`) makes a `transitionToStandby` API call to the specified standby, expected to have been previously placed in `STANDBY_CANDIDATE` state via `prepareForStandby`. After this call, the active and standby VCOs should be polled via `getReplicationStatus` until they  both reach `STANDBY_RUNNING` `drState` (or a configuration error is reported).  (Note: `drVCOPassword` is not persisted.)\n\nPrivileges required:\n\n`CREATE` `REPLICATION`",
+        "operationId": "disaster_recovery_configure_active_for_replication",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "REPLICATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "disaster_recovery_configure_active_for_replication",
+              "properties": {
+                "standbyList": {
+                  "type": "array",
+                  "items": {
+                    "title": "standby_vco_designee",
+                    "type": "object",
+                    "properties": {
+                      "standbyAddress": {
+                        "type": "string"
+                      },
+                      "standbyReplicationAddress": {
+                        "type": "string"
+                      },
+                      "standbyUuid": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "standbyAddress",
+                      "standbyUuid"
+                    ]
+                  }
+                },
+                "autoConfigStandby": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "drVCOUser": {
+                  "type": "string"
+                },
+                "drVCOPassword": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "standbyList",
+                "drVCOUser",
+                "drVCOPassword"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_configure_active_for_replication_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/disasterRecovery/demoteActive": {
+      "post": {
+        "summary": "Demote current VCO from active to zombie",
+        "tags": [
+          "all",
+          "disasterRecovery"
+        ],
+        "description": "Demotes the current VCO from active to zombie. No input parameters are required. The active server is expected to be in the `drState` `FAILURE_GET_STANDBY_STATUS` or `FAILURE_MYSQL_ACTIVE_STATUS`, meaning that DR protection had been engaged (with the last successful replication status observed at `lastDRProtectedTime`) but that active failed a health check since that time.  If the active server is in the `drState` `STANDBY_RUNNING`, meaning that it has detected no problems in interacting with the standby server, the operator can force demotion of the active using the optional `force` parameter passed with value of `true`; in this case, the operator must ensure that the standby server has already been successfully promoted.\n\nPrivileges required:\n\n`CREATE` `REPLICATION`",
+        "operationId": "disaster_recovery_demote_active",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "REPLICATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "disaster_recovery_demote_active",
+              "properties": {
+                "force": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_demote_active_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/disasterRecovery/getReplicationBlob": {
+      "post": {
+        "summary": "Get blob needed to configure VCO replication on standby",
+        "tags": [
+          "all",
+          "disasterRecovery"
+        ],
+        "description": "Gets from the active Orchestrator the blob needed to configure replication on the standby. Used only when `configureActiveForReplication` was called with `autoConfigStandby` set to `false` [`true` by default].\n\nPrivileges required:\n\n`CREATE` `REPLICATION`",
+        "operationId": "disaster_recovery_get_replication_blob",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "REPLICATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_get_replication_blob"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_get_replication_blob_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/disasterRecovery/getReplicationStatus": {
+      "post": {
+        "summary": "Get disaster recovery status",
+        "tags": [
+          "all",
+          "disasterRecovery"
+        ],
+        "description": "Gets the disaster recovery replication status, optionally with client contact, state transition history, and storage information. No input parameters are required.  Can optionally specify one or more of the following `with` parameters: `clientContact`, `clientCount`, `stateHistory`, and `storageInfo`.\n\nPrivileges required:\n\n`READ` `REPLICATION`",
+        "operationId": "disaster_recovery_get_replication_status",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "REPLICATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "disaster_recovery_get_replication_status",
+              "properties": {
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "clientContact",
+                      "stateHistory",
+                      "clientCount",
+                      "storageInfo"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_get_replication_status_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/disasterRecovery/prepareForStandby": {
+      "post": {
+        "summary": "Designate current VCO as DR standby candidate",
+        "tags": [
+          "all",
+          "disasterRecovery"
+        ],
+        "description": "Transitions the current Orchestrator to a quiesced state, ready to be configured as a standby system. No input parameters are required.  After this call, the Orchestrator will be restarted in standby mode. The caller should subsequently poll `getReplicationStatus` until `drState` is `STANDBY_CANDIDATE`.  This is the first step in configuring Orchestrator disaster recovery.\n\nPrivileges required:\n\n`CREATE` `REPLICATION`",
+        "operationId": "disaster_recovery_prepare_for_standby",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "REPLICATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_prepare_for_standby"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_prepare_for_standby_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/disasterRecovery/promoteStandbyToActive": {
+      "post": {
+        "summary": "Promote standby VCO to active",
+        "tags": [
+          "all",
+          "disasterRecovery"
+        ],
+        "description": "Promotes the current server to take over as the single standalone VCO. The current server is expected to be a standby in the `drState` `FAILURE_MYSQL_STANDBY_STATUS`, meaning that DR protection had been engaged (with the last successful replication status observed at `lastDRProtectedTime`), but that standby has been unable to replicate since that time. \n If the standby server is in the `drState` `STANDBY_RUNNING`, meaning that it has detected no problems in replicating from the active server, the operator can force promotion of the standby using the optional `force` parameter passed with a value of `true`. In this case, the standby server will call `demoteActive/force` on the active server.  The operator should, if possible, ensure that the formerly active server is demoted by running `demoteServer` directly on that server if the standby server was unable to do so successfully.\n\nPrivileges required:\n\n`CREATE` `REPLICATION`",
+        "operationId": "disaster_recovery_promote_standby_to_active",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "REPLICATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "disaster_recovery_promote_standby_to_active",
+              "properties": {
+                "force": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_promote_standby_to_active_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/disasterRecovery/removeStandby": {
+      "post": {
+        "summary": "Remove VCO disaster recovery on current server",
+        "tags": [
+          "all",
+          "disasterRecovery"
+        ],
+        "description": "Removes disaster recovery on the current server. In addition, makes a best-effort call to `removeStandby` on the paired disaster recovery server. No input parameters are required.\n\nPrivileges required:\n\n`CREATE` `REPLICATION`",
+        "operationId": "disaster_recovery_remove_standby",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "REPLICATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_remove_standby"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_remove_standby_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/disasterRecovery/transitionToStandby": {
+      "post": {
+        "summary": "Transition VCO to standby",
+        "tags": [
+          "all",
+          "disasterRecovery"
+        ],
+        "description": "Configures the current Orchestrator to transition to standby in a disaster recovery active/standby pair. Requires the `activeAccessFromStandby` parameter that contains the data needed to configure standby. This data is produced by `configureActiveForReplication`, which by default automatically calls `transitionToStandby`; an explicit call is needed (with a blob obtained from `getReplicationBlob`), only if `configureActiveForReplication` is called with `autoConfigStandby` set to `false`.\n\nPrivileges required:\n\n`CREATE` `REPLICATION`",
+        "operationId": "disaster_recovery_transition_to_standby",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "REPLICATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "disaster_recovery_transition_to_standby",
+              "properties": {
+                "activeAccessFromStandby": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/disaster_recovery_transition_to_standby_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/deleteEdge": {
+      "post": {
+        "summary": "Delete Edge",
+        "description": "Deletes the specified Edge(s) (by `id` or an array of `ids`).\n\nPrivileges required:\n\n`DELETE` `EDGE`",
+        "tags": [
+          "all",
+          "edge"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "operationId": "edge_delete_edge",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_delete_edge",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/edge_delete_edge_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/deleteEdgeBgpNeighborRecords": {
+      "post": {
+        "summary": "Delete Edge BGP neighbor records",
+        "description": "Deletes BGP record(s) matching the specified record keys (`neighborIp`) on the Edges with the specified `edgeId`s, if they exist.\n\nPrivileges required:\n\n`DELETE` `NETWORK_SERVICE`",
+        "tags": [
+          "all",
+          "edge"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "NETWORK_SERVICE"
+            }
+          ]
+        },
+        "operationId": "edge_delete_edge_bgp_neighbor_records",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_delete_edge_bgp_neighbor_records",
+              "properties": {
+                "records": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "edgeId": {
+                        "type": "integer"
+                      },
+                      "neighborIp": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/edge_delete_edge_bgp_neighbor_records_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/edgeCancelReactivation": {
+      "post": {
+        "summary": "Cancel pending Edge reactivation request",
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "description": "Cancels a pending Edge reactivation request for the specified Edge (by `edgeId`).\n\nPrivileges required:\n\n`CREATE` `EDGE`",
+        "operationId": "edge_edge_cancel_reactivation",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_edge_cancel_reactivation",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enterpriseId",
+                "edgeId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/edge_edge_cancel_reactivation_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/edgeProvision": {
+      "post": {
+        "summary": "Provision Edge",
+        "description": "Provisions an Edge before activation.\n\nPrivileges required:\n\n`CREATE` `EDGE`",
+        "operationId": "edge_edge_provision",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_edge_provision",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "configurationId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "serialNumber": {
+                  "type": "string"
+                },
+                "modelNumber": {
+                  "type": "string",
+                  "enum": [
+                    "edge500",
+                    "edge5X0",
+                    "edge510",
+                    "edge6X0",
+                    "edge840",
+                    "edge1000",
+                    "edge1000qat",
+                    "edge3X00",
+                    "virtual"
+                  ]
+                },
+                "description": {
+                  "type": "string"
+                },
+                "site": {
+                  "$ref": "#/definitions/site"
+                },
+                "haEnabled": {
+                  "type": "boolean"
+                },
+                "generateCertificate": {
+                  "type": "boolean"
+                },
+                "subjectCN": {
+                  "type": "string"
+                },
+                "subjectO": {
+                  "type": "string"
+                },
+                "subjectOU": {
+                  "type": "string"
+                },
+                "challengePassword": {
+                  "type": "string"
+                },
+                "privateKeyPassword": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "configurationId",
+                "modelNumber"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/edge_edge_provision_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/edgeRequestReactivation": {
+      "post": {
+        "summary": "Prepare Edge for reactivation",
+        "description": "Updates the activation state of the specified Edge to `REACTIVATION_PENDING`.\n\nPrivileges required:\n\n`CREATE` `EDGE`",
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "operationId": "edge_edge_request_reactivation",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_edge_request_reactivation",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enterpriseId",
+                "edgeId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/edge_edge_request_reactivation_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/getClientVisibilityMode": {
+      "post": {
+        "summary": "Get an edge's client visibility mode",
+        "description": "Retrieve an edge's client visibility mode.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "operationId": "edge_get_client_visibility_mode",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "forceEnterpriseContext": true,
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_get_client_visibility_mode",
+              "properties": {
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "edgeId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "edge_get_client_visibility_mode_result",
+              "type": "object",
+              "properties": {
+                "edgeClientVisibilityMode": {
+                  "type": "string",
+                  "enum": [
+                    "MAC",
+                    "IP"
+                  ]
+                }
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/getEdge": {
+      "post": {
+        "summary": "Get Edge",
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "description": "Gets the specified Edge with optional link, site, configuration, certificate, orenterprise details. Supports queries by Edge `id`, `deviceId`, `activationKey`, and `logicalId`.\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "operationId": "edge_get_edge",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_get_edge",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "logicalId": {
+                  "type": "string"
+                },
+                "activationKey": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "recentLinks",
+                      "links",
+                      "serviceGroups",
+                      "site",
+                      "enterprise",
+                      "configuration",
+                      "configurationWithModules"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/edge_get_edge_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/getEdgeConfigurationModules": {
+      "post": {
+        "summary": "Get edge configuration modules",
+        "description": "Gets edge composite configuration modules for the specified Edge (by `edgeId`).\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`READ` `ENTERPRISE_PROFILE`",
+        "operationId": "edge_get_edge_configuration_modules",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_get_edge_configuration_modules",
+              "properties": {
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "modules": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "imageUpdate",
+                      "controlPlane",
+                      "managementPlane",
+                      "firewall",
+                      "QOS",
+                      "deviceSettings",
+                      "WAN",
+                      "metaData",
+                      "properties"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "edgeId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "edge_get_edge_configuration_modules_result",
+              "type": "object",
+              "properties": {
+                "deviceSettings": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "ENTERPRISE",
+                        "OPERATOR",
+                        "GATEWAY"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/definitions/edgeDeviceSettingsData"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "schemaVersion",
+                    "type",
+                    "data"
+                  ]
+                },
+                "firewall": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "ENTERPRISE",
+                        "OPERATOR",
+                        "GATEWAY"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/definitions/firewall_data"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "schemaVersion",
+                    "type",
+                    "data"
+                  ]
+                },
+                "QOS": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "ENTERPRISE",
+                        "OPERATOR",
+                        "GATEWAY"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/definitions/QOSData"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "schemaVersion",
+                    "type",
+                    "data"
+                  ]
+                },
+                "WAN": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "ENTERPRISE",
+                        "OPERATOR",
+                        "GATEWAY"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/definitions/WAN_data"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "schemaVersion",
+                    "type",
+                    "data"
+                  ]
+                },
+                "controlPlane": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "ENTERPRISE",
+                        "OPERATOR",
+                        "GATEWAY"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/definitions/control_plane_data"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "schemaVersion",
+                    "type",
+                    "data"
+                  ]
+                },
+                "managementPlane": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "ENTERPRISE",
+                        "OPERATOR",
+                        "GATEWAY"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/definitions/management_plane_data"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "schemaVersion",
+                    "type",
+                    "data"
+                  ]
+                },
+                "imageUpdate": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    },
+                    "schemaVersion": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "ENTERPRISE",
+                        "OPERATOR",
+                        "GATEWAY"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/definitions/image_update_data"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "schemaVersion",
+                    "type",
+                    "data"
+                  ]
+                }
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/getEdgeConfigurationStack": {
+      "post": {
+        "summary": "Get Edge configuration stack",
+        "description": "Gets the complete configuration profile (including all modules) of the specified Edge (by `edgeId`).\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`READ` `ENTERPRISE_PROFILE`",
+        "operationId": "edge_get_edge_configuration_stack",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_get_edge_configuration_stack",
+              "properties": {
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "edgeId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "edge_get_edge_configuration_stack_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/edge_get_edge_configuration_stack_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/setEdgeEnterpriseConfiguration": {
+      "post": {
+        "summary": "Apply configuration profile to Edge",
+        "tags": [
+          "all",
+          "edge"
+        ],
+        "description": "Sets the enterprise configuration for the specified Edge (by `edgeId`).\n\nPrivileges required:\n\n`UPDATE` `EDGE`\n\n`UPDATE` `ENTERPRISE_PROFILE`",
+        "operationId": "edge_set_edge_enterprise_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "EDGE"
+            },
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_set_edge_enterprise_configuration",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "alias for edgeId"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "configurationId": {
+                  "type": "integer"
+                },
+                "skipEdgeRoutingUpdates": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "configurationId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/edge_set_edge_enterprise_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/setEdgeHandOffGateways": {
+      "post": {
+        "summary": "Set Edge on premise hand-off gateway(s)",
+        "description": "Sets the on-premise hand off gateways for the specified Edge (by `edgeId`). A primary and secondary gateway are defined. The primary is required, the secondary is optional. Moves all existing Edge-gateway hand-off relationships and replaces them with the specified primary and secondary gateways.\n\nPrivileges required:\n\n`UPDATE` `EDGE`",
+        "tags": [
+          "all",
+          "edge"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "operationId": "edge_set_edge_hand_off_gateways",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_set_edge_hand_off_gateways",
+              "properties": {
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "gateways": {
+                  "type": "object",
+                  "properties": {
+                    "primary": {
+                      "type": "integer"
+                    },
+                    "primaryIpsecDetail": {
+                      "$ref": "#/definitions/gateway_handoff_ipsec_gateway_detail"
+                    },
+                    "secondary": {
+                      "type": "integer"
+                    },
+                    "secondaryIpsecDetail": {
+                      "$ref": "#/definitions/gateway_handoff_ipsec_gateway_detail"
+                    }
+                  },
+                  "required": [
+                    "primary"
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/edge_set_edge_hand_off_gateways_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/setEdgeOperatorConfiguration": {
+      "post": {
+        "summary": "Apply operator profile to Edge",
+        "tags": [
+          "all",
+          "edge"
+        ],
+        "description": "Sets the operator configuration for the specified Edge (by `edgeId`). This overrides any enterprise-assigned operator configuration and the network default operator configuration.\n\nPrivileges required:\n\n`UPDATE` `EDGE`\n\n`READ` `OPERATOR_PROFILE`",
+        "operationId": "edge_set_edge_operator_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "EDGE"
+            },
+            {
+              "action": "READ",
+              "object": "OPERATOR_PROFILE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_set_edge_operator_configuration",
+              "properties": {
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "configurationId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "edgeId",
+                "configurationId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/edge_set_edge_operator_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/updateEdgeAdminPassword": {
+      "post": {
+        "summary": "Update Edge local UI authentication credentials",
+        "description": "Requests an update to the Edge's local UI authentication credentials. On success, returns a JSON object with the ID of the action queued, the status of which can be queried using the `edgeAction/getEdgeAction` API.\n\nPrivileges required:\n\n`UPDATE` `EDGE`\n\n`UPDATE` `ENTERPRISE_KEYS`",
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "operationId": "edge_update_edge_admin_password",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "EDGE"
+            },
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_KEYS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_update_edge_admin_password",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "password"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/edge_update_edge_admin_password_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/updateEdgeAttributes": {
+      "post": {
+        "summary": "Update Edge attributes",
+        "description": "Updates basic attributes (including Edge name, description, site information, and serial number) for the specified Edge. Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `EDGE`",
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "operationId": "edge_update_edge_attributes",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_update_edge_attributes",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "_update": {
+                  "type": "object",
+                  "properties": {
+                    "site": {
+                      "$ref": "#/definitions/site"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "serialNumber": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "_update"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/edge_update_edge_attributes_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/edge/updateEdgeCredentialsByConfiguration": {
+      "post": {
+        "summary": "Update Edge local UI credentials by configuration profile",
+        "tags": [
+          "edge",
+          "all"
+        ],
+        "description": "Requests an update to the Edge-local UI authentication credentials for all Edges belonging to the specified configuration profile. On success, returns a JSON object containing a list of each of the action IDs queued.\n\nPrivileges required:\n\n`UPDATE` `EDGE`\n\n`UPDATE` `ENTERPRISE_KEYS`",
+        "operationId": "edge_update_edge_credentials_by_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "EDGE"
+            },
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_KEYS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "edge_update_edge_credentials_by_configuration",
+              "properties": {
+                "configurationId": {
+                  "type": "integer"
+                },
+                "credentials": {
+                  "type": "object",
+                  "properties": {
+                    "username": {
+                      "type": "string"
+                    },
+                    "password": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "credentials"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/edge_update_edge_credentials_by_configuration_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/decodeEnterpriseKey": {
+      "post": {
+        "summary": "Decrypt an enterprise key",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "description": "Decrypt an enterprise key\n\nPrivileges required:\n\n`READ` `ENTERPRISE_KEYS`",
+        "operationId": "enterprise_decode_enterprise_key",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_KEYS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_decode_enterprise_key",
+              "properties": {
+                "key": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_decode_enterprise_key_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/deleteEnterprise": {
+      "post": {
+        "summary": "Delete enterprise",
+        "description": "Deletes the specified enterprise (by `id` or `enterpriseId`).\n\nPrivileges required:\n\n`DELETE` `ENTERPRISE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "enterprise_delete_enterprise",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_delete_enterprise",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_delete_enterprise_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/deleteEnterpriseGatewayRecords": {
+      "post": {
+        "summary": "Delete gateway BGP neighbor record(s) for enterprise",
+        "description": "Deletes the enterprise gateway BGP neighbor record(s) matching the specified gateway id(s) (`gatewayId`) and neighbor IP addresses (`neighborIp`).\n\nPrivileges required:\n\n`DELETE` `NETWORK_SERVICE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "NETWORK_SERVICE"
+            }
+          ]
+        },
+        "operationId": "enterprise_delete_enterprise_gateway_records",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_delete_enterprise_gateway_records",
+              "properties": {
+                "records": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/enterprise_delete_enterprise_delete_enterprise_gateway_records_record"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_delete_enterprise_gateway_records_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/deleteEnterpriseNetworkAllocation": {
+      "post": {
+        "summary": "Delete enterprise network allocation",
+        "description": "Deletes the specified enterprise network allocation (by `id`).\n\nPrivileges required:\n\n`DELETE` `NETWORK_ALLOCATION`",
+        "operationId": "enterprise_delete_enterprise_network_allocation",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_delete_enterprise_network_allocation",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_delete_enterprise_network_allocation_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/deleteEnterpriseNetworkSegment": {
+      "post": {
+        "summary": "Delete an enterprise network segment",
+        "description": "Delete an enterprise network segment, by id.\n\nPrivileges required:\n\n`DELETE` `NETWORK_ALLOCATION`",
+        "operationId": "enterprise_delete_enterprise_network_segment",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_delete_enterprise_network_segment",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/deletion_confirmation"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/deleteEnterpriseService": {
+      "post": {
+        "summary": "Delete enterprise network service",
+        "description": "Deletes the specified enterprise network service (by `id`).\n\nPrivileges required:\n\n`DELETE` `NETWORK_SERVICE`",
+        "operationId": "enterprise_delete_enterprise_service",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "NETWORK_SERVICE"
+            }
+          ]
+        },
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_delete_enterprise_service",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "logicalId": {
+                  "type": "string"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_delete_enterprise_service_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/encodeEnterpriseKey": {
+      "post": {
+        "summary": "Encrypt an enterprise key",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "description": "Encrypt an enterprise key\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE_KEYS`",
+        "operationId": "enterprise_encode_enterprise_key",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE_KEYS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_encode_enterprise_key",
+              "properties": {
+                "key": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_encode_enterprise_key_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterprise": {
+      "post": {
+        "summary": "Get enterprise",
+        "description": "Gets data for the specified enterprise with optional proxy (partner) detail.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "operationId": "enterprise_get_enterprise",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "title": "enterprise_get_enterprise",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "enterpriseProxy"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseAddresses": {
+      "post": {
+        "summary": "Get enterprise IP address(es)",
+        "description": "Gets all public IP address information for the management and control entities associated with the specified enterprise, including Orchestrator(s), Gateway(s), and datacenter(s).\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "operationId": "enterprise_get_enterprise_addresses",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_addresses",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enterpriseId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_get_enterprise_addresses_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_get_enterprise_addresses_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseAlertConfigurations": {
+      "post": {
+        "summary": "Get enterprise alert configuration(s)",
+        "description": "Gets all alert configuration(s) for the specified enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_ALERT`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_ALERT"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_alert_configurations",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_alert_configurations",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_get_enterprise_alert_configurations_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_get_enterprise_alert_configurations_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseAlerts": {
+      "post": {
+        "summary": "Get triggered enterprise alerts",
+        "description": "Gets past triggered alerts for the specified enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_ALERT`",
+        "operationId": "enterprise_get_enterprise_alerts",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_ALERT"
+            }
+          ]
+        },
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_alerts",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "limit": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "notifications"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "enterpriseId",
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_get_enterprise_alerts_result",
+              "type": "object",
+              "properties": {
+                "metaData": {
+                  "$ref": "#/definitions/list_metadata"
+                },
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/enterprise_get_enterprise_alerts_result_item"
+                  }
+                }
+              },
+              "required": [
+                "metaData",
+                "data"
+              ]
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseAllAlertsRecipients": {
+      "post": {
+        "summary": "Get recipients receiving all enterprise alerts",
+        "description": "Gets all recipients configured to receive all alerts for the specified enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_ALERT`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_ALERT"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_all_alert_recipients",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_all_alert_recipients",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_all_alert_recipients_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseCapabilities": {
+      "post": {
+        "summary": "Get enterprise capabilities",
+        "description": "Gets all enterprise capabilities (e.g. BGP, COS mapping, PKI, etc.) currently enabled/disabled for the specified enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_capabilities",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_capabilities",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_capabilities_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseConfigurations": {
+      "post": {
+        "summary": "Get enterprise configuration profiles",
+        "description": "Gets all configuration profiles, with optional Edge and/or module details, for the specified enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_PROFILE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "operationId": "enterprise_get_enterprise_configurations",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_configurations",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "configurationType": {
+                  "type": "string",
+                  "enum": [
+                    "NETWORK_BASED",
+                    "SEGMENT_BASED"
+                  ]
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "edges",
+                      "modules",
+                      "edgeCount",
+                      "refs",
+                      "deviceSettings"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "enterpriseId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_get_enterprise_configurations_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_get_enterprise_configurations_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseEdges": {
+      "post": {
+        "summary": "Get enterprise Edges",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "description": "Gets all Edges associated with the specified enterprise, including optional site, link, and configuration details.\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "operationId": "enterprise_get_enterprise_edges",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_edges",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "site",
+                      "links",
+                      "recentLinks",
+                      "configuration",
+                      "cloudServices",
+                      "cloudServiceSiteStatus",
+                      "vnfs",
+                      "certificates",
+                      "licenses"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_get_enterprise_edges_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_get_enterprise_edges_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseGatewayHandoff": {
+      "post": {
+        "summary": "Get enterprise gateway handoff configuration",
+        "description": "Gets the gateway handoff configuration for the specified enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER",
+            "ENTERPRISE_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_gateway_handoff",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "title": "enterprise_get_enterprise_gateway_handoff",
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enterpriseId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_gateway_handoff_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseMaximumSegments": {
+      "post": {
+        "summary": "Get enterprise maximum segment",
+        "description": "Gets maximum segments for the specified enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_maximum_segments",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_maximum_segments",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_property_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseNetworkAllocation": {
+      "post": {
+        "summary": "Get enterprise network allocation",
+        "description": "Gets the specified network allocation object (by `id`) for the specified enterprise.\n\nPrivileges required:\n\n`READ` `NETWORK_ALLOCATION`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_network_allocation",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_network_allocation",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "edges",
+                      "edgeCount",
+                      "profileCount"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_network_allocation_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseNetworkAllocations": {
+      "post": {
+        "summary": "Get enterprise network allocations",
+        "description": "Gets all network allocations for the specified enterprise.\n\nPrivileges required:\n\n`READ` `NETWORK_ALLOCATION`",
+        "operationId": "enterprise_get_enterprise_network_allocations",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_network_allocations",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "edges",
+                      "edgeCount",
+                      "profileCount"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_get_enterprise_network_allocations_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_get_enterprise_network_allocations_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseNetworkSegments": {
+      "post": {
+        "summary": "Get all network segment objects defined on an enterprise",
+        "description": "Retrieve a list of all of the network segments defined forthe given enterprise.\n\nPrivileges required:\n\n`READ` `NETWORK_ALLOCATION`",
+        "operationId": "enterprise_get_enterprise_network_segments",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_network_segments",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "profileCount",
+                      "edgeUsage",
+                      "configuration",
+                      "handoffUsage",
+                      "mpgUsage"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_get_enterprise_network_segments_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_get_enterprise_network_segments_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseProperty": {
+      "post": {
+        "summary": "Get enterprise property",
+        "description": "Get a enterprise property by object id or other attribute.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "operationId": "enterprise_get_enterprise_property",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_property",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_property_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseRouteConfiguration": {
+      "post": {
+        "summary": "Get enterprise global routing preferences",
+        "description": "Gets all global routing preferences for the specified enterprise, incuding enterprise route advertisement, routing preferences, OSPF, and BGP advertisement policy.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_PROFILE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_route_configuration",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "title": "enterprise_get_enterprise_route_configuration",
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_route_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseRouteTable": {
+      "post": {
+        "summary": "Get enterprise route table",
+        "description": "Gets the composite enterprise route table, optionally scoped by profile(s). The returned routes include static routes, directly connected routes, and learned routes.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_PROFILE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_route_table",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_route_table",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "profiles": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "subnets": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "subnet": {
+                        "type": "string"
+                      },
+                      "preferredExits": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/enterprise_route"
+                        }
+                      },
+                      "eligableExits": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/enterprise_route"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_get_enterprise_route_table_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseServices": {
+      "post": {
+        "summary": "Get enterprise network services",
+        "description": "Gets all network service JSON objects defined for the specified enterprise.\n\nPrivileges required:\n\n`READ` `NETWORK_SERVICE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "NETWORK_SERVICE"
+            }
+          ]
+        },
+        "operationId": "enterprise_get_enterprise_services",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_services",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "profileCount",
+                      "edgeUsage",
+                      "configuration",
+                      "groupCount"
+                    ]
+                  }
+                },
+                "name": {
+                  "type": "string"
+                },
+                "includePartnerGateways": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_get_enterprise_services_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_get_enterprise_services_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseUsers": {
+      "post": {
+        "tags": [
+          "userMaintenance",
+          "all"
+        ],
+        "summary": "Get enterprise users",
+        "description": "Gets all enterprise users for the specified enterprise (by `enterpriseId`).\n\nPrivileges required:\n\n`READ` `ENTERPRISE`\n\n`READ` `ENTERPRISE_USER`",
+        "operationId": "enterprise_get_enterprise_users",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            },
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_get_enterprise_users",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_get_enterprise_users_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertEnterprise": {
+      "post": {
+        "summary": "Create enterprise",
+        "description": "Creates a new enterprise, which is owned by the operator.\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "operationId": "enterprise_insert_enterprise",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_enterprise"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_enterprise_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertEnterpriseNetworkAllocation": {
+      "post": {
+        "summary": "Create enterprise network allocation",
+        "description": "Creates a new network allocation for the specified enterprise.\n\nPrivileges required:\n\n`CREATE` `NETWORK_ALLOCATION`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "operationId": "enterprise_insert_enterprise_network_allocation",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_insert_enterprise_network_allocation",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "spaces": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/enterprise_network_space"
+                      }
+                    }
+                  }
+                }
+              },
+              "required": [
+                "name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_enterprise_network_allocation_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertEnterpriseNetworkSegment": {
+      "post": {
+        "summary": "Create enterprise network segment",
+        "description": "Creates a new network segment for the specified enterprise.\n\nPrivileges required:\n\n`CREATE` `NETWORK_ALLOCATION`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "operationId": "enterprise_insert_enterprise_network_segment",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_insert_enterprise_network_segment",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "REGULAR",
+                    "CDE"
+                  ]
+                },
+                "data": {
+                  "$ref": "#/definitions/network_segment_data"
+                }
+              },
+              "required": [
+                "name",
+                "type",
+                "data"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_enterprise_network_segment_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertEnterpriseService": {
+      "post": {
+        "summary": "Create enterprise service",
+        "description": "Creates a new enterprise service for the specified enterprise.\n\nPrivileges required:\n\n`CREATE` `NETWORK_SERVICE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "NETWORK_SERVICE"
+            }
+          ]
+        },
+        "operationId": "enterprise_insert_enterprise_service",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_insert_enterprise_service",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "object"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "parentGroupId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "type",
+                "name",
+                "data"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_enterprise_service_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertEnterpriseUser": {
+      "post": {
+        "summary": "Create enterprise user",
+        "description": "Creates a new enterprise user.\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE_USER`",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE_USER"
+            }
+          ]
+        },
+        "tags": [
+          "userMaintenance",
+          "all"
+        ],
+        "operationId": "enterprise_insert_enterprise_user",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/new_enterprise_user"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_enterprise_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertOrUpdateEnterpriseAlertConfigurations": {
+      "post": {
+        "summary": "Create, update, or delete enterprise alert configurations",
+        "description": "Creates, updates, or deletes alert configurations for the specified enterprise. Returns the array of alert configurations submitted, with ids added for the entries that have been successfully created. If an entry is not successfully created or updated, an `error` property is included in the response.\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE_ALERT`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE_ALERT"
+            }
+          ]
+        },
+        "operationId": "enterprise_insert_or_update_enterprise_alert_configurations",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_insert_or_update_enterprise_alert_configurations",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "enterpriseAlertConfigurations": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/enterprise_alert_configuration"
+                  }
+                }
+              },
+              "required": [
+                "enterpriseAlertConfigurations"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_or_update_enterprise_alert_configurations_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertOrUpdateEnterpriseCapability": {
+      "post": {
+        "summary": "Create or update enterprise capability",
+        "description": "Creates or updates the specified capability (`name`, `value`) for the specified enterprise (by `enterpriseId`).\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "enterprise_insert_or_update_enterprise_capability",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_insert_or_update_enterprise_capability",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string",
+                  "enum": [
+                    "enableOSPF",
+                    "enableBGP",
+                    "enableNAT",
+                    "enablePKI",
+                    "enableFwLogs",
+                    "enableStatefulFirewall",
+                    "enableVQM",
+                    "enableServiceRateLimiting",
+                    "enableCosMapping",
+                    "enableSegmentation",
+                    "enableNetworks",
+                    "enableEnterpriseAuth",
+                    "enablePremium",
+                    "edgeVnfs.enable",
+                    "edgeVnfs.securityVnf.paloAlto",
+                    "edgeVnfs.securityVnf.checkPoint",
+                    "edgeVnfs.securityVnf.fortinet",
+                    "edgeVnfs.securityVnf.centOS"
+                  ]
+                },
+                "value": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "value"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_or_update_enterprise_capability_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertOrUpdateEnterpriseGatewayHandoff": {
+      "post": {
+        "summary": "Create or update enterprise gateway handoff configuration",
+        "description": "Creates or updates a gateway handoff configuration for the specified enterprise (by `enterpriseId`).\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE`\n\n`UPDATE` `GATEWAY`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE"
+            },
+            {
+              "action": "UPDATE",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "operationId": "enterprise_insert_or_update_enterprise_gateway_handoff",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_or_update_enterprise_gateway_handoff"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_or_update_enterprise_gateway_handoff_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/insertOrUpdateEnterpriseProperty": {
+      "post": {
+        "summary": "Insert or update an enterprise property",
+        "description": "Insert a enterprise property. If property with the given name already exists, the property will be updated.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE`",
+        "operationId": "enterprise_insert_or_update_enterprise_property",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_insert_or_update_enterprise_property",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                },
+                "dataType": {
+                  "type": "string",
+                  "enum": [
+                    "STRING",
+                    "NUMBER",
+                    "BOOLEAN",
+                    "JSON",
+                    "DATE",
+                    "DATETIME"
+                  ]
+                },
+                "isPassword": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enterpriseId",
+                "name",
+                "value"
+              ],
+              "example": {
+                "enterpriseId": 1532,
+                "name": "vco.enterprise.authentication.twoFactor.enable",
+                "dataType": "BOOLEAN",
+                "value": "true"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_insert_or_update_enterprise_property_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/setEnterpriseAllAlertsRecipients": {
+      "post": {
+        "summary": "Specify recipients for all enterprise alerts",
+        "description": "Specifies the recipients who should receive all alerts for the specified enterprise.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_ALERT`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_ALERT"
+            }
+          ]
+        },
+        "operationId": "enterprise_set_enterprise_all_alert_recipients",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_set_enterprise_all_alert_recipients",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "enterpriseUsers": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "enterpriseUserId": {
+                        "type": "integer"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "smsEnabled": {
+                        "type": "boolean"
+                      },
+                      "emailEnabled": {
+                        "type": "boolean"
+                      },
+                      "mobileEnabled": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                },
+                "smsEnabled": {
+                  "type": "boolean"
+                },
+                "smsList": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "username": {
+                        "type": "string"
+                      },
+                      "mobilePhone": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "emailEnabled": {
+                  "type": "boolean"
+                },
+                "emailList": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "mobileEnabled": {
+                  "type": "boolean"
+                },
+                "mobileList": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_set_enterprise_all_alert_recipients_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/setEnterpriseMaximumSegments": {
+      "post": {
+        "summary": "Set enterprise maximum segments",
+        "description": "Set maximum segments for the specified enterprise (by `enterpriseId`).\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "enterprise_set_enterprise_maximum_segments",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "title": "enterprise_set_enterprise_maximum_segments",
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "value": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_set_enterprise_maximum_segments_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/setEnterpriseOperatorConfiguration": {
+      "post": {
+        "summary": "Apply operator profile to given enterprise",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "description": "Sets the operator configuration for the specified enterprise (by `enterpriseId`). This overrides any network-assigned operator configuration and the network default operator configuration.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE`",
+        "operationId": "enterprise_set_enterprise_operator_configuration",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_set_enterprise_operator_configuration",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "configurationId": {
+                  "type": "integer"
+                },
+                "networkId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "enterpriseId",
+                "configurationId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_set_enterprise_operator_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/updateEnterprise": {
+      "post": {
+        "summary": "Update enterprise",
+        "description": "Updates the specified enterprise (by `enterpriseId` or `name`). Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "operationId": "enterprise_update_enterprise",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "title": "enterprise_update_enterprise",
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "_update": {
+                  "$ref": "#/definitions/enterprise_update_enterprise"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_update_enterprise_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/updateEnterpriseNetworkAllocation": {
+      "post": {
+        "summary": "Update enterprise network allocation",
+        "description": "Updates the specified enterprise network allocation (by `id`). Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `NETWORK_ALLOCATION`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "operationId": "enterprise_update_enterprise_network_allocation",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_update_enterprise_network_allocation",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "_update": {
+                  "type": "object",
+                  "properties": {
+                    "enterpriseId": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "spaces": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/enterprise_network_space"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_update_enterprise_network_allocation_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/updateEnterpriseNetworkSegment": {
+      "post": {
+        "summary": "Update an enterprise network segment",
+        "description": "Update an enterprise network segment.\n\nPrivileges required:\n\n`UPDATE` `NETWORK_ALLOCATION`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "operationId": "enterprise_update_enterprise_network_segment",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "NETWORK_ALLOCATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_update_enterprise_network_segment",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "_update": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "REGULAR",
+                        "CDE"
+                      ]
+                    },
+                    "data": {
+                      "$ref": "#/definitions/network_segment_data"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_update_enterprise_network_segment_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/updateEnterpriseRoute": {
+      "post": {
+        "summary": "Update preferred VPN exits for a route",
+        "description": "Updates the specified enterprise route, set advertisement, and cost values. Required parameters include the original route, as returned by `enterprise/getEnterpriseRouteTable`, and the updated route with modified advertisement and route preference ordering.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_PROFILE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "operationId": "enterprise_update_enterprise_route",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_update_enterprise_route",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "original": {
+                  "$ref": "#/definitions/enterprise_route_collection"
+                },
+                "updated": {
+                  "$ref": "#/definitions/enterprise_route_collection"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_update_enterprise_route_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/updateEnterpriseRouteConfiguration": {
+      "post": {
+        "summary": "Update enterprise global routing preferences",
+        "description": "Updates the specified enterprise global routing preferences as specified by configuration `id` or logicalId.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_PROFILE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "operationId": "enterprise_update_enterprise_route_configuration",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_update_enterprise_route_configuration",
+              "required": [
+                "data"
+              ],
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "data": {
+                  "type": "object",
+                  "required": [
+                    "edge",
+                    "hub",
+                    "partnerGateway",
+                    "routingPreference"
+                  ],
+                  "properties": {
+                    "edge": {
+                      "type": "object",
+                      "required": [
+                        "ospf",
+                        "bgp",
+                        "assigned"
+                      ],
+                      "properties": {
+                        "ospf": {
+                          "type": "object",
+                          "required": [
+                            "advertiseExternal",
+                            "advertiseInterArea",
+                            "advertiseIntraArea"
+                          ],
+                          "properties": {
+                            "advertiseExternal": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "advertiseInterArea": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "advertiseIntraArea": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          }
+                        },
+                        "bgp": {
+                          "type": "object",
+                          "required": [
+                            "advertiseInternal",
+                            "advertiseExternal",
+                            "advertiseNeighborTags"
+                          ],
+                          "properties": {
+                            "advertiseInternal": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "advertiseExternal": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "advertiseNeighborTags": {
+                              "type": "object",
+                              "required": [
+                                "UPLINK"
+                              ],
+                              "properties": {
+                                "UPLINK": {
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "assigned": {
+                          "type": "object",
+                          "required": [
+                            "advertiseStatic",
+                            "advertiseConnected"
+                          ],
+                          "properties": {
+                            "advertiseStatic": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "advertiseConnected": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hub": {
+                      "type": "object",
+                      "required": [
+                        "ospf",
+                        "bgp",
+                        "assigned"
+                      ],
+                      "properties": {
+                        "ospf": {
+                          "type": "object",
+                          "required": [
+                            "advertiseExternal",
+                            "advertiseInterArea",
+                            "advertiseIntraArea"
+                          ],
+                          "properties": {
+                            "advertiseExternal": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "advertiseInterArea": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "advertiseIntraArea": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          }
+                        },
+                        "bgp": {
+                          "type": "object",
+                          "required": [
+                            "advertiseInternal",
+                            "advertiseExternal",
+                            "advertiseNeighborTags"
+                          ],
+                          "properties": {
+                            "advertiseInternal": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "advertiseExternal": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "advertiseNeighborTags": {
+                              "type": "object",
+                              "required": [
+                                "UPLINK"
+                              ],
+                              "properties": {
+                                "UPLINK": {
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "assigned": {
+                          "type": "object",
+                          "required": [
+                            "advertiseStatic",
+                            "advertiseConnected"
+                          ],
+                          "properties": {
+                            "advertiseStatic": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "advertiseConnected": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "partnerGateway": {
+                      "type": "object",
+                      "required": [
+                        "bgp",
+                        "assigned"
+                      ],
+                      "properties": {
+                        "bgp": {
+                          "type": "object",
+                          "required": [
+                            "advertiseExternal"
+                          ],
+                          "properties": {
+                            "advertiseExternal": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          }
+                        },
+                        "assigned": {
+                          "type": "object",
+                          "required": [
+                            "advertiseStatic"
+                          ],
+                          "properties": {
+                            "advertiseStatic": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "routingPreference": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "entity",
+                          "allow"
+                        ],
+                        "properties": {
+                          "entity": {
+                            "type": "string",
+                            "enum": [
+                              "EDGE",
+                              "HUB",
+                              "ROUTER",
+                              "PARTNER"
+                            ]
+                          },
+                          "allow": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_update_enterprise_route_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/updateEnterpriseSecurityPolicy": {
+      "post": {
+        "summary": "Update enterprise security policy",
+        "description": "Updates the security policy for the specified enterprise (by `enterpriseId`) using the passed in `ipsec` settings.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_PROFILE`",
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_PROFILE"
+            }
+          ]
+        },
+        "operationId": "enterprise_update_enterprise_security_policy",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_update_enterprise_security_policy",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "ipsec": {
+                  "type": "object",
+                  "properties": {
+                    "hash": {
+                      "type": "string",
+                      "enum": [
+                        "MD5",
+                        "SHA_1",
+                        "SHA_256"
+                      ]
+                    },
+                    "encryption": {
+                      "type": "string",
+                      "enum": [
+                        "AES_128_CBC",
+                        "AES_256_CBC"
+                      ]
+                    },
+                    "diffieHellmanGroup": {
+                      "type": "string",
+                      "enum": [
+                        "GROUP_2",
+                        "GROUP_5",
+                        "GROUP_14"
+                      ]
+                    },
+                    "perfectForwardSecrecy": {
+                      "type": "string",
+                      "enum": [
+                        "DISABLED",
+                        "GROUP_2",
+                        "GROUP_5"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_update_enterprise_security_policy_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/updateEnterpriseService": {
+      "post": {
+        "summary": "Update enterprise network service",
+        "description": "Updates the enterprise service for the specified enterprise (by `id` or `enterpriseId`). Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `NETWORK_SERVICE`",
+        "tags": [
+          "all",
+          "enterprise"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "NETWORK_SERVICE"
+            }
+          ]
+        },
+        "operationId": "enterprise_update_enterprise_service",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_update_enterprise_service",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "_update": {
+                  "type": "object",
+                  "properties": {
+                    "operatorAlertsEnabled": {
+                      "type": "integer"
+                    },
+                    "alertsEnabled": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "_update"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_update_enterprise_service_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/deleteEnterpriseProxyUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Delete partner admin user",
+        "description": "Deletes the specified enterprise proxy user (by `id` or `username`). Note: `enterpriseProxyId` is a required parameter when invoking this method as an operator or as a partner user.\n\nPrivileges required:\n\n`DELETE` `PROXY_USER`",
+        "operationId": "enterprise_proxy_delete_enterprise_proxy_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "PROXY_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_delete_enterprise_proxy_user",
+              "properties": {
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_proxy_delete_enterprise_proxy_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/getEnterpriseProxyEdgeInventory": {
+      "post": {
+        "summary": "Get partner enterprises and associated Edge inventory",
+        "description": "Gets all partner enterprises and their associated Edge inventory.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "tags": [
+          "all",
+          "enterpriseProxy"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "enterprise_proxy_get_enterprise_proxy_edge_inventory",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_get_enterprise_proxy_edge_inventory",
+              "properties": {
+                "enterpriseProxyId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "enterprise_proxy_get_enterprise_proxy_edge_inventory_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_proxy_get_enterprise_proxy_edge_inventory_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/getEnterpriseProxyEnterprises": {
+      "post": {
+        "summary": "Get partner enterprises",
+        "description": "Gets all partner enterprises. Optionally includes all Edges or Edge counts.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "tags": [
+          "all",
+          "enterpriseProxy"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "enterprise_proxy_get_enterprise_proxy_enterprises",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_get_enterprise_proxy_enterprises",
+              "properties": {
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "edges",
+                      "edgeCount"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "enterprise_proxy_get_enterprise_proxy_enterprises_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_proxy_get_enterprise_proxy_enterprises_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/getEnterpriseProxyGatewayPools": {
+      "post": {
+        "summary": "Get gateway pools",
+        "tags": [
+          "all",
+          "enterpriseProxy"
+        ],
+        "description": "Gets all gateway pools associated with the specified enterprise proxy. Optionally includes all gateways or enterprises belonging to each pool.\n\nPrivileges required:\n\n`READ` `GATEWAY`",
+        "operationId": "enterprise_proxy_get_enterprise_proxy_gateway_pools",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_get_enterprise_proxy_gateway_pools",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "gateways",
+                      "enterprises"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "enterprise_proxy_get_enterprise_proxy_gateway_pools_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_proxy_get_enterprise_proxy_gateway_pools_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/getEnterpriseProxyGateways": {
+      "post": {
+        "summary": "Get gateways for enterprise proxy",
+        "description": "Gets all gateways associated with the specified enterprise proxy.\n\nPrivileges required:\n\n`READ` `GATEWAY`",
+        "tags": [
+          "enterpriseProxy",
+          "all"
+        ],
+        "operationId": "enterprise_proxy_get_enterprise_proxy_gateways",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_get_enterprise_proxy_gateways",
+              "properties": {
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "site",
+                      "roles",
+                      "pools",
+                      "dataCenters",
+                      "certificates",
+                      "enterprises",
+                      "handOffEdges",
+                      "enterpriseAssociations",
+                      "enterpriseAssociationCounts"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "enterprise_proxy_get_enterprise_proxy_gateways_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_proxy_get_enterprise_proxy_gateways_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/getEnterpriseProxyOperatorProfiles": {
+      "post": {
+        "summary": "Get partner operator profiles",
+        "description": "Gets all operator profiles associated with the specified partner (MSP), as assigned by the operator.\n\nPrivileges required:\n\n`READ` `OPERATOR_PROFILE`",
+        "tags": [
+          "all",
+          "enterpriseProxy"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "OPERATOR_PROFILE"
+            }
+          ]
+        },
+        "operationId": "enterprise_proxy_get_enterprise_proxy_operator_profiles",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_get_enterprise_proxy_operator_profiles",
+              "properties": {
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "edges",
+                      "edgeCount",
+                      "modules",
+                      "enterprises"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "enterprise_proxy_get_enterprise_proxy_operator_profiles_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_proxy_get_enterprise_proxy_operator_profiles_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterprise/getEnterpriseProxyProperty": {
+      "post": {
+        "summary": "Get enterprise proxy property",
+        "description": "Get a enterprise proxy property by object id or other attribute.\n\nPrivileges required:\n\n`READ` `PROXY`",
+        "operationId": "enterprise_proxy_get_enterprise_proxy_property",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "PROXY"
+            }
+          ]
+        },
+        "tags": [
+          "enterprise",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_get_enterprise_proxy_property",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_proxy_get_enterprise_proxy_property_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/getEnterpriseProxyUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Get enterprise proxy user",
+        "description": "Gets the specified enterprise proxy user (by `id` or `username`).\n\nPrivileges required:\n\n`READ` `PROXY_USER`\n\n`READ` `PROXY`",
+        "operationId": "enterprise_proxy_get_enterprise_proxy_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "allowPrivilegeToSelf": "MSP_USER",
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "PROXY_USER"
+            },
+            {
+              "action": "READ",
+              "object": "PROXY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_get_enterprise_proxy_user",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_proxy_get_enterprise_proxy_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/getEnterpriseProxyUsers": {
+      "post": {
+        "tags": [
+          "userMaintenance",
+          "all"
+        ],
+        "summary": "Get enterprise proxy admin users",
+        "description": "Gets all proxy admin users for the specified enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`\n\n`READ` `PROXY_USER`",
+        "operationId": "enterprise_proxy_get_enterprise_proxy_users",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            },
+            {
+              "action": "READ",
+              "object": "PROXY_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_get_enterprise_proxy_users",
+              "properties": {
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_proxy_get_enterprise_proxy_users_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/insertEnterpriseProxyEnterprise": {
+      "post": {
+        "summary": "Create enterprise owned by MSP",
+        "description": "Creates a new enterprise owned by an MSP. Whereas the `insertEnterprise` method creates an enterprise in the global or network context with no MSP association, this method creates one owned by an MSP, as determined by the credentials of the caller.\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE`",
+        "tags": [
+          "enterpriseProxy",
+          "all"
+        ],
+        "operationId": "enterprise_proxy_insert_enterprise_proxy_enterprise",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/enterprise_proxy_insert_enterprise_proxy_enterprise"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/enterprise_proxy_insert_enterprise_proxy_enterprise_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/insertEnterpriseProxyUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Create partner admin user",
+        "description": "Creates a new partner admin user.\n\nPrivileges required:\n\n`CREATE` `PROXY_USER`",
+        "operationId": "enterprise_proxy_insert_enterprise_proxy_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "MSP_USER",
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "PROXY_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/new_enterprise_proxy_user"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_proxy_insert_enterprise_proxy_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/insertOrUpdateEnterpriseProxyProperty": {
+      "post": {
+        "summary": "Insert or update an enterprise proxy (MSP) property",
+        "description": "Insert a enterprise proxy property. If property with the given name already exists, the property will be updated.\n\nPrivileges required:\n\n`UPDATE` `PROXY`",
+        "operationId": "enterprise_proxy_insert_or_update_enterprise_proxy_property",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            null
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "PROXY"
+            }
+          ]
+        },
+        "tags": [
+          "enterpriseProxy",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_insert_or_update_enterprise_proxy_property",
+              "properties": {
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                },
+                "dataType": {
+                  "type": "string",
+                  "enum": [
+                    "STRING",
+                    "NUMBER",
+                    "BOOLEAN",
+                    "JSON",
+                    "DATE",
+                    "DATETIME"
+                  ]
+                },
+                "isPassword": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enterpriseProxyId",
+                "name",
+                "value"
+              ],
+              "example": {
+                "enterpriseProxyId": 1532,
+                "name": "vco.enterprise.proxy.authentication.twoFactor.enable",
+                "dataType": "BOOLEAN",
+                "value": "true"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_proxy_insert_or_update_enterprise_proxy_property_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseProxy/updateEnterpriseProxyUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Update enterprise proxy admin user",
+        "description": "Updates the specified enterprise proxy admin user (by object `id` or other identifying attribute). Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `PROXY_USER`",
+        "operationId": "enterprise_proxy_update_enterprise_proxy_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "allowPrivilegeToSelf": "MSP_USER",
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "PROXY_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_proxy_update_enterprise_proxy_user",
+              "properties": {
+                "_update": {
+                  "$ref": "#/definitions/enterprise_user_with_role_info"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "_update"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_proxy_update_enterprise_proxy_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseUser/deleteEnterpriseUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Delete enterprise user",
+        "description": "Deletes the specified enterprise user (by `id` or `username`). Note: `enterpriseId` is a required parameter when invoking this method as an operator or as a partner user.\n\nPrivileges required:\n\n`DELETE` `ENTERPRISE_USER`",
+        "operationId": "enterprise_user_delete_enterprise_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "ENTERPRISE_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_user_delete_enterprise_user",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_user_delete_enterprise_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseUser/getEnterpriseUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Get enterprise user",
+        "description": "Gets the specified enterprise user (by `id` or `username`).\n\nPrivileges required:\n\n`READ` `ENTERPRISE_USER`",
+        "operationId": "enterprise_user_get_enterprise_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "allowPrivilegeToSelf": "ENTERPRISE_USER",
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_user_get_enterprise_user",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_user_get_enterprise_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/enterpriseUser/updateEnterpriseUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Update enterprise user",
+        "description": "Updates the specified enterprise user (by object `id` or other identifying attribute). Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_USER`, or\n\n`UPDATE` `OPERATOR_USER`",
+        "operationId": "enterprise_user_update_enterprise_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "allowPrivilegeToSelf": "ENTERPRISE_USER",
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_USER",
+              "sufficient": true
+            },
+            {
+              "action": "UPDATE",
+              "object": "OPERATOR_USER",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "enterprise_user_update_enterprise_user",
+              "properties": {
+                "_update": {
+                  "$ref": "#/definitions/enterprise_user_update_enterprise_user"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "_update"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/enterprise_user_update_enterprise_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/event/getEnterpriseEvents": {
+      "post": {
+        "summary": "Get Edge events",
+        "description": "Gets Edge events in an enterprise or Edge context. Returns an array of Edge events sorted by `eventTime`..\n\nPrivileges required:\n\n`READ` `ENTERPRISE_EVENT`",
+        "tags": [
+          "event",
+          "all"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_EVENT"
+            }
+          ]
+        },
+        "operationId": "event_get_enterprise_events",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "event_get_enterprise_events",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "filter": {
+                  "title": "filter",
+                  "type": "object",
+                  "properties": {
+                    "limit": {
+                      "type": "integer",
+                      "default": 2048
+                    },
+                    "rules": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "enum": [
+                              "event",
+                              "edgeName",
+                              "user",
+                              "severity",
+                              "message",
+                              "detail",
+                              "segmentName"
+                            ]
+                          },
+                          "op": {
+                            "type": "string",
+                            "enum": [
+                              "is",
+                              "is not",
+                              "startsWith",
+                              "notStartsWith",
+                              "endsWith",
+                              "notEndsWith",
+                              "contains",
+                              "notContains"
+                            ]
+                          },
+                          "values": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "edgeId": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/event_get_enterprise_events_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/event/getOperatorEvents": {
+      "post": {
+        "summary": "Get operator events",
+        "description": "Gets operator events by network ID (optional). If not specified, will be taken for the caller's security context. Optionally, use a filter object to limit the number of events returned. Additionally, specify a time interval with an interval object. If no end date is specified, then the default is the current date. Specify a `gatewayId` to filter events for the specified gateway.\n\nPrivileges required:\n\n`READ` `OPERATOR_EVENT`",
+        "tags": [
+          "event",
+          "all"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "OPERATOR_EVENT"
+            }
+          ]
+        },
+        "operationId": "event_get_operator_events",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "event_get_operator_events",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "filter": {
+                  "title": "filter",
+                  "type": "object",
+                  "properties": {
+                    "limit": {
+                      "type": "integer",
+                      "default": 2048
+                    },
+                    "rules": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "enum": [
+                              "event",
+                              "gatewayName",
+                              "user",
+                              "severity",
+                              "message"
+                            ]
+                          },
+                          "op": {
+                            "type": "string",
+                            "enum": [
+                              "is",
+                              "is not",
+                              "startsWith",
+                              "notStartsWith",
+                              "endsWith",
+                              "notEndsWith",
+                              "contains",
+                              "notContains"
+                            ]
+                          },
+                          "values": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "gatewayId": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/event_get_operator_events_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/event/getProxyEvents": {
+      "post": {
+        "summary": "Fetch Partner events",
+        "description": "Fetch Partner Events by enterprise ID. Optionally, a filter object to specify search criteria and limit on number of records. A time interval could be specified with an interval object. If no end date is given, it will default to the current date. Enterprise ID can be supplied to filter events to those of a specific enterprises.\n\nPrivileges required:\n\n`READ` `PROXY_EVENT`",
+        "tags": [
+          "event",
+          "all"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "MSP_USER",
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "PROXY_EVENT"
+            }
+          ]
+        },
+        "operationId": "event_get_proxy_events",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "event_get_proxy_events",
+              "properties": {
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "filter": {
+                  "title": "filter",
+                  "type": "object",
+                  "properties": {
+                    "limit": {
+                      "type": "integer",
+                      "default": 2048
+                    },
+                    "rules": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string",
+                            "enum": [
+                              "event",
+                              "gatewayName",
+                              "user",
+                              "severity",
+                              "message"
+                            ]
+                          },
+                          "op": {
+                            "type": "string",
+                            "enum": [
+                              "is",
+                              "is not",
+                              "startsWith",
+                              "notStartsWith",
+                              "endsWith",
+                              "notEndsWith",
+                              "contains",
+                              "notContains"
+                            ]
+                          },
+                          "values": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "enterpriseId": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/event_get_proxy_events_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/firewall/getEnterpriseFirewallLogs": {
+      "post": {
+        "summary": "Get enterprise firewall logs",
+        "description": "Gets firewall logs for the specified enterprise.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FIREWALL_LOGS` `undefined`",
+        "tags": [
+          "firewall",
+          "all"
+        ],
+        "operationId": "firewall_get_enterprise_firewall_logs",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FIREWALL_LOGS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "title": "firewall_get_enterprise_firewall_logs",
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "limit": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "rules": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sourceIps": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "destIps": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "edges": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "rules"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/firewall_get_enterprise_firewall_logs_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/gateway/deleteGateway": {
+      "post": {
+        "summary": "Delete a gateway",
+        "description": "Delete a gateway by id.\n\nPrivileges required:\n\n`DELETE` `GATEWAY`",
+        "tags": [
+          "gateway",
+          "all"
+        ],
+        "operationId": "gateway_delete_gateway",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "gateway_delete_gateway",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/gateway_delete_gateway_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/gateway/gatewayProvision": {
+      "post": {
+        "summary": "Provision gateway",
+        "description": "Provisions a gateway into the specified operator network.\n\nPrivileges required:\n\n`CREATE` `GATEWAY`",
+        "tags": [
+          "gateway",
+          "all"
+        ],
+        "operationId": "gateway_gateway_provision",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "gateway_gateway_provision",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                },
+                "ipAddress": {
+                  "type": "string"
+                },
+                "gatewayPoolId": {
+                  "type": "integer"
+                },
+                "dnsName": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "isLoadBalanced": {
+                  "type": "boolean"
+                },
+                "privateIpAddress": {
+                  "type": "string"
+                },
+                "roles": {
+                  "$ref": "#/definitions/gateway_roles_object"
+                },
+                "site": {
+                  "$ref": "#/definitions/site"
+                }
+              },
+              "required": [
+                "networkId",
+                "ipAddress"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/gateway_gateway_provision_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/gateway/getGatewayEdgeAssignments": {
+      "post": {
+        "summary": "Get edge assignments for a gateway",
+        "tags": [
+          "gateway",
+          "all"
+        ],
+        "description": "Get edge assignments for a gateway\n\nPrivileges required:\n\n`READ` `GATEWAY`",
+        "operationId": "gateway_get_gateway_edge_assignments",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "gateway_get_gateway_edge_assignments",
+              "properties": {
+                "gatewayId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "gatewayId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "gateway_get_gateway_edge_assignments_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/gateway_get_gateway_edge_assignments_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/gateway/updateGatewayAttributes": {
+      "post": {
+        "summary": "Update gateway attributes",
+        "description": "Updates gateway attributes (`name`, `ipAddress`, on-premise parametrization, and `description`) and associated site attributes for the specified gateway (by `id`).\n\nPrivileges required:\n\n`UPDATE` `GATEWAY`",
+        "tags": [
+          "gateway",
+          "all"
+        ],
+        "operationId": "gateway_update_gateway_attributes",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "gateway_update_gateway_attributes",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "site": {
+                  "$ref": "#/definitions/site"
+                },
+                "ipsecGatewayDetail": {
+                  "$ref": "#/definitions/gateway_handoff_detail"
+                },
+                "handOffDetail": {
+                  "$ref": "#/definitions/gateway_handoff_detail"
+                },
+                "roles": {
+                  "$ref": "#/definitions/gateway_roles_object"
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/gateway_update_gateway_attributes_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/linkQualityEvent/getLinkQualityEvents": {
+      "post": {
+        "summary": "Get link quality events",
+        "description": "Gets all link quality scores per link for the specified Edge within the specified time interval. Rolls up link quality events to provide an aggregate score for the Edge. Returns an empty array if no link quality events are available in the specified timeframe.\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "tags": [
+          "linkQualityEvent",
+          "all"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "operationId": "link_quality_event_get_link_quality_events",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "link_quality_event_get_link_quality_events",
+              "properties": {
+                "edgeId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "maxSamples": {
+                  "type": "integer"
+                },
+                "individualScores": {
+                  "type": "boolean"
+                },
+                "minutesPerSample": {
+                  "type": "integer"
+                },
+                "debug": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "edgeId",
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/link_quality_event_get_link_quality_events_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeAppLinkMetrics": {
+      "post": {
+        "summary": "Get flow metric aggregate data",
+        "description": "Gets flow metric summaries for the specified time interval by link. On success, this method returns an array of flow data in which each entry corresponds to a link on the specified Edge. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_app_link_metrics",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_app_link_metrics",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                }
+              },
+              "required": [
+                "id",
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_app_link_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_app_link_metrics_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeAppLinkSeries": {
+      "post": {
+        "summary": "Get flow metric time series data",
+        "description": "Gets flow metric time series data for the specified time interval by link. On success, this method returns an array of flow data in which each entry corresponds to a link on the specified Edge. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_app_link_series",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_app_link_series",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "links": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_app_link_series_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_app_link_series_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeAppMetrics": {
+      "post": {
+        "summary": "Get flow metric aggregate data by application",
+        "description": "Gets flow metric summaries for the specified time interval by application. On success, this method returns an array of flow data in which each entry corresponds to a single application. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_app_metrics",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_app_metrics",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "applications": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "category",
+                      "linkId"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_app_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_app_metrics_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeAppSeries": {
+      "post": {
+        "summary": "Get flow metric time series data by application",
+        "description": "Gets flow metric time series data for the specified time interval by application. On success, this method returns an array of flow data in which each entry corresponds to a single application. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_app_series",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_app_series",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "maxSamples": {
+                  "type": "integer"
+                },
+                "applications": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_app_series_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_app_series_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeCategoryMetrics": {
+      "post": {
+        "summary": "Get flow metric aggregate data by application category",
+        "description": "Gets flow metric summaries for the specified time interval by application category. On success, this method returns an array of flow data in which each entry corresponds to a category of application traffic that has traversed the specified Edge. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_category_metrics",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_category_metrics",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_category_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_category_metrics_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeCategorySeries": {
+      "post": {
+        "summary": "Get flow metric time series data by application category",
+        "description": "Gets flow metric time series data for the specified time interval by application category. On success, this method returns an array of flow data in which each entry corresponds to a category of application traffic that has traversed the specified Edge. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_category_series",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_category_series",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "maxSamples": {
+                  "type": "integer"
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_category_series_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_category_series_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeDestMetrics": {
+      "post": {
+        "summary": "Get flow metric aggregate data by destination",
+        "description": "Gets flow metric summaries for the specified time interval by destination. On success, this method returns an array of flow data in which each entry corresponds to a distinct traffic destination. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_dest_metrics",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_dest_metrics",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "attribute": {
+                  "type": "string",
+                  "enum": [
+                    "destDomain",
+                    "destIp",
+                    "destFQDN"
+                  ]
+                },
+                "destinations": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_dest_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_dest_metrics_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeDestSeries": {
+      "post": {
+        "summary": "Get flow metric time series data by destination",
+        "description": "Gets flow metric time series data for the specified time interval by destination. On success, this method returns an array of flow data in which each entry corresponds to a distinct traffic destination. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_dest_series",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_dest_series",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "attribute": {
+                  "type": "string",
+                  "enum": [
+                    "destDomain",
+                    "destIp",
+                    "destFQDN"
+                  ]
+                },
+                "destinations": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_dest_series_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_dest_series_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeDeviceMetrics": {
+      "post": {
+        "summary": "Get flow metric aggregate data by client device",
+        "description": "Gets flow metric summaries for the specified time interval by client device. On success, this method returns an array of flow data in which each entry corresponds to a distinct device. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_USER_IDENTIFIABLE_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_device_metrics",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_USER_IDENTIFIABLE_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_device_metrics",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "devices": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_device_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_device_metrics_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeDeviceSeries": {
+      "post": {
+        "summary": "Get flow metric time series data by client device",
+        "description": "Gets flow metric time series data for the specified time interval by client device. On success, this method returns an array of flow data in which each entry corresponds to a distinct device. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_USER_IDENTIFIABLE_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_device_series",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_USER_IDENTIFIABLE_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_device_series",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "maxSamples": {
+                  "type": "integer"
+                },
+                "devices": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_device_series_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_device_series_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeLinkMetrics": {
+      "post": {
+        "summary": "Get advanced flow metric aggregate data by link",
+        "description": "Gets advanced flow metric summaries for the specified time interval by link. On success, this method returns an array of flow data in which each entry corresponds to a link on the specified Edge. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_link_metrics",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_link_metrics",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/edge_link_metric"
+                  }
+                },
+                "sort": {
+                  "$ref": "#/definitions/edge_link_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "links": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_link_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_link_metrics_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeLinkSeries": {
+      "post": {
+        "summary": "Get advanced flow metric time series data by link",
+        "description": "Gets advanced flow metric time series data for the specified time interval by link. On success, this method returns an array of flow data in which each entry corresponds to a link on the specified Edge. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_link_series",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_link_series",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/edge_link_metric"
+                  }
+                },
+                "sort": {
+                  "$ref": "#/definitions/edge_link_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "links": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_link_series_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_link_series_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeOsMetrics": {
+      "post": {
+        "summary": "Get flow metric aggregate data by client OS",
+        "description": "Gets flow metric summaries for the specified time interval by client OS. On success, this method returns an array of flow data in which each entry corresponds to a distinct OS on a client device. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_os_metrics",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_os_metrics",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "os": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_os_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_os_metrics_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeOsSeries": {
+      "post": {
+        "summary": "Get flow metric time series data by client OS",
+        "description": "Gets flow metric time series data for the specified time interval by client OS. On success, this method returns an array of flow data in which each entry corresponds to a distinct OS on a client device. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_os_series",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_os_series",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "maxSamples": {
+                  "type": "integer"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "os": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_os_series_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_os_series_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeSegmentMetrics": {
+      "post": {
+        "summary": "Get flow metric aggregate data by segment Id",
+        "description": "Gets flow metric summaries for the specified time interval by segment id. On success, this method returns an array of flow data where each entry corresponds to a segment id traffic that has traversed the specified Edge. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_segment_metrics",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_segment_metrics",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "segments": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_segment_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_segment_metrics_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeSegmentSeries": {
+      "post": {
+        "summary": "Get flow metric time series data by segment id",
+        "description": "Gets flow metric time series data for the specified time interval by segment id. On success, this method returns an array of flow data in which each entry corresponds to a segment id of traffic that has traversed the specified Edge. In the request body, the `id` and `edgeId` property names are interchangeable. The `enterpriseId` property is required when this method is invoked in the operator context.\n\nPrivileges required:\n\n`READ` `EDGE`\n\n`VIEW_FLOW_STATS` `undefined`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_segment_series",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            },
+            {
+              "action": "VIEW_FLOW_STATS"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_segment_series",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/basic_metrics"
+                },
+                "sort": {
+                  "$ref": "#/definitions/basic_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "maxSamples": {
+                  "type": "integer"
+                },
+                "segments": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "interval"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "metrics_get_edge_segment_series_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/metrics_get_edge_segment_series_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeStatusMetrics": {
+      "post": {
+        "summary": "Get Edge healthStats metrics for an interval",
+        "description": "Fetch healthStats metric summaries for the given edge, time interval and list of metrics. On success, this method returns anhealthsStats object with min, max and average values of requested metrics\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_status_metrics",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_status_metrics",
+              "properties": {
+                "edgeId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/edge_metrics"
+                }
+              },
+              "required": [
+                "edgeId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/edge_status_metrics_summary"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getEdgeStatusSeries": {
+      "post": {
+        "summary": "Get Edge healthStats time series for an interval ",
+        "description": "Fetch healthStats time series for the given edge, time interval and list of metrics. On success, this method returns anarray of healthsStats series of requested metrics\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_edge_status_series",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_edge_status_series",
+              "properties": {
+                "edgeId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/edge_metrics"
+                }
+              },
+              "required": [
+                "edgeId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/get_edge_status_metrics_time_series_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getGatewayStatusMetrics": {
+      "post": {
+        "summary": "Get Gateway health metric summaries for an interval",
+        "description": "Fetch health metric summaries given a target gateway, time interval and list of metrics. On success, this method returns an object containing min, max and average values of requested metrics\n\nPrivileges required:\n\n`READ` `GATEWAY`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_gateway_status_metrics",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_gateway_status_metrics",
+              "properties": {
+                "gatewayId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/gateway_metrics"
+                }
+              },
+              "required": [
+                "gatewayId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/gateway_status_metrics_summary"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/metrics/getGatewayStatusSeries": {
+      "post": {
+        "summary": "Get Gateway health metric time series for an interval",
+        "description": "Fetch health metric time series given a target gateway, time interval and list of metrics. On success, this method returns an array of time series, one per metric.\n\nPrivileges required:\n\n`READ` `GATEWAY`",
+        "tags": [
+          "all",
+          "metrics"
+        ],
+        "operationId": "metrics_get_gateway_status_series",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "metrics_get_gateway_status_series",
+              "properties": {
+                "gatewayId": {
+                  "type": "integer"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/gateway_metrics"
+                }
+              },
+              "required": [
+                "gatewayId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/get_gateway_status_metrics_time_series_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getAggregateEdgeLinkMetrics": {
+      "post": {
+        "summary": "Get aggregate Edge link metrics across enterprises",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "description": "Gets aggregate link metrics for the request interval for all active links across all enterprises, where a link is considered to be active if an Edge has reported any activity for it in the last 24 hours. On success, returns an array of network utilization metrics, one per link.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`\n\n`READ` `EDGE`",
+        "operationId": "monitoring_get_aggregate_edge_link_metrics",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER",
+            "ENTERPRISE_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            },
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "monitoring_get_aggregate_edge_link_metrics",
+              "properties": {
+                "enterprises": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "metrics": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/edge_link_metric"
+                  }
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "title": "monitoring_get_aggregate_edge_link_metrics_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/monitoring_get_aggregate_edge_link_metrics_result_item"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getAggregateEnterpriseEvents": {
+      "post": {
+        "summary": "Get events across all enterprises",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "description": "Gets events across all enterprises in a paginated list. When called in the MSP/Partner context, queries only enterprises managed by the MSP.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`\n\n`READ` `EDGE`",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            },
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "operationId": "monitoring_get_aggregate_enterprise_events",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "monitoring_get_aggregate_enterprise_events",
+              "properties": {
+                "detail": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "$ref": "#/definitions/interval"
+                },
+                "filter": {
+                  "type": "object",
+                  "required": [
+                    "limit"
+                  ],
+                  "properties": {
+                    "limit": {
+                      "type": "integer",
+                      "default": 2048
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/monitoring_get_aggregate_enterprise_events_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getAggregates": {
+      "post": {
+        "summary": "Get aggregate enterprise and Edge information",
+        "description": "Gets a comprehensive listing of all enterprises and Edges on a network. Returns an object containing an aggregate `edgeCount`, a list (`enterprises`) containing enterprise objects, and a map (`edges`) that provides Edge counts per enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`\n\n`READ` `EDGE`",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "operationId": "monitoring_get_aggregates",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            },
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "monitoring_get_aggregates",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/monitoring_get_aggregates_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getEnterpriseBgpPeerStatus": {
+      "post": {
+        "summary": "Get gateway BGP peer status for all enterprise gateways",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "description": "Gets the gateway BGP peer status for all enterprise gateways. Returns an array in which each entry corresponds to a gateway and contains an associated set of BGP peers with state records.\n\nPrivileges required:\n\n`READ` `NETWORK_SERVICE`",
+        "operationId": "monitoring_get_enterprise_bgp_peer_status",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "NETWORK_SERVICE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "monitoring_get_enterprise_bgp_peer_status_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/monitoring_get_enterprise_bgp_peer_status_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getEnterpriseEdgeBgpPeerStatus": {
+      "post": {
+        "summary": "Get Edge BGP peer status for all enterprise Edges",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "description": "Gets the Edge BGP peer status for all enterprise Edges. Returns an array in which each entry corresponds to an Edge and contains an associated set of BGP peers and state records.\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "operationId": "monitoring_get_enterprise_edge_bgp_peer_status",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "EDGE"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "monitoring_get_enterprise_edge_bgp_peer_status_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/monitoring_get_enterprise_edge_bgp_peer_status_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getEnterpriseEdgeClusterStatus": {
+      "post": {
+        "summary": "Get Edge Cluster status",
+        "description": "Get edge`s utilization data by clusters\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "operationId": "monitoring_get_enterprise_edge_cluster_status",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER",
+            "ENTERPRISE_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "monitoring_get_enterprise_edge_cluster_status",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/edge_metrics"
+                }
+              },
+              "required": [
+                "enterpriseId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "edgeId": {
+                    "type": "integer"
+                  },
+                  "edgeName": {
+                    "type": "string"
+                  },
+                  "tunnelCount": {
+                    "type": "integer"
+                  },
+                  "memoryPct": {
+                    "type": "number"
+                  },
+                  "flowCount": {
+                    "type": "number"
+                  },
+                  "cpuPct": {
+                    "type": "number"
+                  },
+                  "handoffQueueDrops": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getEnterpriseEdgeLinkStatus": {
+      "post": {
+        "summary": "Get Edge and link status data",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "description": "Gets the current Edge and Edge-link status for all enterprises. edges.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`\n\n`READ` `EDGE`",
+        "operationId": "monitoring_get_enterprise_edge_link_status",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            },
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "enterprises": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "networkId": {
+                  "type": "integer"
+                },
+                "links": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/monitoring_get_enterprise_edge_link_status_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getEnterpriseEdgeStatus": {
+      "post": {
+        "summary": "Get Enterprise Edge monitoring status",
+        "description": "Fetch Enterprise Edge monitoring status time series for the given time interval, all for the enterprise or list of edgess, and list of metrics. On success, this method returns anarray of edge monitoring statuses.\n\nPrivileges required:\n\n`READ` `EDGE`",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "operationId": "monitoring_get_enterprise_edge_status",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "EDGE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "monitoring_get_enterprise_edge_status",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "edgeIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "time": {
+                  "$ref": "#/definitions/js_date_formats"
+                },
+                "sort": {
+                  "$ref": "#/definitions/edge_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/edge_metrics"
+                }
+              },
+              "required": [
+                "enterpriseId",
+                "sort"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/monitoring_get_enterprise_edge_status_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/monitoring/getNetworkGatewayStatus": {
+      "post": {
+        "summary": "Get Network Gateway monitoring status",
+        "description": "Fetch Network Gateway monitoring status time series for the given time interval, all for the network or list of gateways, and list of metrics. On success, this method returns anarray of gateway monitoring statuses.\n\nPrivileges required:\n\n`READ` `GATEWAY`",
+        "tags": [
+          "all",
+          "monitoring"
+        ],
+        "operationId": "monitoring_get_network_gateway_status",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "monitoring_get_network_gateway_status",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                },
+                "gatewayIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "time": {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "sort": {
+                  "$ref": "#/definitions/gateway_metric"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "metrics": {
+                  "$ref": "#/definitions/gateway_metrics"
+                }
+              },
+              "required": [
+                "networkId",
+                "sort"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/monitoring_get_network_gateway_status_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/network/deleteNetworkGatewayPool": {
+      "post": {
+        "summary": "Delete gateway pool",
+        "description": "Deletes the specified gateway pool (by `id`).\n\nPrivileges required:\n\n`DELETE` `GATEWAY`",
+        "operationId": "network_delete_network_gateway_pool",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "tags": [
+          "network",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "network_delete_network_gateway_pool",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                },
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "alias for `gatewayPoolId`"
+                },
+                "gatewayPoolId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/network_delete_network_gateway_pool_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/network/getNetworkConfigurations": {
+      "post": {
+        "summary": "Get operator configuration profiles",
+        "tags": [
+          "all",
+          "network"
+        ],
+        "description": "Gets all operator configuration profiles associated with an operator's network. Optionally includes the modules associated with each profile. This call does not return templates.\n\nPrivileges required:\n\n`READ` `OPERATOR_PROFILE`",
+        "operationId": "network_get_network_configurations",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "OPERATOR_PROFILE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "network_get_network_configurations",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "networkId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "modules",
+                      "counts"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "network_get_network_configurations_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/network_get_network_configurations_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/network/getNetworkEnterprises": {
+      "post": {
+        "summary": "Get enterprises on network",
+        "description": "Gets all enterprises existing on a network, optionally including all Edges or Edge counts. The `edgeConfigUpdate` \"with\" option may also be passed to check whether the application of configuration updates to Edges is enabled for each enterprise.\n\nPrivileges required:\n\n`READ` `ENTERPRISE`",
+        "tags": [
+          "all",
+          "network"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "operationId": "network_get_network_enterprises",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "network_get_network_enterprises",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "edges",
+                      "edgeCount",
+                      "edgeConfigUpdate"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "network_get_network_enterprises_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/network_get_network_enterprises_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/network/getNetworkGatewayPools": {
+      "post": {
+        "summary": "Get gateway pools on network",
+        "tags": [
+          "all",
+          "network"
+        ],
+        "description": "Gets all gateway pools associated with the specified network. Optionally includes the gateways or enterprises belonging to each pool.\n\nPrivileges required:\n\n`READ` `GATEWAY`",
+        "operationId": "network_get_network_gateway_pools",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "network_get_network_gateway_pools",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "networkId": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "gateways",
+                      "enterprises"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "network_get_network_gateway_pools_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/network_get_network_gateway_pools_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/network/getNetworkGateways": {
+      "post": {
+        "summary": "Get gateways on network",
+        "description": "Gets all gateways associated with the specified network.\n\nPrivileges required:\n\n`READ` `GATEWAY`",
+        "tags": [
+          "network",
+          "all"
+        ],
+        "operationId": "network_get_network_gateways",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "network_get_network_gateways",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                },
+                "gatewayIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "site",
+                      "pools",
+                      "enterprises",
+                      "enterpriseAssociations",
+                      "enterpriseAssociationCounts",
+                      "dataCenters",
+                      "certificates",
+                      "handOffEdges",
+                      "roles"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "network_get_network_gateways_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/network_get_network_gateways_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/network/getNetworkOperatorUsers": {
+      "post": {
+        "summary": "Get operator users for network",
+        "description": "Gets all operator users associated with the specified network.\n\nPrivileges required:\n\n`READ` `OPERATOR_USER`",
+        "tags": [
+          "all",
+          "network"
+        ],
+        "operationId": "network_get_network_operator_users",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "OPERATOR_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "network_get_network_operator_users",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "network_get_network_operator_users_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/network_get_network_operator_users_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/network/insertNetworkGatewayPool": {
+      "post": {
+        "summary": "Create gateway pool",
+        "description": "Creates a gateway pool for the specified network.\n\nPrivileges required:\n\n`CREATE` `GATEWAY`",
+        "tags": [
+          "network",
+          "all"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "operationId": "network_insert_network_gateway_pool",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "network_insert_network_gateway_pool",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                },
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "handOffType": {
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "ALLOW",
+                    "ONLY"
+                  ]
+                }
+              },
+              "required": [
+                "name",
+                "networkId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/network_insert_network_gateway_pool_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/network/updateNetworkGatwayPoolAttributes": {
+      "post": {
+        "summary": "Update gateway pool attributes",
+        "description": "Updates the configurable attributes (`name`, `description`, and `handOffType`) of the specified gateway pool (by `id` or `gatewayPoolId`).\n\nPrivileges required:\n\n`UPDATE` `GATEWAY`",
+        "tags": [
+          "network",
+          "all"
+        ],
+        "operationId": "network_update_network_gateway_pool_attributes",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "GATEWAY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "network_update_network_gateway_pool_attributes",
+              "properties": {
+                "networkId": {
+                  "type": "integer"
+                },
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "alias for `gatewayPoolId`"
+                },
+                "gatewayPoolId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "handOffType": {
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "ALLOW",
+                    "ONLY"
+                  ]
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/network_update_network_gateway_pool_attributes_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/operatorUser/deleteOperatorUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Delete operator user",
+        "description": "Deletes the specified operator user (by `id` or `username`).\n\nPrivileges required:\n\n`DELETE` `OPERATOR_USER`",
+        "operationId": "operator_user_delete_operator_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "DELETE",
+              "object": "OPERATOR_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "operator_user_delete_operator_user",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/operator_user_delete_operator_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/operatorUser/getOperatorUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Get operator user",
+        "description": "Gets the specified operator user object (by `id` or `username`).\n\nPrivileges required:\n\n`READ` `OPERATOR_USER`",
+        "operationId": "operator_user_get_operator_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "allowPrivilegeToSelf": "OPERATOR_USER",
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "OPERATOR_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "operator_user_get_operator_user",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/operator_user_get_operator_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/operatorUser/insertOperatorUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Create operator user",
+        "description": "Creates an operator user and associates it with the operator's network.\n\nPrivileges required:\n\n`CREATE` `OPERATOR_USER`",
+        "operationId": "operator_user_insert_operator_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "OPERATOR_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/operator_user_insert_operator_user"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/operator_user_get_operator_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/operatorUser/updateOperatorUser": {
+      "post": {
+        "tags": [
+          "all",
+          "userMaintenance"
+        ],
+        "summary": "Update operator user",
+        "description": "Updates the specified operator user (by object `id` or `username`). Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `OPERATOR_USER`",
+        "operationId": "operator_user_update_operator_user",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "allowPrivilegeToSelf": "OPERATOR_USER",
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "OPERATOR_USER"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "operator_user_update_operator_user",
+              "properties": {
+                "_update": {
+                  "$ref": "#/definitions/operator_user_update_operator_user"
+                },
+                "networkId": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "username": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "_update"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/operator_user_update_operator_user_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/role/createRoleCustomization": {
+      "post": {
+        "summary": "Create role customization",
+        "tags": [
+          "all",
+          "role"
+        ],
+        "description": "Creates a role customization specified by `roleId` and an array of `privilegeIds`.\n\nPrivileges required:\n\n`UPDATE` `NETWORK`",
+        "operationId": "role_create_role_customization",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "NETWORK"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "role_create_role_customization",
+              "properties": {
+                "forRoleId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "userId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "operatorId": {
+                  "type": "integer"
+                },
+                "networkId": {
+                  "type": "integer"
+                },
+                "privilegeIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "forRoleId",
+                "privilegeIds"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/role_create_role_customization_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/role/deleteRoleCustomization": {
+      "post": {
+        "summary": "Delete role customization",
+        "tags": [
+          "all",
+          "role"
+        ],
+        "description": "Deletes the specified role customization (by `name` or `forRoleId`).\n\nPrivileges required:\n\n`UPDATE` `NETWORK`",
+        "operationId": "role_delete_role_customization",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "NETWORK"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "role_delete_role_customization",
+              "properties": {
+                "forRoleId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "userId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "operatorId": {
+                  "type": "integer"
+                },
+                "networkId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "forRoleId"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/role_delete_role_customization_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/role/getUserTypeRoles": {
+      "post": {
+        "summary": "Get roles per user type",
+        "tags": [
+          "all",
+          "role"
+        ],
+        "description": "Gets all roles defined for the specified `userType`.\n\nPrivileges required:\n\n`READ` `ENTERPRISE_USER`, or\n\n`READ` `PROXY_USER`, or\n\n`READ` `OPERATOR_USER`",
+        "operationId": "role_get_user_type_roles",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "ENTERPRISE_USER",
+              "sufficient": true
+            },
+            {
+              "action": "READ",
+              "object": "PROXY_USER",
+              "sufficient": true
+            },
+            {
+              "action": "READ",
+              "object": "OPERATOR_USER",
+              "sufficient": true
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "role_get_user_type_roles",
+              "properties": {
+                "userType": {
+                  "type": "string",
+                  "enum": [
+                    "OPERATOR",
+                    "MSP",
+                    "PARTNER",
+                    "ENTERPRISE",
+                    "END_USER",
+                    "CUSTOM"
+                  ]
+                },
+                "networkId": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "userType"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "title": "role_get_user_type_roles_result",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/role_get_user_type_roles_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/role/setEnterpriseDelegatedToEnterpriseProxy": {
+      "post": {
+        "summary": "Grant enterprise access to partner",
+        "description": "Grants enterprise access to the specified enterprise proxy (partner). When an enterprise is delegated to a proxy, proxy users are granted access to view, configure, and troubleshoot Edges owned by the enterprise. As a security consideration, proxy Support users cannot view personally identifiable information.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_DELEGATION`",
+        "tags": [
+          "role",
+          "all"
+        ],
+        "operationId": "role_set_enterprise_delegated_to_enterprise_proxy",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_DELEGATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "isDelegated": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "isDelegated"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/role_set_enterprise_delegated_to_enterprise_proxy_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/role/setEnterpriseDelegatedToOperator": {
+      "post": {
+        "summary": "Grant enterprise access to network operator",
+        "description": "Grants enterprise access to the network operator. When an enterprise is delegated to the operator, operator users are permitted to view, configure, and troubleshoot Edges owned by the enterprise. As a security consideration, operator users cannot view personally identifiable information.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_DELEGATION`",
+        "tags": [
+          "role",
+          "all"
+        ],
+        "operationId": "role_set_enterprise_delegated_to_operator",
+        "x-privileges": {
+          "forceEnterpriseContext": true,
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_DELEGATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "isDelegated": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "isDelegated"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/role_set_enterprise_delegated_to_operator_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/role/setEnterpriseProxyDelegatedToOperator": {
+      "post": {
+        "summary": "Grant enterprise proxy access to network operator",
+        "description": "Grants enterprise proxy access to the network operator. When an enterprise proxy is delegated to the operator, operator users are granted access to view, configure and troubleshoot objects owned by the proxy.\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_PROXY_DELEGATION`",
+        "tags": [
+          "role",
+          "all"
+        ],
+        "operationId": "role_set_enterprise_proxy_delegated_to_operator",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_PROXY_DELEGATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "enterpriseProxyId": {
+                  "type": "integer"
+                },
+                "isDelegated": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "isDelegated"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/role_set_enterprise_proxy_delegated_to_operator_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/role/setEnterpriseUserManagementDelegatedToOperator": {
+      "post": {
+        "summary": "Grant enterprise user access to network operator",
+        "description": "Grants enterprise user access to the specified network operator. When enterprise user management is delegated to the operator, operator users are granted enterprise-level user management capabilities (user creation, password resets, etc.).\n\nPrivileges required:\n\n`UPDATE` `ENTERPRISE_DELEGATION`",
+        "tags": [
+          "role",
+          "all"
+        ],
+        "operationId": "role_set_enterprise_user_management_delegated_to_operator",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "MSP_USER",
+            "ENTERPRISE_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "ENTERPRISE_DELEGATION"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "isDelegated": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "isDelegated"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/role_set_enterprise_user_management_delegated_to_operator_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/systemProperty/getSystemProperties": {
+      "post": {
+        "summary": "Get all system properties",
+        "description": "Gets all configured system properties.\n\nPrivileges required:\n\n`READ` `SYSTEM_PROPERTY`",
+        "operationId": "system_property_get_system_properties",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "SYSTEM_PROPERTY"
+            }
+          ]
+        },
+        "tags": [
+          "systemProperty",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "system_property_get_system_properties",
+              "properties": {
+                "group": {
+                  "type": "string",
+                  "description": "Filter for properties matching a given group prefix"
+                },
+                "normalize": {
+                  "type": "boolean",
+                  "description": "If true, transforms query result from rowset to single object with attribute names matching property names fetched"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/system_property_get_system_properties_result_item"
+              }
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/systemProperty/getSystemProperty": {
+      "post": {
+        "summary": "Get system property",
+        "description": "Gets the specified system property. Specify by object `id` or `name`.\n\nPrivileges required:\n\n`READ` `SYSTEM_PROPERTY`",
+        "operationId": "system_property_get_system_property",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "SYSTEM_PROPERTY"
+            }
+          ]
+        },
+        "tags": [
+          "systemProperty",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "system_property_get_system_property",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/system_property_get_system_property_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/systemProperty/insertOrUpdateSystemProperty": {
+      "post": {
+        "summary": "Create or update system property",
+        "description": "Creates the specified system property. If the system property with the specified `name` already exists, then the API call updates it.\n\nPrivileges required:\n\n`CREATE` `SYSTEM_PROPERTY`",
+        "operationId": "system_property_insert_or_update_system_property",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "SYSTEM_PROPERTY"
+            }
+          ]
+        },
+        "tags": [
+          "systemProperty",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "system_property_insert_or_update_system_property",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                },
+                "defaultValue": {
+                  "type": "string"
+                },
+                "isPassword": {
+                  "type": "boolean"
+                },
+                "isReadOnly": {
+                  "type": "boolean"
+                },
+                "dataType": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "value"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/system_property_insert_or_update_system_property_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/systemProperty/insertSystemProperty": {
+      "post": {
+        "summary": "Create system property",
+        "description": "Creates a new system property with the specified `name`, `value`, and optionally other attributes.\n\nPrivileges required:\n\n`CREATE` `SYSTEM_PROPERTY`",
+        "operationId": "system_property_insert_system_property",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "SYSTEM_PROPERTY"
+            }
+          ]
+        },
+        "tags": [
+          "systemProperty",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "system_property_insert_system_property",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                },
+                "defaultValue": {
+                  "type": "string"
+                },
+                "dataType": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "isPassword": {
+                  "type": "boolean"
+                },
+                "isReadOnly": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "value"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/system_property_insert_system_property_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/systemProperty/updateSystemProperty": {
+      "post": {
+        "summary": "Update system property",
+        "description": "Updates the specified system property (by object `id` or `name`). Expects an `_update` object containing the field(s) to be updated and their corresponding value(s).\n\nPrivileges required:\n\n`UPDATE` `SYSTEM_PROPERTY`",
+        "operationId": "system_property_update_system_property",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "UPDATE",
+              "object": "SYSTEM_PROPERTY"
+            }
+          ]
+        },
+        "tags": [
+          "systemProperty",
+          "all"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "system_property_update_system_property",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer"
+                },
+                "_update": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "defaultValue": {
+                      "type": "string"
+                    },
+                    "isPassword": {
+                      "type": "boolean"
+                    },
+                    "isReadOnly": {
+                      "type": "boolean"
+                    },
+                    "dataType": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "_update"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/system_property_update_system_property_result"
+            },
+            "description": "Request was successfully processed"
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/vcoDiagnostics/getVcoDbDiagnostics": {
+      "post": {
+        "summary": "Get VCO Database Diagnostics",
+        "description": "Gets the diagnostic information of the VCO database.\n\nPrivileges required:\n\n`READ` `VCO_DIAGNOSTICS`",
+        "operationId": "vco_diagnostics_get_vco_db_diagnostics",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "VCO_DIAGNOSTICS"
+            }
+          ]
+        },
+        "tags": [
+          "all",
+          "vcoDiagnostics"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "vco_diagnostics_get_vco_db_diagnostics",
+              "properties": {}
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "method": {
+                    "type": "string"
+                  },
+                  "result": {
+                    "type": "object",
+                    "properties": {
+                      "velocloud": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "table_schema": {
+                              "type": "string"
+                            },
+                            "table_name": {
+                              "type": "string"
+                            },
+                            "table_rows": {
+                              "type": "integer"
+                            },
+                            "avg_row_length": {
+                              "type": "integer"
+                            },
+                            "data_length": {
+                              "type": "integer"
+                            },
+                            "index_length": {
+                              "type": "integer"
+                            },
+                            "data_free": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      },
+                      "velocloud_ca": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "table_schema": {
+                              "type": "string"
+                            },
+                            "table_name": {
+                              "type": "string"
+                            },
+                            "table_rows": {
+                              "type": "integer"
+                            },
+                            "avg_row_length": {
+                              "type": "integer"
+                            },
+                            "data_length": {
+                              "type": "integer"
+                            },
+                            "index_length": {
+                              "type": "integer"
+                            },
+                            "data_free": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      },
+                      "velocloud_dr": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "table_schema": {
+                              "type": "string"
+                            },
+                            "table_name": {
+                              "type": "string"
+                            },
+                            "table_rows": {
+                              "type": "integer"
+                            },
+                            "avg_row_length": {
+                              "type": "integer"
+                            },
+                            "data_length": {
+                              "type": "integer"
+                            },
+                            "index_length": {
+                              "type": "integer"
+                            },
+                            "data_free": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      },
+                      "velocloud_stats": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "table_schema": {
+                              "type": "string"
+                            },
+                            "table_name": {
+                              "type": "string"
+                            },
+                            "table_rows": {
+                              "type": "integer"
+                            },
+                            "avg_row_length": {
+                              "type": "integer"
+                            },
+                            "data_length": {
+                              "type": "integer"
+                            },
+                            "index_length": {
+                              "type": "integer"
+                            },
+                            "data_free": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/vcoInventory/associateEdge": {
+      "post": {
+        "summary": "Assign Edge to enterprise",
+        "tags": [
+          "all",
+          "vcoInventory"
+        ],
+        "description": "Assigns an Edge in the inventory to the specified enterprise. To perform the action, the Edge should already be in a `STAGING` state. The assignment can be done at an enterprise level, without selecting a destination Edge profile. In such a case, the inventory Edge is assigned to a staging profile within the enterprise. Optionally, a profile or destination Edge can be assigned to this inventory Edge. The Edge in the inventory can be assigned to any profile. The inventory Edge can be assigned to an enterprise Edge only if it is in a `PENDING` or `REACTIVATION_PENDING` state.\n\nPrivileges required:\n\n`CREATE` `ENTERPRISE`",
+        "operationId": "vco_inventory_associate_edge",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "ENTERPRISE"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "vco_inventory_associate_edge",
+              "properties": {
+                "edgeInventoryId": {
+                  "type": "integer"
+                },
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "edgeId": {
+                  "type": "integer"
+                },
+                "deviceSerialNumber": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "deviceSerialNumber": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/vcoInventory/getInventoryItems": {
+      "post": {
+        "summary": "Get available VCO inventory items",
+        "tags": [
+          "all",
+          "vcoInventory"
+        ],
+        "description": "Gets all of the inventory information available with this VCO. This method does not have required parameters. The optional parameters are \n`enterpriseId` - Returns inventory items belonging to the specified enterprise. If the caller context is an enterprise, then this value will be taken from the token itself.\n`modifiedSince` - Returns inventory items that have been modified in the last `modifiedSince` hours.\n`with` - Array containing the string \"edge\" to get details about the provisioned Edge, if any.\n\nPrivileges required:\n\n`READ` `INVENTORY`",
+        "operationId": "vco_inventory_get_inventory_items",
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "OPERATOR_USER",
+            "ENTERPRISE_USER"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "READ",
+              "object": "INVENTORY"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "vco_inventory_get_inventory_items",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "modifiedSince": {
+                  "type": "integer"
+                },
+                "with": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "edge",
+                      "vcoOwner"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/vco_inventory_get_inventory_items_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    },
+    "/vpn/generateVpnGatewayConfiguration": {
+      "post": {
+        "summary": "Provision a non-SD-WAN VPN site",
+        "description": "Provision a non-SD-WAN site (e.g. a data center or cloud service PoP) and generate VPN configuration.\n\nPrivileges required:\n\n`CREATE` `NETWORK_SERVICE`",
+        "tags": [
+          "all",
+          "vpn"
+        ],
+        "x-privileges": {
+          "excludeAuthTypes": [],
+          "allowAuthTypes": [
+            "ANY"
+          ],
+          "allowPrincipleTypes": [],
+          "excludePrincipleTypes": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "requirePrivileges": [
+            {
+              "action": "CREATE",
+              "object": "NETWORK_SERVICE"
+            }
+          ]
+        },
+        "operationId": "vpn_generate_vpn_gateway_configuration",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "title": "vpn_generate_vpn_gateway_configuration",
+              "properties": {
+                "enterpriseId": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "data": {
+                  "$ref": "#/definitions/data_center_data"
+                }
+              },
+              "required": [
+                "name",
+                "data"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request was successfully processed",
+            "schema": {
+              "$ref": "#/definitions/vpn_generate_vpn_gateway_configuration_result"
+            }
+          },
+          "400": {
+            "$ref": "#/responses/generic_400"
+          },
+          "500": {
+            "$ref": "#/responses/generic_500"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "error": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "integer",
+              "description": "A JSON-RPC error code (see http://www.jsonrpc.org/specification#error_object for details)",
+              "example": -32600
+            },
+            "message": {
+              "type": "string",
+              "example": "An error occurred while processing your request"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      },
+      "required": [
+        "error"
+      ]
+    },
+    "tinyint": {
+      "type": "integer",
+      "enum": [
+        0,
+        1
+      ]
+    },
+    "logicalid_reference": {
+      "type": "object",
+      "properties": {
+        "logicalId": {
+          "type": "string"
+        }
+      }
+    },
+    "subnet": {
+      "type": "object",
+      "properties": {
+        "cidrIp": {
+          "type": "string"
+        },
+        "cidrPrefix": {
+          "type": "integer"
+        }
+      }
+    },
+    "enterprise": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "gatewayPoolId": {
+          "type": "integer"
+        },
+        "alertsEnabled": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "operatorAlertsEnabled": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "endpointPkiMode": {
+          "type": "string",
+          "enum": [
+            "CERTIFICATE_DISABLED",
+            "CERTIFICATE_OPTIONAL",
+            "CERTIFICATE_REQUIRED"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "accountNumber": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "contactName": {
+          "type": "string"
+        },
+        "contactPhone": {
+          "type": "string"
+        },
+        "contactMobile": {
+          "type": "string"
+        },
+        "contactEmail": {
+          "type": "string"
+        },
+        "streetAddress": {
+          "type": "string"
+        },
+        "streetAddress2": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "postalCode": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "lat": {
+          "type": "number",
+          "format": "double"
+        },
+        "lon": {
+          "type": "number",
+          "format": "double"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "configuration_enterprise": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "configurationAssociationId": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_with_proxy_attributes": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise"
+        },
+        {
+          "properties": {
+            "enterpriseProxyId": {
+              "type": "integer"
+            },
+            "enterpriseProxyName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "created",
+            "networkId",
+            "gatewayPoolId",
+            "alertsEnabled",
+            "operatorAlertsEnabled",
+            "endpointPkiMode",
+            "name",
+            "domain",
+            "prefix",
+            "logicalId",
+            "accountNumber",
+            "description",
+            "contactName",
+            "contactPhone",
+            "contactMobile",
+            "contactEmail",
+            "streetAddress",
+            "streetAddress2",
+            "city",
+            "state",
+            "postalCode",
+            "country",
+            "lat",
+            "lon",
+            "timezone",
+            "locale",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "enterprise_proxy": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "proxyType": {
+          "type": "string",
+          "enum": [
+            "PARTNER",
+            "MSP"
+          ]
+        },
+        "operateGateways": {
+          "type": "boolean"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "contactName": {
+          "type": "string"
+        },
+        "contactPhone": {
+          "type": "string"
+        },
+        "contactMobile": {
+          "type": "string"
+        },
+        "contactEmail": {
+          "type": "string"
+        },
+        "streetAddress": {
+          "type": "string"
+        },
+        "streetAddress2": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "postalCode": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "lat": {
+          "type": "number",
+          "format": "double"
+        },
+        "lon": {
+          "type": "number",
+          "format": "double"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "enterprise_alert_configuration": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "alertDefinitionId": {
+          "type": "integer"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "EDGE_DOWN",
+            "EDGE_UP",
+            "LINK_DOWN",
+            "LINK_UP",
+            "VPN_TUNNEL_DOWN",
+            "EDGE_HA_FAILOVER",
+            "EDGE_SERVICE_DOWN",
+            "GATEWAY_SERVICE_DOWN",
+            "VNF_VM_EVENT",
+            "VNF_VM_DEPLOYED_AND_POWERED_OFF",
+            "VNF_VM_POWERED_ON",
+            "VNF_VM_POWERED_OFF",
+            "VNF_VM_DELETED",
+            "VNF_VM_ERROR",
+            "VNF_INSERTION_EVENT",
+            "VNF_INSERTION_ENABLED",
+            "VNF_INSERTION_DISABLED",
+            "TEST_ALERT",
+            "VNF_IMAGE_DOWNLOAD_EVENT",
+            "VNF_IMAGE_DOWNLOAD_IN_PROGRESS",
+            "VNF_IMAGE_DOWNLOAD_COMPLETED",
+            "VNF_IMAGE_DOWNLOAD_FAILED",
+            "EDGE_CSS_TUNNEL_DOWN",
+            "EDGE_CSS_TUNNEL_UP"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EDGE_DOWN",
+            "EDGE_UP",
+            "LINK_DOWN",
+            "LINK_UP",
+            "VPN_TUNNEL_DOWN",
+            "EDGE_HA_FAILOVER",
+            "EDGE_SERVICE_DOWN",
+            "GATEWAY_SERVICE_DOWN",
+            "VNF_VM_EVENT",
+            "VNF_VM_DEPLOYED_AND_POWERED_OFF",
+            "VNF_VM_POWERED_ON",
+            "VNF_VM_POWERED_OFF",
+            "VNF_VM_DELETED",
+            "VNF_VM_ERROR",
+            "VNF_INSERTION_EVENT",
+            "VNF_INSERTION_ENABLED",
+            "VNF_INSERTION_DISABLED",
+            "TEST_ALERT",
+            "VNF_IMAGE_DOWNLOAD_EVENT",
+            "VNF_IMAGE_DOWNLOAD_IN_PROGRESS",
+            "VNF_IMAGE_DOWNLOAD_COMPLETED",
+            "VNF_IMAGE_DOWNLOAD_FAILED",
+            "EDGE_CSS_TUNNEL_DOWN",
+            "EDGE_CSS_TUNNEL_UP"
+          ]
+        },
+        "definition": {
+          "$ref": "#/definitions/enterprise_alert_definition"
+        },
+        "firstNotificationSeconds": {
+          "type": "integer"
+        },
+        "maxNotifications": {
+          "type": "integer"
+        },
+        "notificationIntervalSeconds": {
+          "type": "integer"
+        },
+        "resetIntervalSeconds": {
+          "type": "integer"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "enterprise_alert_definition": {
+      "type": "object",
+      "properties": {
+        "isSystemOnly": {
+          "type": "boolean"
+        },
+        "isOperatorOnly": {
+          "type": "boolean"
+        }
+      }
+    },
+    "enterprise_alert_trigger": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "triggerTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "enterpriseAlertConfigurationId": {
+          "type": "integer"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "edgeName": {
+          "type": "string"
+        },
+        "linkId": {
+          "type": "integer"
+        },
+        "linkName": {
+          "type": "string"
+        },
+        "enterpriseObjectId": {
+          "type": "integer"
+        },
+        "enterpriseObjectName": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "EDGE_DOWN",
+            "EDGE_UP",
+            "LINK_DOWN",
+            "LINK_UP",
+            "VPN_TUNNEL_DOWN",
+            "EDGE_HA_FAILOVER",
+            "EDGE_SERVICE_DOWN",
+            "GATEWAY_SERVICE_DOWN",
+            "VNF_VM_EVENT",
+            "VNF_VM_DEPLOYED_AND_POWERED_OFF",
+            "VNF_VM_POWERED_ON",
+            "VNF_VM_POWERED_OFF",
+            "VNF_VM_DELETED",
+            "VNF_VM_ERROR",
+            "VNF_INSERTION_EVENT",
+            "VNF_INSERTION_ENABLED",
+            "VNF_INSERTION_DISABLED",
+            "TEST_ALERT",
+            "VNF_IMAGE_DOWNLOAD_EVENT",
+            "VNF_IMAGE_DOWNLOAD_IN_PROGRESS",
+            "VNF_IMAGE_DOWNLOAD_COMPLETED",
+            "VNF_IMAGE_DOWNLOAD_FAILED",
+            "EDGE_CSS_TUNNEL_DOWN",
+            "EDGE_CSS_TUNNEL_UP"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EDGE_DOWN",
+            "EDGE_UP",
+            "LINK_DOWN",
+            "LINK_UP",
+            "VPN_TUNNEL_DOWN",
+            "EDGE_HA_FAILOVER",
+            "EDGE_SERVICE_DOWN",
+            "GATEWAY_SERVICE_DOWN",
+            "VNF_VM_EVENT",
+            "VNF_VM_DEPLOYED_AND_POWERED_OFF",
+            "VNF_VM_POWERED_ON",
+            "VNF_VM_POWERED_OFF",
+            "VNF_VM_DELETED",
+            "VNF_VM_ERROR",
+            "VNF_INSERTION_EVENT",
+            "VNF_INSERTION_ENABLED",
+            "VNF_INSERTION_DISABLED",
+            "TEST_ALERT",
+            "VNF_IMAGE_DOWNLOAD_EVENT",
+            "VNF_IMAGE_DOWNLOAD_IN_PROGRESS",
+            "VNF_IMAGE_DOWNLOAD_COMPLETED",
+            "VNF_IMAGE_DOWNLOAD_FAILED",
+            "EDGE_CSS_TUNNEL_DOWN",
+            "EDGE_CSS_TUNNEL_UP"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "CLOSED"
+          ]
+        },
+        "stateSetTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastContact": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "firstNotificationSeconds": {
+          "type": "integer"
+        },
+        "maxNotifications": {
+          "type": "integer"
+        },
+        "notificationIntervalSeconds": {
+          "type": "integer"
+        },
+        "resetIntervalSeconds": {
+          "type": "integer"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "nextNotificationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "remainingNotifications": {
+          "type": "integer"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "enterprise_object_base": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "operatorId": {
+          "type": "integer"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "gatewayId": {
+          "type": "integer"
+        },
+        "parentGroupId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "alertsEnabled": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "operatorAlertsEnabled": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "status": {
+          "type": "string"
+        },
+        "statusModified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "previousData": {
+          "type": "object"
+        },
+        "previousCreated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "draftData": {
+          "type": "string"
+        },
+        "draftCreated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "draftComment": {
+          "type": "string"
+        },
+        "lastContact": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "id",
+        "created",
+        "operatorId",
+        "networkId",
+        "enterpriseId",
+        "edgeId",
+        "gatewayId",
+        "parentGroupId",
+        "description",
+        "object",
+        "name",
+        "type",
+        "logicalId",
+        "alertsEnabled",
+        "operatorAlertsEnabled",
+        "status",
+        "statusModified",
+        "previousData",
+        "previousCreated",
+        "draftData",
+        "draftCreated",
+        "draftComment",
+        "lastContact",
+        "version",
+        "modified"
+      ]
+    },
+    "event_base": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "eventTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "event": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "SYSTEM",
+            "NETWORK",
+            "APPLICATION",
+            "USER",
+            "SECURITY",
+            "EDGE",
+            "GATEWAY",
+            "CONFIGURATION",
+            "ENTERPRISE"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "EMERGENCY",
+            "ALERT",
+            "CRITICAL",
+            "ERROR",
+            "WARNING",
+            "NOTICE",
+            "INFO",
+            "DEBUG"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "enterprise_event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/event_base"
+        },
+        {
+          "properties": {
+            "detail": {
+              "type": "string"
+            },
+            "enterpriseUsername": {
+              "type": "string"
+            },
+            "edgeName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "eventTime",
+            "event",
+            "category",
+            "severity",
+            "message",
+            "detail",
+            "enterpriseUsername",
+            "edgeName"
+          ]
+        }
+      ]
+    },
+    "operator_event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/event_base"
+        },
+        {
+          "properties": {
+            "detail": {
+              "type": "string"
+            },
+            "operatorUsername": {
+              "type": "string"
+            },
+            "networkName": {
+              "type": "string"
+            },
+            "gatewayName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "eventTime",
+            "event",
+            "category",
+            "severity",
+            "message",
+            "detail",
+            "operatorUsername",
+            "networkName",
+            "gatewayName"
+          ]
+        }
+      ]
+    },
+    "proxy_event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/event_base"
+        },
+        {
+          "properties": {
+            "detail": {
+              "type": "string"
+            },
+            "proxyUsername": {
+              "type": "string"
+            },
+            "networkName": {
+              "type": "string"
+            },
+            "enterpriseName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "eventTime",
+            "event",
+            "category",
+            "severity",
+            "message",
+            "detail",
+            "proxyUsername",
+            "networkName",
+            "enterpriseName"
+          ]
+        }
+      ]
+    },
+    "aggregate_enterprise_event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/event_base"
+        },
+        {
+          "properties": {
+            "enterpriseId": {
+              "type": "integer"
+            },
+            "enterpriseName": {
+              "type": "string"
+            },
+            "enterpriseUsername": {
+              "type": "string"
+            },
+            "edgeName": {
+              "type": "string"
+            },
+            "detail": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "eventTime",
+            "event",
+            "category",
+            "severity",
+            "message",
+            "enterpriseId",
+            "enterpriseName",
+            "enterpriseUsername",
+            "edgeName",
+            "detail"
+          ]
+        }
+      ]
+    },
+    "vnf_image_download_event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/event_base"
+        },
+        {
+          "properties": {
+            "detail": {
+              "$ref": "#/definitions/vnf_image_download_event_detail"
+            }
+          },
+          "required": [
+            "id",
+            "eventTime",
+            "event",
+            "category",
+            "severity",
+            "detail"
+          ]
+        }
+      ]
+    },
+    "vnf_image_download_event_detail": {
+      "type": "object",
+      "properties": {
+        "logicalId": {
+          "type": "string"
+        },
+        "vnfType": {
+          "type": "string",
+          "pattern": "vnfImage"
+        },
+        "vendor": {
+          "type": "string",
+          "enum": [
+            "PaloAlto",
+            "CheckPoint",
+            "Fortinet",
+            "CentOS"
+          ]
+        },
+        "downloadType": {
+          "type": "string",
+          "enum": [
+            "s3",
+            "http",
+            "https"
+          ]
+        },
+        "edgeSerialNumber": {
+          "type": "string"
+        },
+        "isEdgeActive": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "IN_PROGRESS",
+            "ERROR",
+            "FAILED",
+            "COMPLETED",
+            "UNKNOWN"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "service": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/logicalid_reference"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string",
+                  "pattern": "deviceSettings:securityVnf:service"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "gateway_pool_gateway": {
+      "type": "object",
+      "properties": {
+        "gatewayPoolAssocId": {
+          "type": "integer"
+        },
+        "poolName": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "enterpriseProxyId": {
+          "type": "integer"
+        },
+        "siteId": {
+          "type": "integer"
+        },
+        "activationKey": {
+          "type": "string"
+        },
+        "activationState": {
+          "type": "string"
+        },
+        "activationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "softwareVersion": {
+          "type": "string"
+        },
+        "buildNumber": {
+          "type": "string"
+        },
+        "utilization": {
+          "type": "number"
+        },
+        "utilizationDetail": {
+          "type": "object",
+          "properties": {
+            "load": {
+              "type": "number"
+            },
+            "overall": {
+              "type": "number"
+            },
+            "cpu": {
+              "type": "number"
+            },
+            "memory": {
+              "type": "number"
+            }
+          }
+        },
+        "connectedEdges": {
+          "type": "integer"
+        },
+        "connectedEdgeList": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "vceid": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "deviceId": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "gatewayState": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "dnsName": {
+          "type": "string"
+        },
+        "isLoadBalanced": {
+          "type": "integer"
+        },
+        "privateIpAddress": {
+          "type": "string"
+        },
+        "ipAddress": {
+          "type": "string"
+        },
+        "lastContact": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "systemUpSince": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "serviceUpSince": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "serviceState": {
+          "type": "string"
+        },
+        "endpointPkiMode": {
+          "type": "string"
+        },
+        "handOffDetail": {
+          "$ref": "#/definitions/gateway_handoff_detail"
+        },
+        "ipsecGatewayDetail": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "strictHostCheck": {
+              "type": "boolean"
+            },
+            "strictHostCheckDN": {
+              "type": "string"
+            }
+          }
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "gateway_handoff_detail": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "subnets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "routeCost": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 255
+              },
+              "cidrIp": {
+                "type": "string"
+              },
+              "cidrPrefix": {
+                "type": "integer"
+              },
+              "encrypt": {
+                "type": "boolean"
+              },
+              "handOffType": {
+                "type": "string",
+                "enum": [
+                  "NAT",
+                  "VLAN"
+                ]
+              }
+            }
+          }
+        },
+        "icmpProbe": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "probeType": {
+              "type": "string"
+            },
+            "cTag": {
+              "type": "integer"
+            },
+            "sTag": {
+              "type": "integer"
+            },
+            "destinationIp": {
+              "type": "string"
+            },
+            "frequencySeconds": {
+              "type": "integer"
+            },
+            "threshold": {
+              "type": "integer"
+            }
+          }
+        },
+        "icmpResponder": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "ipAddress": {
+              "type": "string"
+            },
+            "mode": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "gateway_handoff_ipsec_gateway_detail": {
+      "type": "object",
+      "properties": {
+        "ipsecGatewayAddress": {
+          "type": "string"
+        },
+        "strictHostCheck": {
+          "type": "boolean"
+        },
+        "strictHostCheckDN": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "ipsecGatewayAddress"
+      ]
+    },
+    "gateway_pool": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "enterpriseProxyId": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "isDefault": {
+          "type": "boolean"
+        },
+        "handOffType": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ALLOW",
+            "ONLY"
+          ]
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "link": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "internalId": {
+          "type": "string"
+        },
+        "interface": {
+          "type": "string"
+        },
+        "macAddress": {
+          "type": "string"
+        },
+        "ipAddress": {
+          "type": "string"
+        },
+        "netmask": {
+          "type": "string"
+        },
+        "networkSide": {
+          "type": "string",
+          "enum": [
+            "UNKOWN",
+            "WAN",
+            "LAN"
+          ]
+        },
+        "networkType": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "WIRELESS",
+            "ETHERNET",
+            "WIFI"
+          ]
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "isp": {
+          "type": "string"
+        },
+        "org": {
+          "type": "string"
+        },
+        "lat": {
+          "type": "number",
+          "format": "double"
+        },
+        "lon": {
+          "type": "number",
+          "format": "double"
+        },
+        "lastActive": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "STABLE",
+            "UNSTABLE",
+            "DISCONNECTED",
+            "QUIET",
+            "INITIAL",
+            "STANDBY"
+          ]
+        },
+        "backupState": {
+          "type": "string",
+          "enum": [
+            "UNCONFIGURED",
+            "STANDBY",
+            "ACTIVE"
+          ]
+        },
+        "vpnState": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "STABLE",
+            "UNSTABLE",
+            "DEAD",
+            "STANDBY"
+          ]
+        },
+        "lastEvent": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastEventState": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "STABLE",
+            "UNSTABLE",
+            "DISCONNECTED",
+            "QUIET",
+            "INITIAL",
+            "STANDBY"
+          ]
+        },
+        "alertsEnabled": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "operatorAlertsEnabled": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "serviceState": {
+          "type": "string",
+          "enum": [
+            "IN_SERVICE",
+            "OUT_OF_SERVICE",
+            "HISTORICAL"
+          ]
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "serviceGroups": {
+          "$ref": "#/definitions/link_service_groups"
+        }
+      },
+      "required": [
+        "id",
+        "created",
+        "edgeId",
+        "logicalId",
+        "internalId",
+        "interface",
+        "macAddress",
+        "ipAddress",
+        "netmask",
+        "networkSide",
+        "networkType",
+        "displayName",
+        "isp",
+        "org",
+        "lat",
+        "lon",
+        "lastActive",
+        "state",
+        "backupState",
+        "vpnState",
+        "lastEvent",
+        "lastEventState",
+        "alertsEnabled",
+        "operatorAlertsEnabled",
+        "serviceState",
+        "modified"
+      ]
+    },
+    "client_device": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "macAddress": {
+          "type": "string"
+        },
+        "hostName": {
+          "type": "string"
+        },
+        "ipAddress": {
+          "type": "string"
+        },
+        "os": {
+          "type": "integer"
+        },
+        "osName": {
+          "type": "string"
+        },
+        "osVersion": {
+          "type": "string"
+        },
+        "deviceType": {
+          "type": "string"
+        },
+        "deviceModel": {
+          "type": "string"
+        },
+        "lastContact": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "id",
+        "created",
+        "enterpriseId",
+        "macAddress",
+        "hostName",
+        "ipAddress",
+        "os",
+        "osName",
+        "osVersion",
+        "deviceType",
+        "deviceModel",
+        "lastContact",
+        "modified"
+      ]
+    },
+    "link_quality_object": {
+      "type": "object",
+      "properties": {
+        "distribution": {
+          "$ref": "#/definitions/link_quality_object_distribution"
+        },
+        "sampleCount": {
+          "type": "integer"
+        },
+        "sampleLength": {
+          "type": "integer"
+        },
+        "score": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "timeseries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/link_quality_object_timeseries_data"
+          }
+        },
+        "totalScore": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "distribution",
+        "sampleCount",
+        "sampleLength",
+        "score",
+        "timeseries",
+        "totalScore"
+      ]
+    },
+    "link_quality_object_distribution": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "number"
+        }
+      }
+    },
+    "link_quality_object_timeseries_data": {
+      "type": "object",
+      "properties": {
+        "before": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "after": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "detail": {
+              "type": "object",
+              "properties": {
+                "latencyMsRx": {
+                  "type": "integer"
+                },
+                "latencyMsTx": {
+                  "type": "integer"
+                },
+                "lossPctRx": {
+                  "type": "integer"
+                },
+                "lossPctTx": {
+                  "type": "integer"
+                },
+                "jitterMsRx": {
+                  "type": "integer"
+                },
+                "jitterMsTx": {
+                  "type": "integer"
+                }
+              }
+            },
+            "metrics": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "trafficType": {
+                    "type": "integer",
+                    "enum": [
+                      0,
+                      1,
+                      2
+                    ]
+                  },
+                  "action": {
+                    "type": "integer",
+                    "enum": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  "metric": {
+                    "type": "integer",
+                    "enum": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4,
+                      5
+                    ]
+                  },
+                  "beforeState": {
+                    "type": "integer",
+                    "enum": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  },
+                  "afterState": {
+                    "type": "integer",
+                    "enum": [
+                      0,
+                      1,
+                      2,
+                      3,
+                      4
+                    ]
+                  }
+                }
+              }
+            },
+            "stateMap": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "before": {
+                      "type": "integer"
+                    },
+                    "after": {
+                      "type": "integer"
+                    },
+                    "action": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "timestamp": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "required": [
+        "after",
+        "metadata",
+        "timestamp"
+      ]
+    },
+    "enterprise_route": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "exitType": {
+          "type": "string"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "edgeName": {
+          "type": "string"
+        },
+        "profileId": {
+          "type": "integer"
+        },
+        "cidrIp": {
+          "type": "string"
+        },
+        "cost": {
+          "type": "integer"
+        },
+        "advertise": {
+          "type": "boolean"
+        }
+      }
+    },
+    "vlan": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "vlanId": {
+          "type": "integer"
+        },
+        "staticReserved": {
+          "type": "integer"
+        }
+      }
+    },
+    "enterprise_network_space": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "static",
+            "dynamic"
+          ]
+        },
+        "cidrIp": {
+          "type": "string"
+        },
+        "cidrPrefix": {
+          "type": "integer"
+        },
+        "maxVlans": {
+          "type": "integer"
+        },
+        "vlans": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/vlan"
+          }
+        }
+      }
+    },
+    "enterprise_service_base_type": {
+      "type": "object",
+      "discriminator": "type",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "enterpriseObjectId": {
+          "type": "integer"
+        },
+        "configurationId": {
+          "type": "integer"
+        },
+        "moduleId": {
+          "type": "integer"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "dns": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_service_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/dns_data"
+            }
+          }
+        }
+      ]
+    },
+    "dns_data": {
+      "type": "object",
+      "properties": {
+        "primary": {
+          "type": "string"
+        },
+        "secondary": {
+          "type": "string"
+        },
+        "isPrivate": {
+          "type": "boolean"
+        },
+        "domains": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rule": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "enterprise_service_network": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_service_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/enterprise_service_network_data"
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_service_network_data": {
+      "type": "object",
+      "properties": {
+        "zone": {
+          "type": "string"
+        },
+        "spaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "cidrIp": {
+                "type": "string"
+              },
+              "cidrPrefix": {
+                "type": "integer"
+              },
+              "maxVlans": {
+                "type": "integer"
+              },
+              "mode": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "branchCidrPrefix": {
+                "type": "integer"
+              },
+              "guest": {
+                "type": "boolean"
+              },
+              "vlans": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "vlanId": {
+                      "type": "integer"
+                    },
+                    "advertise": {
+                      "type": "boolean"
+                    },
+                    "cost": {
+                      "type": "integer"
+                    },
+                    "staticReserved": {
+                      "type": "integer"
+                    },
+                    "dhcp": {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "leaseTimeSeconds": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "configuration_module_base_type": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "imageUpdate",
+            "controlPlane",
+            "managementPlane",
+            "firewall",
+            "QOS",
+            "deviceSettings",
+            "WAN",
+            "metaData",
+            "properties"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "ENTERPRISE",
+            "OPERATOR",
+            "GATEWAY"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "configurationId": {
+          "type": "integer"
+        }
+      },
+      "discriminator": "name"
+    },
+    "genericRefs": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/enterprise_service_base_type"
+      }
+    },
+    "imageUpdate": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/image_update_data"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "image_update_data": {
+      "type": "object",
+      "properties": {
+        "buildNumber": {
+          "type": "string"
+        },
+        "profileDeviceFamily": {
+          "type": "string"
+        },
+        "profileVersion": {
+          "type": "string"
+        },
+        "scheduledStartTime": {
+          "$ref": "#/definitions/image_update_scheduled_time"
+        },
+        "softwarePackageId": {
+          "type": "integer"
+        },
+        "softwarePackageName": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "windowDurationMins": {
+          "type": "integer"
+        },
+        "windowed": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "buildNumber",
+        "profileDeviceFamily",
+        "profileVersion",
+        "softwarePackageId",
+        "softwarePackageName",
+        "version",
+        "windowDurationMins",
+        "windowed"
+      ]
+    },
+    "image_update_scheduled_time": {
+      "type": "object",
+      "properties": {
+        "dayOfWeek": {
+          "type": "integer"
+        },
+        "specified": {
+          "type": "boolean"
+        },
+        "timeOfDayMins": {
+          "type": "integer"
+        },
+        "useEdgeTimeZone": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "dayOfWeek",
+        "specified",
+        "timeOfDayMins",
+        "useEdgeTimeZone"
+      ]
+    },
+    "controlPlane": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/control_plane_data"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "control_plane_data": {
+      "type": "object",
+      "properties": {
+        "gatewaySelection": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string"
+            },
+            "primary": {
+              "type": "string"
+            },
+            "primaryDetail": {
+              "type": "object",
+              "properties": {
+                "ipAddress": {
+                  "type": "string"
+                },
+                "logicalId": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "ipAddress",
+                "logicalId",
+                "name"
+              ]
+            },
+            "secondary": {
+              "type": "string"
+            },
+            "secondaryDetail": {
+              "type": "object",
+              "properties": {
+                "ipAddress": {
+                  "type": "string"
+                },
+                "logicalId": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "ipAddress",
+                "logicalId",
+                "name"
+              ]
+            },
+            "super": {
+              "type": "string"
+            },
+            "superDetail": {
+              "type": "object",
+              "properties": {
+                "ipAddress": {
+                  "type": "string"
+                },
+                "logicalId": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "vpn": {
+          "type": "object",
+          "properties": {
+            "dataCenterEdges": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "logicalId": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "edgeToDataCenter": {
+              "type": "boolean"
+            },
+            "edgeToEdge": {
+              "type": "boolean"
+            },
+            "edgeToEdgeDetail": {
+              "type": "object",
+              "properties": {
+                "dynamic": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "timeout": {
+                      "type": "integer"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "encryptionProtocol": {
+                  "type": "string"
+                },
+                "profileIsolation": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "isolateDynamic": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "useCloudGateway": {
+                  "type": "boolean"
+                },
+                "vpnHubs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "autoSelectVpnHubs": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "edgeToEdgeList": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "isolateDynamic": {
+                    "type": "integer"
+                  },
+                  "logicalId": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "profileLogicalId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ipsecGatewayDetail": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "strictHostCheck": {
+                "type": "boolean"
+              },
+              "strictHostCheckDN": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "gatewaySelection"
+      ]
+    },
+    "managementPlane": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/management_plane_data"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "management_plane_data": {
+      "type": "object",
+      "properties": {
+        "heartBeatSeconds": {
+          "type": "integer"
+        },
+        "managementPlaneProxy": {
+          "type": "object",
+          "properties": {
+            "primary": {
+              "type": "string"
+            },
+            "secondary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary",
+            "secondary"
+          ]
+        },
+        "statsUploadSeconds": {
+          "type": "integer"
+        },
+        "timeSliceSeconds": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "heartBeatSeconds",
+        "managementPlaneProxy",
+        "statsUploadSeconds",
+        "timeSliceSeconds"
+      ]
+    },
+    "firewall": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/firewall_data"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "firewall_data": {
+      "type": "object",
+      "properties": {
+        "firewall_enabled": {
+          "type": "boolean"
+        },
+        "stateful_firewall_enabled": {
+          "type": "boolean"
+        },
+        "firewall_logging_enabled": {
+          "type": "boolean"
+        },
+        "inbound": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/firewall_inbound_rule"
+          }
+        },
+        "segments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/firewall_segment"
+          }
+        },
+        "services": {
+          "type": "object",
+          "properties": {
+            "loggingEnabled": {
+              "type": "boolean"
+            },
+            "ssh": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowSelectedIp": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ruleLogicalId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ]
+            },
+            "localUi": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowSelectedIp": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of IP addresses allowed UI access"
+                },
+                "portNumber": {
+                  "type": "integer"
+                },
+                "ruleLogicalId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled",
+                "portNumber"
+              ]
+            },
+            "snmp": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowSelectedIp": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of IP addresses allowed SNMP access"
+                },
+                "ruleLogicalId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ]
+            },
+            "icmp": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "allowSelectedIp": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of IP addresses allowed ICMP access"
+                },
+                "ruleLogicalId": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ]
+            }
+          },
+          "required": [
+            "loggingEnabled"
+          ]
+        }
+      },
+      "required": [
+        "firewall_enabled",
+        "inbound",
+        "segments"
+      ]
+    },
+    "firewall_segment": {
+      "type": "object",
+      "properties": {
+        "firewall_logging_enabled": {
+          "type": "boolean"
+        },
+        "stateful_firewall_enabled": {
+          "type": "boolean"
+        },
+        "outbound": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/firewall_outbound_rule"
+          }
+        },
+        "segment": {
+          "$ref": "#/definitions/configuration_module_segment_metadata"
+        }
+      },
+      "required": [
+        "firewall_logging_enabled",
+        "outbound",
+        "segment"
+      ]
+    },
+    "firewall_inbound_rule": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "match": {
+          "$ref": "#/definitions/firewall_rule_match"
+        },
+        "action": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "port_forwarding",
+                "one_to_one_nat"
+              ]
+            },
+            "nat": {
+              "type": "object",
+              "properties": {
+                "lan_ip": {
+                  "type": "string"
+                },
+                "lan_port": {
+                  "type": "integer"
+                },
+                "outbound": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "lan_ip"
+              ]
+            },
+            "interface": {
+              "type": "string",
+              "description": "The name of the interface from which traffic should be forwarded"
+            },
+            "subinterfaceId": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "type",
+            "nat",
+            "interface"
+          ]
+        },
+        "ruleLogicalId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "match",
+        "action"
+      ]
+    },
+    "firewall_outbound_rule": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "match": {
+          "$ref": "#/definitions/firewall_rule_match"
+        },
+        "action": {
+          "type": "object",
+          "properties": {
+            "allow_or_deny": {
+              "type": "string",
+              "enum": [
+                "allow",
+                "deny",
+                "drop",
+                "reject",
+                "skip"
+              ]
+            }
+          }
+        },
+        "ruleLogicalId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "match",
+        "action"
+      ]
+    },
+    "netflow_filter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/netflow_filter_data"
+            }
+          }
+        }
+      ]
+    },
+    "netflow_filter_data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "match": {
+          "$ref": "#/definitions/netflow_filter_rule"
+        },
+        "action": {
+          "type": "object",
+          "properties": {
+            "allow_or_deny": {
+              "type": "string",
+              "enum": [
+                "allow",
+                "deny"
+              ]
+            }
+          },
+          "required": [
+            "allow_or_deny"
+          ]
+        }
+      },
+      "required": [
+        "match",
+        "action",
+        "name"
+      ]
+    },
+    "netflow_filter_rule": {
+      "type": "object",
+      "properties": {
+        "appid": {
+          "type": "integer",
+          "description": "Integer ID corresponding to an application in the network-level application map"
+        },
+        "classid": {
+          "type": "integer",
+          "description": "Integer ID corresponding to an application class in the network-level application map"
+        },
+        "dscp": {
+          "type": "integer",
+          "description": "Integer ID indicating DSCP classification, where mappings are as follows: [EF:46,VA:44,AF11:10,AF12:12,AF13:14,AF21:18,AF22:20,AF23:22,AF31:26,AF32:28,AF33:30,AF41:34,AF42:36,AF43:38,CS0:0,CS1:8,CS2:16,CS3:24,CS4:32,CS5:40,CS6:48,CS7:56]"
+        },
+        "sip": {
+          "type": "string",
+          "description": "Source IP address"
+        },
+        "sport_high": {
+          "type": "integer",
+          "description": "Upper bound of a source port range"
+        },
+        "sport_low": {
+          "type": "integer",
+          "description": "Lower bound of a source port range"
+        },
+        "sAddressGroup": {
+          "type": "string",
+          "description": "Source address group reference"
+        },
+        "sPortGroup": {
+          "type": "string",
+          "description": "Source port group reference"
+        },
+        "ssm": {
+          "type": "string",
+          "description": "Source subnet mask, e.g. 255.255.255.0"
+        },
+        "smac": {
+          "type": "string",
+          "description": "Source MAC address"
+        },
+        "svlan": {
+          "type": "integer",
+          "description": "Integer ID for the source VLAN"
+        },
+        "os_version": {
+          "type": "integer",
+          "description": "Index corresponding to the OS in the array: [OTHER,WINDOWS,LINUX,MACOS,IOS,ANDROID,EDGE]"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "dip": {
+          "type": "string",
+          "description": "Destination IP address"
+        },
+        "dport_low": {
+          "type": "integer",
+          "description": "Lower bound of a destination port range"
+        },
+        "dport_high": {
+          "type": "integer",
+          "description": "Upper bound of a destination port range"
+        },
+        "dAddressGroup": {
+          "type": "string",
+          "description": "Destination address group reference"
+        },
+        "dPortGroup": {
+          "type": "string",
+          "description": "Destination port group reference"
+        },
+        "dsm": {
+          "type": "string",
+          "description": "Destination subnet mask e.g. 255.255.255.0"
+        },
+        "dmac": {
+          "type": "string",
+          "description": "Destination MAC address"
+        },
+        "dvlan": {
+          "type": "integer",
+          "description": "Integer ID for the destination VLAN"
+        },
+        "proto": {
+          "type": "integer",
+          "description": "Integer ID corresponding to a protocol"
+        },
+        "s_rule_type": {
+          "type": "string",
+          "enum": [
+            "exact",
+            "prefix",
+            "wildcard",
+            "netmask"
+          ],
+          "description": "Source rule type"
+        },
+        "d_rule_type": {
+          "type": "string",
+          "enum": [
+            "exact",
+            "prefix",
+            "wildcard",
+            "netmask"
+          ],
+          "description": "Destination rule type"
+        }
+      }
+    },
+    "firewall_rule_match": {
+      "type": "object",
+      "properties": {
+        "appid": {
+          "type": "integer",
+          "description": "Integer ID corresponding to an application in the network-level application map"
+        },
+        "classid": {
+          "type": "integer",
+          "description": "Integer ID corresponding to an application class in the network-level application map"
+        },
+        "dscp": {
+          "type": "integer",
+          "description": "Integer ID indicating DSCP classification, where mappings are as follows: [EF:46,VA:44,AF11:10,AF12:12,AF13:14,AF21:18,AF22:20,AF23:22,AF31:26,AF32:28,AF33:30,AF41:34,AF42:36,AF43:38,CS0:0,CS1:8,CS2:16,CS3:24,CS4:32,CS5:40,CS6:48,CS7:56]"
+        },
+        "sip": {
+          "type": "string",
+          "description": "Source IP address"
+        },
+        "sport_high": {
+          "type": "integer",
+          "description": "Upper bound of a source port range"
+        },
+        "sport_low": {
+          "type": "integer",
+          "description": "Lower bound of a source port range"
+        },
+        "ssm": {
+          "type": "string",
+          "description": "Source subnet mask, e.g. 255.255.255.0"
+        },
+        "smac": {
+          "type": "string",
+          "description": "Source MAC address"
+        },
+        "svlan": {
+          "type": "integer",
+          "description": "Integer ID for the source VLAN"
+        },
+        "os_version": {
+          "type": "integer",
+          "description": "Index corresponding to the OS in the array: [OTHER,WINDOWS,LINUX,MACOS,IOS,ANDROID,EDGE]"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "dip": {
+          "type": "string",
+          "description": "Destination IP address"
+        },
+        "dport_low": {
+          "type": "integer",
+          "description": "Lower bound of a destination port range"
+        },
+        "dport_high": {
+          "type": "integer",
+          "description": "Upper bound of a destination port range"
+        },
+        "dsm": {
+          "type": "string",
+          "description": "Destination subnet mask e.g. 255.255.255.0"
+        },
+        "dmac": {
+          "type": "string",
+          "description": "Destination MAC address"
+        },
+        "dvlan": {
+          "type": "integer",
+          "description": "Integer ID for the destination VLAN"
+        },
+        "proto": {
+          "type": "integer",
+          "description": "Integer ID corresponding to a protocol"
+        },
+        "s_rule_type": {
+          "type": "string",
+          "enum": [
+            "exact",
+            "prefix",
+            "wildcard",
+            "netmask"
+          ],
+          "description": "Source rule type"
+        },
+        "d_rule_type": {
+          "type": "string",
+          "enum": [
+            "exact",
+            "prefix",
+            "wildcard",
+            "netmask"
+          ],
+          "description": "Destination rule type"
+        }
+      }
+    },
+    "QOS": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/QOSData"
+            },
+            "refs": {
+              "$ref": "#/definitions/QOSRefs"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "QOSData": {
+      "type": "object",
+      "properties": {
+        "serviceRateLimit": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "inputType": {
+              "type": "string"
+            },
+            "value": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "enabled"
+          ]
+        },
+        "segments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QOSSegments"
+          }
+        }
+      },
+      "required": [
+        "segments"
+      ]
+    },
+    "QOSSegments": {
+      "type": "object",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QOS_business_rules"
+          }
+        },
+        "defaults": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QOS_business_rules"
+          }
+        },
+        "webProxy": {
+          "type": "object",
+          "properties": {
+            "providers": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "cosMapping": {
+          "type": "object",
+          "properties": {
+            "lsInputType": {
+              "type": "string"
+            },
+            "bulk": {
+              "$ref": "#/definitions/cos_mapping"
+            },
+            "realtime": {
+              "$ref": "#/definitions/cos_mapping"
+            },
+            "transactional": {
+              "$ref": "#/definitions/cos_mapping"
+            }
+          }
+        },
+        "segment": {
+          "$ref": "#/definitions/configuration_module_segment_metadata"
+        }
+      },
+      "required": [
+        "rules",
+        "webProxy",
+        "segment"
+      ]
+    },
+    "QOS_business_rules": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "match": {
+          "type": "object",
+          "properties": {
+            "appid": {
+              "type": "integer"
+            },
+            "classid": {
+              "type": "integer"
+            },
+            "dscp": {
+              "type": "integer",
+              "description": "Integer ID indicating DSCP classification, where mappings are as follows: [EF:46,VA:44,AF11:10,AF12:12,AF13:14,AF21:18,AF22:20,AF23:22,AF31:26,AF32:28,AF33:30,AF41:34,AF42:36,AF43:38,CS0:0,CS1:8,CS2:16,CS3:24,CS4:32,CS5:40,CS6:48,CS7:56]"
+            },
+            "sip": {
+              "type": "string"
+            },
+            "sport_high": {
+              "type": "integer"
+            },
+            "sport_low": {
+              "type": "integer"
+            },
+            "ssm": {
+              "type": "string"
+            },
+            "svlan": {
+              "type": "integer"
+            },
+            "os_version": {
+              "type": "integer",
+              "description": "Index corresponding to the OS in the array: [OTHER,WINDOWS,LINUX,MACOS,IOS,ANDROID,EDGE]"
+            },
+            "hostname": {
+              "type": "string"
+            },
+            "dip": {
+              "type": "string"
+            },
+            "dport_low": {
+              "type": "integer"
+            },
+            "dport_high": {
+              "type": "integer"
+            },
+            "dsm": {
+              "type": "string"
+            },
+            "dvlan": {
+              "type": "integer"
+            },
+            "proto": {
+              "type": "integer"
+            },
+            "s_rule_type": {
+              "type": "string",
+              "enum": [
+                "exact",
+                "prefix",
+                "wildcard",
+                "netmask"
+              ]
+            },
+            "d_rule_type": {
+              "type": "string",
+              "enum": [
+                "exact",
+                "prefix",
+                "wildcard",
+                "netmask"
+              ]
+            }
+          }
+        },
+        "action": {
+          "type": "object",
+          "properties": {
+            "routeType": {
+              "type": "string"
+            },
+            "edge2EdgeRouteAction": {
+              "$ref": "#/definitions/route_action_object"
+            },
+            "edge2DataCenterRouteAction": {
+              "$ref": "#/definitions/route_action_object"
+            },
+            "edge2CloudRouteAction": {
+              "$ref": "#/definitions/route_action_object"
+            },
+            "QoS": {
+              "type": "object"
+            },
+            "sla": {
+              "type": "object"
+            }
+          }
+        },
+        "ruleLogicalId": {
+          "type": "string",
+          "description": "Globally unique identifier for the policy rule"
+        }
+      }
+    },
+    "route_action_object": {
+      "type": "object",
+      "properties": {
+        "interface": {
+          "type": "string"
+        },
+        "linkInternalLogicalId": {
+          "type": "string"
+        },
+        "linkPolicy": {
+          "type": "string"
+        },
+        "routeCfg": {
+          "type": "object"
+        },
+        "routePolicy": {
+          "type": "string"
+        },
+        "serviceGroup": {
+          "type": "string"
+        },
+        "vlanId": {
+          "type": "integer"
+        },
+        "wanlink": {
+          "type": "string"
+        },
+        "linkCosLogicalId": {
+          "type": "string"
+        },
+        "linkOuterDscpTag": {
+          "type": "string"
+        },
+        "linkInnerDscpTag": {
+          "type": "string"
+        }
+      }
+    },
+    "cos_mapping": {
+      "type": "object",
+      "properties": {
+        "high": {
+          "$ref": "#/definitions/cos_mapping_value"
+        },
+        "normal": {
+          "$ref": "#/definitions/cos_mapping_value"
+        },
+        "low": {
+          "$ref": "#/definitions/cos_mapping_value"
+        }
+      }
+    },
+    "cos_mapping_value": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "integer"
+        },
+        "ratelimit": {
+          "type": "boolean"
+        }
+      }
+    },
+    "QOSRefs": {
+      "type": "object",
+      "properties": {
+        "deviceSettings:backHaulEdge": {
+          "type": "object"
+        },
+        "deviceSettings:dataCenter": {
+          "type": "object"
+        }
+      }
+    },
+    "edgeDeviceSettings": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/edgeDeviceSettingsData"
+            },
+            "refs": {
+              "$ref": "#/definitions/deviceSettingsRefs"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "edgeDeviceSettingsData": {
+      "type": "object",
+      "properties": {
+        "bgp": {
+          "type": "object",
+          "properties": {
+            "ASN": {
+              "type": "string"
+            },
+            "connectedRoutes": {
+              "type": "boolean"
+            },
+            "disableASPathCarryOver": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "filters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/bgp_filter_rule"
+                    }
+                  }
+                }
+              }
+            },
+            "holdtime": {
+              "type": "string"
+            },
+            "keepalive": {
+              "type": "string"
+            },
+            "neighbors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/config_edge_bgp_neighbor"
+              }
+            },
+            "networks": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "cidrIp": {
+                    "type": "string"
+                  },
+                  "cidrPrefix": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "overlayPrefix": {
+              "type": "boolean"
+            },
+            "propagateUplink": {
+              "type": "boolean"
+            },
+            "routerId": {
+              "type": "string"
+            },
+            "uplinkCommunity": {
+              "type": "integer"
+            }
+          }
+        },
+        "lan": {
+          "type": "object",
+          "properties": {
+            "networks": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "space": {
+                    "type": "string"
+                  },
+                  "guest": {
+                    "type": "boolean"
+                  },
+                  "secure": {
+                    "type": "boolean"
+                  },
+                  "advertise": {
+                    "type": "boolean"
+                  },
+                  "pingResponse": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "cost": {
+                    "type": "integer"
+                  },
+                  "dhcp": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "leaseTimeSeconds": {
+                        "type": "integer"
+                      },
+                      "override": {
+                        "type": "boolean"
+                      },
+                      "dhcpRelay": {
+                        "type": "object",
+                        "properties": {
+                          "servers": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "staticReserved": {
+                    "type": "integer"
+                  },
+                  "netmask": {
+                    "type": "string"
+                  },
+                  "cidrPrefix": {
+                    "type": "integer"
+                  },
+                  "cidrIp": {
+                    "type": "string"
+                  },
+                  "baseDhcpAddr": {
+                    "type": "integer",
+                    "description": "An offset from the cidrIp including staticReserved (if any)"
+                  },
+                  "numDhcpAddr": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "interfaces": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "vlanId": {
+                    "type": "integer"
+                  },
+                  "managementIp": {
+                    "type": "string"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "routedInterfaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addressing": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "DHCP",
+                      "STATIC",
+                      "PPPOE"
+                    ]
+                  },
+                  "cidrPrefix": {
+                    "type": "integer"
+                  },
+                  "cidrIp": {
+                    "type": "string"
+                  },
+                  "netmask": {
+                    "type": "string"
+                  },
+                  "gateway": {
+                    "type": "string"
+                  },
+                  "username": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  }
+                }
+              },
+              "advertise": {
+                "type": "boolean"
+              },
+              "pingResponse": {
+                "type": "boolean",
+                "default": true
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "dhcpServer": {
+                "$ref": "#/definitions/edgeDeviceSettingsDataDhcpServer"
+              },
+              "encryptOverlay": {
+                "type": "boolean"
+              },
+              "l2": {
+                "type": "object",
+                "properties": {
+                  "autonegotiation": {
+                    "type": "boolean"
+                  },
+                  "speed": {
+                    "type": "string"
+                  },
+                  "duplex": {
+                    "type": "string"
+                  },
+                  "MTU": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "name": {
+                "type": "string"
+              },
+              "natDirect": {
+                "type": "boolean"
+              },
+              "ospf": {
+                "type": "object",
+                "properties": {
+                  "area": {
+                    "type": "integer"
+                  },
+                  "authentication": {
+                    "type": "boolean"
+                  },
+                  "authId": {
+                    "type": "integer"
+                  },
+                  "authPassphrase": {
+                    "type": "string"
+                  },
+                  "cost": {
+                    "type": "integer"
+                  },
+                  "deadTimer": {
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "helloTimer": {
+                    "type": "integer"
+                  },
+                  "inboundRouteLearning": {
+                    "type": "object",
+                    "properties": {
+                      "defaultAction": {
+                        "type": "string"
+                      },
+                      "filters": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  },
+                  "md5Authentication": {
+                    "type": "boolean"
+                  },
+                  "MTU": {
+                    "type": "integer"
+                  },
+                  "outboundRouteAdvertisement": {
+                    "type": "object",
+                    "properties": {
+                      "defaultAction": {
+                        "type": "string"
+                      },
+                      "filters": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  },
+                  "passive": {
+                    "type": "boolean"
+                  },
+                  "vlanId": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "override": {
+                "type": "boolean"
+              },
+              "subinterfaces": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "addressing": {
+                      "type": "object",
+                      "properties": {
+                        "cidrIp": {
+                          "type": "string"
+                        },
+                        "cidrPrefix": {
+                          "type": "integer"
+                        },
+                        "gateway": {
+                          "type": "string"
+                        },
+                        "netmask": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "DHCP",
+                            "STATIC",
+                            "PPPOE"
+                          ]
+                        },
+                        "username": {
+                          "type": "string"
+                        },
+                        "password": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "advertise": {
+                      "type": "boolean"
+                    },
+                    "pingResponse": {
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "dhcpServer": {
+                      "$ref": "#/definitions/edgeDeviceSettingsDataDhcpServer"
+                    },
+                    "disabled": {
+                      "type": "boolean"
+                    },
+                    "natDirect": {
+                      "type": "boolean"
+                    },
+                    "ospf": {
+                      "type": "object",
+                      "properties": {
+                        "area": {
+                          "type": "integer"
+                        },
+                        "authentication": {
+                          "type": "boolean"
+                        },
+                        "authId": {
+                          "type": "integer"
+                        },
+                        "authPassphrase": {
+                          "type": "string"
+                        },
+                        "cost": {
+                          "type": "integer"
+                        },
+                        "deadTimer": {
+                          "type": "integer"
+                        },
+                        "mode": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "helloTimer": {
+                          "type": "integer"
+                        },
+                        "inboundRouteLearning": {
+                          "type": "object",
+                          "properties": {
+                            "defaultAction": {
+                              "type": "string"
+                            },
+                            "filters": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          }
+                        },
+                        "md5Authentication": {
+                          "type": "boolean"
+                        },
+                        "MTU": {
+                          "type": "integer"
+                        },
+                        "outboundRouteAdvertisement": {
+                          "type": "object",
+                          "properties": {
+                            "defaultAction": {
+                              "type": "string"
+                            },
+                            "filters": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          }
+                        },
+                        "passive": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "override": {
+                      "type": "boolean"
+                    },
+                    "subinterfaceId": {
+                      "type": "integer"
+                    },
+                    "subinterfaceType": {
+                      "type": "string"
+                    },
+                    "vlanId": {
+                      "type": "integer",
+                      "description": "static only"
+                    },
+                    "trusted": {
+                      "type": "boolean"
+                    },
+                    "rpf": {
+                      "type": "string",
+                      "enum": [
+                        "SPECIFIC",
+                        "LOOSE",
+                        "DISABLED"
+                      ]
+                    }
+                  }
+                }
+              },
+              "vlanId": {
+                "type": "integer",
+                "description": "static only"
+              },
+              "wanOverlay": {
+                "type": "string",
+                "enum": [
+                  "DISABLED",
+                  "AUTO_DISCOVERED",
+                  "USER_DEFINED"
+                ]
+              },
+              "trusted": {
+                "type": "boolean"
+              },
+              "rpf": {
+                "type": "string",
+                "enum": [
+                  "SPECIFIC",
+                  "LOOSE",
+                  "DISABLED"
+                ]
+              },
+              "underlayAccounting": {
+                "type": "boolean",
+                "default": true
+              }
+            }
+          }
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "icmpProbes": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "icmpResponders": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "static": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "destination": {
+                    "type": "string"
+                  },
+                  "netmask": {
+                    "type": "string"
+                  },
+                  "sourceIp": {
+                    "type": "string"
+                  },
+                  "gateway": {
+                    "type": "string"
+                  },
+                  "cost": {
+                    "type": "integer"
+                  },
+                  "preferred": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "cidrPrefix": {
+                    "type": "string"
+                  },
+                  "wanInterface": {
+                    "type": "string"
+                  },
+                  "icmpProbeLogicalId": {
+                    "type": "string"
+                  },
+                  "vlanId": {
+                    "type": "integer"
+                  },
+                  "advertise": {
+                    "type": "boolean"
+                  },
+                  "subinterfaceId": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ha": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "interface": {
+              "type": "string"
+            }
+          }
+        },
+        "dns": {
+          "type": "object",
+          "properties": {
+            "primaryProvider": {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string"
+                }
+              }
+            },
+            "backupProvider": {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string"
+                }
+              }
+            },
+            "privateProviders": {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "netflow": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "collectors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vqm": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "protocol": {
+              "type": "string"
+            },
+            "collectors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vrrp": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "cidrIp": {
+                    "type": "string"
+                  },
+                  "interface": {
+                    "type": "string"
+                  },
+                  "interval": {
+                    "type": "integer"
+                  },
+                  "preempt": {
+                    "type": "boolean"
+                  },
+                  "preemptDelay": {
+                    "type": "integer"
+                  },
+                  "priority": {
+                    "type": "integer"
+                  },
+                  "subinterfaceId": {
+                    "type": "integer"
+                  },
+                  "vlanId": {
+                    "type": "integer"
+                  },
+                  "vrid": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "snmp": {
+          "type": "object",
+          "properties": {
+            "port": {
+              "type": "integer"
+            },
+            "snmpv2c": {
+              "type": "object",
+              "properties": {
+                "enable": {
+                  "type": "boolean"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "community": {
+                  "type": "string"
+                },
+                "allowedIp": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "snmpv3": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "enable": {
+                  "type": "boolean"
+                },
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "passphrase": {
+                        "type": "string"
+                      },
+                      "authAlg": {
+                        "type": "string"
+                      },
+                      "privacy": {
+                        "type": "boolean"
+                      },
+                      "encrAlg": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multiSourceQos": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "highRatio": {
+              "type": "integer"
+            },
+            "normalRatio": {
+              "type": "integer"
+            },
+            "lowRatio": {
+              "type": "integer"
+            },
+            "maxCapThreshold": {
+              "type": "integer"
+            },
+            "minCapThreshold": {
+              "type": "integer"
+            }
+          }
+        },
+        "tacacs": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string"
+            },
+            "sourceInterface": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "edgeDeviceSettingsDataDhcpServer": {
+      "type": "object",
+      "properties": {
+        "baseDhcpAddr": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "leaseTimeSeconds": {
+          "type": "integer"
+        },
+        "dhcpRelay": {
+          "type": "object",
+          "properties": {
+            "servers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "numDhcpAddr": {
+          "type": "integer"
+        },
+        "staticReserved": {
+          "type": "integer"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "option": {
+                "type": "integer"
+              },
+              "value": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "metaData": {
+                "type": "object",
+                "properties": {
+                  "dataType": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "display": {
+                    "type": "boolean"
+                  },
+                  "list": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "option": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "deviceSettings": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/deviceSettingsData"
+            },
+            "refs": {
+              "$ref": "#/definitions/deviceSettingsRefs"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "segmentBasedDeviceSettings": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/segmentBasedDeviceSettingsData"
+            },
+            "refs": {
+              "$ref": "#/definitions/deviceSettingsRefs"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "deviceSettingsRefs": {
+      "type": "object",
+      "properties": {
+        "deviceSettings:authentication": {
+          "type": "object"
+        },
+        "deviceSettings:css:provider": {
+          "type": "object"
+        },
+        "deviceSettings:css:site": {
+          "type": "object"
+        },
+        "deviceSettings:dns:backupProvider": {
+          "type": "object"
+        },
+        "deviceSettings:dns:primaryProvider": {
+          "type": "object"
+        },
+        "deviceSettings:dns:privateProviders": {
+          "type": "object"
+        },
+        "deviceSettings:handOffGateways:gateways": {
+          "type": "object"
+        },
+        "deviceSettings:lan:allocation": {
+          "type": "object"
+        },
+        "deviceSettings:securityVnf:license": {
+          "type": "object"
+        },
+        "deviceSettings:securityVnf:service": {
+          "type": "object"
+        },
+        "deviceSettings:segment": {
+          "type": "object"
+        },
+        "deviceSettings:segment:netflowCollectors": {
+          "type": "object"
+        },
+        "deviceSettings:segment:netflowFilters": {
+          "type": "object"
+        },
+        "deviceSettings:tacacs": {
+          "type": "object"
+        },
+        "deviceSettings:vnfs:edge": {
+          "type": "object"
+        },
+        "deviceSettings:vnfs:vnfImage": {
+          "type": "object"
+        },
+        "deviceSettings:vpn:dataCenter": {
+          "type": "object"
+        },
+        "deviceSettings:vpn:edgeHub": {
+          "type": "object"
+        },
+        "deviceSettings:vpn:edgeHubCluster": {
+          "type": "object"
+        },
+        "deviceSettings:webProxy:provider": {
+          "type": "object"
+        }
+      }
+    },
+    "ref": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "configurationId": {
+          "type": "integer"
+        },
+        "moduleId": {
+          "type": "integer"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "enterpriseObjectId": {
+          "type": "integer"
+        },
+        "segmentLogicalId": {
+          "type": "string"
+        },
+        "segmentObjectId": {
+          "type": "integer"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "configurationId",
+        "moduleId",
+        "logicalId",
+        "enterpriseObjectId",
+        "segmentLogicalId",
+        "segmentObjectId"
+      ]
+    },
+    "deviceSettingsData": {
+      "type": "object",
+      "properties": {
+        "lan": {
+          "type": "object",
+          "properties": {
+            "allocation": {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string"
+                },
+                "assignableVlans": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "managementVlans": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ospf": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "areas": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "bgp": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "asn": {
+              "type": "string"
+            },
+            "neighbors": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "dns": {
+          "type": "object",
+          "properties": {
+            "primaryProvider": {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string"
+                }
+              }
+            },
+            "backupProvider": {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string"
+                }
+              }
+            },
+            "privateProviders": {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "authentication": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string"
+            }
+          }
+        },
+        "softwareUpdate": {
+          "type": "object",
+          "properties": {
+            "windowed": {
+              "type": "boolean"
+            },
+            "window": {
+              "type": "object",
+              "properties": {
+                "day": {
+                  "type": "integer"
+                },
+                "beginHour": {
+                  "type": "integer"
+                },
+                "endHour": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "radioSettings": {
+          "type": "object",
+          "properties": {
+            "country": {
+              "type": "string"
+            },
+            "radios": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "radioId": {
+                    "type": "integer"
+                  },
+                  "isEnabled": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "band": {
+                    "type": "string"
+                  },
+                  "channel": {
+                    "type": "string"
+                  },
+                  "width": {
+                    "type": "string"
+                  },
+                  "mode": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "netflow": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "collectors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vqm": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "protocol": {
+              "type": "string"
+            },
+            "collectors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "snmp": {
+          "type": "object",
+          "properties": {
+            "port": {
+              "type": "integer"
+            },
+            "snmpv2c": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "community": {
+                  "type": "string"
+                },
+                "allowedIp": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "snmpv3": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "passphrase": {
+                        "type": "string"
+                      },
+                      "authAlg": {
+                        "type": "string"
+                      },
+                      "privacy": {
+                        "type": "boolean"
+                      },
+                      "encrAlg": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multiSourceQos": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "highRatio": {
+              "type": "integer"
+            },
+            "normalRatio": {
+              "type": "integer"
+            },
+            "lowRatio": {
+              "type": "integer"
+            },
+            "maxCapThreshold": {
+              "type": "integer"
+            },
+            "minCapThreshold": {
+              "type": "integer"
+            }
+          }
+        },
+        "models": {
+          "type": "object",
+          "properties": {
+            "virtual": {
+              "type": "object",
+              "properties": {
+                "routedInterfaces": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "disabled": {
+                        "type": "boolean"
+                      },
+                      "addressing": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "cidrPrefix": {
+                            "type": "integer"
+                          },
+                          "cidrIp": {
+                            "type": "string"
+                          },
+                          "netmask": {
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "wanOverlay": {
+                        "type": "string"
+                      },
+                      "natDirect": {
+                        "type": "boolean"
+                      },
+                      "ospf": {
+                        "type": "object",
+                        "properties": {
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "area": {
+                            "type": "integer"
+                          },
+                          "authentication": {
+                            "type": "boolean"
+                          },
+                          "authId": {
+                            "type": "integer"
+                          },
+                          "authPassphrase": {
+                            "type": "string"
+                          },
+                          "helloTimer": {
+                            "type": "integer"
+                          },
+                          "deadTimer": {
+                            "type": "integer"
+                          },
+                          "mode": {
+                            "type": "string"
+                          },
+                          "md5Authentication": {
+                            "type": "boolean"
+                          },
+                          "cost": {
+                            "type": "integer"
+                          },
+                          "MTU": {
+                            "type": "integer"
+                          },
+                          "passive": {
+                            "type": "boolean"
+                          },
+                          "inboundRouteLearning": {
+                            "type": "object",
+                            "properties": {
+                              "defaultAction": {
+                                "type": "string"
+                              },
+                              "filters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          },
+                          "outboundRouteAdvertisement": {
+                            "type": "object",
+                            "properties": {
+                              "defaultAction": {
+                                "type": "string"
+                              },
+                              "filters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "vlanId": {
+                        "type": "integer"
+                      },
+                      "l2": {
+                        "type": "object",
+                        "properties": {
+                          "autonegotiation": {
+                            "type": "boolean"
+                          },
+                          "speed": {
+                            "type": "string"
+                          },
+                          "duplex": {
+                            "type": "string"
+                          },
+                          "MTU": {
+                            "type": "integer"
+                          }
+                        }
+                      },
+                      "underlayAccounting": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "trusted": {
+                        "type": "boolean"
+                      },
+                      "rpf": {
+                        "type": "string",
+                        "enum": [
+                          "SPECIFIC",
+                          "LOOSE",
+                          "DISABLED"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "lan": {
+                  "type": "object",
+                  "properties": {
+                    "interfaces": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "space": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "cwp": {
+                            "type": "boolean"
+                          },
+                          "portMode": {
+                            "type": "string"
+                          },
+                          "untaggedVlan": {
+                            "type": "string"
+                          },
+                          "disabled": {
+                            "type": "boolean"
+                          },
+                          "l2": {
+                            "type": "object",
+                            "properties": {
+                              "autonegotiation": {
+                                "type": "boolean"
+                              },
+                              "speed": {
+                                "type": "string"
+                              },
+                              "duplex": {
+                                "type": "string"
+                              },
+                              "MTU": {
+                                "type": "integer"
+                              }
+                            }
+                          },
+                          "vlanIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vpn": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "edgeToDataCenter": {
+              "type": "boolean"
+            },
+            "ref": {
+              "type": "string"
+            },
+            "edgeToEdgeHub": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "ref": {
+                  "type": "string"
+                }
+              }
+            },
+            "edgeToEdge": {
+              "type": "boolean"
+            },
+            "edgeToEdgeDetail": {
+              "type": "object",
+              "properties": {
+                "useCloudGateway": {
+                  "type": "boolean"
+                },
+                "encryptionProtocol": {
+                  "type": "string"
+                },
+                "dynamic": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "vpnHubs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "autoSelectVpnHubs": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "segmentBasedDeviceSettingsData": {
+      "type": "object",
+      "properties": {
+        "ha": {
+          "$ref": "#/definitions/device_settings_ha"
+        },
+        "lan": {
+          "$ref": "#/definitions/device_settings_lan"
+        },
+        "models": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/device_settings_model"
+          }
+        },
+        "multiSourceQos": {
+          "$ref": "#/definitions/device_settings_multi_source_qos"
+        },
+        "ntp": {
+          "$ref": "#/definitions/device_settings_ntp"
+        },
+        "radioSettings": {
+          "$ref": "#/definitions/device_settings_radio_settings"
+        },
+        "routedInterfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_routed_interface"
+          }
+        },
+        "segments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_segment"
+          }
+        },
+        "snmp": {
+          "$ref": "#/definitions/device_settings_snmp"
+        },
+        "softwareUpdate": {
+          "$ref": "#/definitions/device_settings_software_update"
+        },
+        "tacacs": {
+          "$ref": "#/definitions/device_settings_tacacs"
+        },
+        "vnfs": {
+          "$ref": "#/definitions/device_settings_vnfs"
+        }
+      }
+    },
+    "device_settings_authentication": {
+      "type": "object",
+      "properties": {
+        "override": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": "string",
+          "enum": [
+            "deviceSettings:authentication"
+          ]
+        }
+      }
+    },
+    "device_settings_bgp": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "ASN": {
+          "type": "string"
+        },
+        "connectedRoutes": {
+          "type": "boolean"
+        },
+        "defaultRoute": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "advertise": {
+              "type": "string"
+            }
+          }
+        },
+        "disableASPathCarryOver": {
+          "type": "boolean"
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_bgp_filter"
+          }
+        },
+        "holdtime": {
+          "type": "string"
+        },
+        "isEdge": {
+          "type": "boolean"
+        },
+        "keepalive": {
+          "type": "string"
+        },
+        "neighbors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_bgp_neighbor"
+          }
+        },
+        "networks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_bgp_network"
+          }
+        },
+        "ospf": {
+          "$ref": "#/definitions/device_settings_bgp_ospf_redistribution"
+        },
+        "overlayPrefix": {
+          "type": "boolean"
+        },
+        "propagateUplink": {
+          "type": "boolean"
+        },
+        "routerId": {
+          "type": "string"
+        },
+        "uplinkCommunity": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_bgp_filter": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_bgp_filter_rule"
+          }
+        }
+      }
+    },
+    "device_settings_bgp_filter_rule": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "PERMIT",
+                "DENY"
+              ]
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "AS_PATH_PREPEND",
+                      "METRIC",
+                      "LOCAL_PREFERENCE",
+                      "COMMUNITY"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "match": {
+          "type": "object",
+          "properties": {
+            "exactMatch": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "COMMUNITY",
+                "PREFIX"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "device_settings_bgp_neighbor": {
+      "type": "object",
+      "properties": {
+        "neighborAS": {
+          "type": "string"
+        },
+        "neighborIp": {
+          "type": "string"
+        },
+        "neighborTag": {
+          "type": "string",
+          "enum": [
+            "UPLINK"
+          ]
+        },
+        "inboundFilter": {
+          "$ref": "#/definitions/device_settings_bgp_filter_set"
+        },
+        "outboundFilter": {
+          "$ref": "#/definitions/device_settings_bgp_filter_set"
+        },
+        "allowAS": {
+          "type": "boolean"
+        },
+        "connect": {
+          "type": "string"
+        },
+        "defaultRoute": {
+          "type": "boolean"
+        },
+        "holdtime": {
+          "type": "string"
+        },
+        "keepalive": {
+          "type": "string"
+        },
+        "enableMd5": {
+          "type": "boolean"
+        },
+        "md5Password": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_bgp_filter_set": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "device_settings_bgp_network": {
+      "type": "object",
+      "properties": {
+        "cidrIp": {
+          "type": "string"
+        },
+        "cidrPrefix": {
+          "type": "integer"
+        },
+        "segmentId": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_bgp_ospf_redistribution": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "metric": {
+          "type": "integer"
+        }
+      }
+    },
+    "device_settings_cloud_security": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "config": {
+          "type": "object",
+          "properties": {
+            "tunnelingProtocol": {
+              "type": "string",
+              "enum": [
+                "GRE",
+                "IPSEC"
+              ]
+            },
+            "authenticationAlgorithm": {
+              "type": "string"
+            },
+            "encryptionAlgorithm": {
+              "type": "string"
+            },
+            "redirect": {
+              "type": "string"
+            },
+            "IKEPROP": {
+              "type": "object",
+              "properties": {
+                "protocolVersion": {
+                  "type": "integer"
+                }
+              }
+            },
+            "GREPROP": {
+              "type": "object",
+              "properties": {
+                "keepaliveIntervalSecs": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 30
+                },
+                "keepaliveRetries": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 10
+                }
+              }
+            }
+          }
+        },
+        "provider": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string",
+              "enum": [
+                "deviceSettings:css:provider"
+              ]
+            }
+          }
+        },
+        "sites": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_cloud_security_site"
+          }
+        }
+      }
+    },
+    "device_settings_cloud_security_site": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/cloud_security_service_site_data"
+        },
+        "logicalId": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_dns": {
+      "type": "object",
+      "properties": {
+        "override": {
+          "type": "boolean"
+        },
+        "primaryProvider": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string",
+              "enum": [
+                "deviceSettings:dns:primaryProvider"
+              ]
+            }
+          }
+        },
+        "backupProvider": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string",
+              "enum": [
+                "deviceSettings:dns:backupProvider"
+              ]
+            }
+          }
+        },
+        "privateProviders": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string",
+              "enum": [
+                "deviceSettings:dns:privateProviders"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "device_settings_ha": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "interface": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_handoff_gateways": {
+      "type": "object",
+      "properties": {
+        "override": {
+          "type": "boolean"
+        },
+        "autoSelect": {
+          "type": "boolean"
+        },
+        "gatewayList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_handoff_gateway"
+          }
+        },
+        "gateways": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/logicalid_reference"
+          }
+        }
+      }
+    },
+    "device_settings_handoff_gateway": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/logicalid_reference"
+        },
+        {
+          "properties": {
+            "ipsecDetail": {
+              "$ref": "#/definitions/device_settings_handoff_gateway_ipsec_detail"
+            }
+          }
+        }
+      ]
+    },
+    "device_settings_handoff_gateway_ipsec_detail": {
+      "type": "object",
+      "properties": {
+        "ipsecGatewayAddress": {
+          "type": "string"
+        },
+        "strictHostCheck": {
+          "type": "boolean"
+        }
+      }
+    },
+    "device_settings_model": {
+      "type": "object",
+      "properties": {
+        "lan": {
+          "$ref": "#/definitions/device_settings_lan"
+        },
+        "routedInterfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_routed_interface"
+          }
+        }
+      }
+    },
+    "device_settings_multicast": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "igmpHostQueryIntervalSeconds": {
+          "type": "integer"
+        },
+        "igmpMaxQueryResponse": {
+          "type": "integer"
+        },
+        "pimKeepAliveTimerSeconds": {
+          "type": "integer"
+        },
+        "pimOnWanOverlay": {
+          "$ref": "#/definitions/device_settings_multicast_pim_on_wan_overlay"
+        },
+        "pimPruneIntervalSeconds": {
+          "type": "integer"
+        },
+        "rp": {
+          "$ref": "#/definitions/device_settings_multicast_rp"
+        }
+      }
+    },
+    "device_settings_multicast_pim_on_wan_overlay": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "SOURCE_IP"
+          ]
+        },
+        "sourceCidrIp": {
+          "type": "string"
+        },
+        "sourceInterface": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_multicast_rp": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "STATIC"
+          ]
+        },
+        "staticGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_multicast_rp_static_group"
+          }
+        }
+      }
+    },
+    "device_settings_multicast_rp_static_group": {
+      "type": "object",
+      "properties": {
+        "multicastGroups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rpAddress": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_netflow_collector": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "sourceInterface": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "allowAllSegment": {
+          "type": "boolean"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "filterList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_netflow_filter_list"
+          }
+        }
+      }
+    },
+    "device_settings_netflow_filter_list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_nat": {
+      "type": "object",
+      "properties": {
+        "override": {
+          "type": "boolean"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_nat_rule"
+          },
+          "maxItems": 256
+        }
+      }
+    },
+    "device_settings_nat_rule": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "source",
+            "destination"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "insideCidrIp": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "insideCidrPrefix": {
+          "type": "integer"
+        },
+        "insideNetmask": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "insidePort": {
+          "type": "integer"
+        },
+        "outsideCidrIp": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "outsideCidrPrefix": {
+          "type": "integer"
+        },
+        "outsideNetmask": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "outsidePort": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "type",
+        "insideCidrIp",
+        "insideCidrPrefix",
+        "insideNetmask",
+        "outsideCidrIp",
+        "outsideCidrPrefix",
+        "outsideNetmask"
+      ]
+    },
+    "device_settings_netflow": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "collectors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_netflow_collector"
+          }
+        },
+        "version": {
+          "type": "integer"
+        },
+        "intervals": {
+          "type": "object",
+          "properties": {
+            "flowStats": {
+              "type": "integer"
+            },
+            "flowLinkStats": {
+              "type": "integer"
+            },
+            "vrfTable": {
+              "type": "integer"
+            },
+            "applicationTable": {
+              "type": "integer"
+            },
+            "interfaceTable": {
+              "type": "integer"
+            },
+            "linkTable": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "netflow_collector": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/netflow_collector_data"
+            }
+          }
+        }
+      ]
+    },
+    "netflow_collector_data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "address",
+        "port"
+      ]
+    },
+    "device_settings_vqm_collector": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        }
+      }
+    },
+    "device_settings_ospf": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "areas": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_ospf_area"
+          }
+        },
+        "bgp": {
+          "$ref": "#/definitions/device_settings_ospf_bgp_redistribution"
+        },
+        "defaultPrefixes": {
+          "type": "boolean"
+        },
+        "defaultRouteAdvertise": {
+          "type": "string",
+          "enum": [
+            "ALWAYS",
+            "CONDITIONAL"
+          ]
+        },
+        "defaultRoutes": {
+          "type": "string",
+          "enum": [
+            "OE1",
+            "OE2",
+            "NONE"
+          ]
+        }
+      }
+    },
+    "device_settings_ospf_area": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_ospf_bgp_redistribution": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "metric": {
+          "type": "integer"
+        },
+        "metricType": {
+          "type": "string",
+          "enum": [
+            "E1",
+            "E2"
+          ]
+        }
+      }
+    },
+    "device_settings_syslog": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "facilityCode": {
+          "type": "string",
+          "enum": [
+            "local0",
+            "local1",
+            "local2",
+            "local3",
+            "local4",
+            "local5",
+            "local6",
+            "local7"
+          ]
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "collectors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_syslog_collector"
+          }
+        }
+      },
+      "required": [
+        "collectors",
+        "enabled"
+      ]
+    },
+    "device_settings_syslog_collector": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "TCP",
+            "UDP"
+          ]
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "EDGE EVENT"
+            ]
+          }
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "EMERG",
+            "ALERT",
+            "CRIT",
+            "ERR",
+            "WARNING",
+            "NOTICE",
+            "INFO",
+            "DEBUG"
+          ]
+        },
+        "sourceInterface": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "host",
+        "port",
+        "protocol",
+        "roles",
+        "severity",
+        "sourceInterface"
+      ]
+    },
+    "device_settings_icmp_probe": {
+      "type": "object"
+    },
+    "device_settings_icmp_responder": {
+      "type": "object"
+    },
+    "device_settings_static_route": {
+      "type": "object",
+      "properties": {
+        "destination": {
+          "type": "string"
+        },
+        "netmask": {
+          "type": "string"
+        },
+        "sourceIp": {
+          "type": "string"
+        },
+        "gateway": {
+          "type": "string"
+        },
+        "cost": {
+          "type": "integer"
+        },
+        "preferred": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "cidrPrefix": {
+          "type": "string"
+        },
+        "wanInterface": {
+          "type": "string"
+        },
+        "icmpProbeLogicalId": {
+          "type": "string"
+        },
+        "vlanId": {
+          "type": "integer"
+        },
+        "advertise": {
+          "type": "boolean"
+        },
+        "subinterfaceId": {
+          "type": "integer"
+        }
+      }
+    },
+    "configuration_module_segment_metadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "segmentId": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "REGULAR",
+            "CDE"
+          ]
+        }
+      }
+    },
+    "device_settings_vpn": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "edgeToDataCenter": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": "string",
+          "enum": [
+            "deviceSettings:vpn:dataCenter"
+          ]
+        },
+        "isolationGroupId": {
+          "type": "string"
+        },
+        "edgeToEdgeHub": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "ref": {
+              "type": "string",
+              "enum": [
+                "deviceSettings:vpn:edgeHub"
+              ]
+            }
+          }
+        },
+        "edgeToEdge": {
+          "type": "boolean"
+        },
+        "edgeToEdgeDetail": {
+          "type": "object",
+          "properties": {
+            "autoSelectVpnHubs": {
+              "type": "boolean"
+            },
+            "dynamic": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "isolation": {
+                  "$ref": "#/definitions/device_settings_vpn_profile_isolation"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "timeout": {
+                  "type": "integer"
+                }
+              }
+            },
+            "encryptionProtocol": {
+              "type": "string"
+            },
+            "profileIsolation": {
+              "$ref": "#/definitions/device_settings_vpn_profile_isolation_deprecated"
+            },
+            "isolation": {
+              "$ref": "#/definitions/device_settings_vpn_profile_isolation"
+            },
+            "isolationGroupId": {
+              "type": "string"
+            },
+            "isolationGroups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "logicalId": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "useCloudGateway": {
+              "type": "boolean"
+            },
+            "vpnHubs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/device_settings_vpn_hub"
+              }
+            }
+          }
+        }
+      }
+    },
+    "device_settings_vpn_profile_isolation_deprecated": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "profileLogicalId": {
+          "type": "string"
+        },
+        "isolateDynamic": {
+          "type": "boolean"
+        }
+      }
+    },
+    "device_settings_vpn_profile_isolation": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "device_settings_vpn_profile_isolation_group": {
+      "type": "object",
+      "properties": {
+        "logicalId": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_vpn_hub": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/logicalid_reference"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "edgeHub",
+                "edgeHubCluster"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "device_settings_vqm": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "RFC6035"
+          ]
+        },
+        "collectors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_vqm_collector"
+          }
+        }
+      }
+    },
+    "device_settings_vrrp": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_vrrp_virtual_router"
+          }
+        }
+      }
+    },
+    "device_settings_vrrp_virtual_router": {
+      "type": "object",
+      "properties": {
+        "cidrIp": {
+          "type": "string"
+        },
+        "interface": {
+          "type": "string"
+        },
+        "interval": {
+          "type": "integer"
+        },
+        "preempt": {
+          "type": "boolean"
+        },
+        "preemptDelay": {
+          "type": "integer"
+        },
+        "priority": {
+          "type": "integer"
+        },
+        "subinterfaceId": {
+          "type": "integer"
+        },
+        "vlanId": {
+          "type": "integer"
+        },
+        "vrid": {
+          "type": "integer"
+        }
+      }
+    },
+    "device_settings_lan": {
+      "type": "object",
+      "properties": {
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_lan_interface"
+          }
+        },
+        "management": {
+          "$ref": "#/definitions/subnet"
+        },
+        "networks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_lan_network"
+          }
+        },
+        "visibility": {
+          "type": "object",
+          "properties": {
+            "override": {
+              "type": "boolean"
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "MAC",
+                "IP"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "device_settings_lan_interface": {
+      "type": "object",
+      "properties": {
+        "override": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "cwp": {
+          "type": "boolean"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "l2": {
+          "type": "object",
+          "properties": {
+            "autonegotiation": {
+              "type": "boolean"
+            },
+            "speed": {
+              "type": "string"
+            },
+            "duplex": {
+              "type": "string",
+              "enum": [
+                "FULL",
+                "HALF"
+              ]
+            },
+            "MTU": {
+              "type": "integer"
+            }
+          }
+        },
+        "portMode": {
+          "type": "string",
+          "enum": [
+            "access",
+            "trunk"
+          ]
+        },
+        "space": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "wired",
+            "wireless"
+          ]
+        },
+        "untaggedVlan": {
+          "type": "integer"
+        },
+        "vlanIds": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "authenticationType": {
+          "type": "string",
+          "enum": [
+            "none",
+            "802.1x"
+          ]
+        },
+        "broadcastSsid": {
+          "type": "boolean"
+        },
+        "passphrase": {
+          "type": "string"
+        },
+        "ssid": {
+          "type": "string"
+        },
+        "securityMode": {
+          "type": "string",
+          "enum": [
+            "Open",
+            "WPA2Enterprise",
+            "WPA2Personal"
+          ]
+        }
+      }
+    },
+    "device_settings_lan_network": {
+      "type": "object",
+      "properties": {
+        "override": {
+          "type": "boolean"
+        },
+        "advertise": {
+          "type": "boolean"
+        },
+        "pingResponse": {
+          "type": "boolean",
+          "default": true
+        },
+        "bindEdgeAddress": {
+          "type": "boolean"
+        },
+        "baseDhcpAddr": {
+          "type": "integer"
+        },
+        "cidrIp": {
+          "type": "string"
+        },
+        "cidrPrefix": {
+          "type": "integer"
+        },
+        "cost": {
+          "type": "integer"
+        },
+        "dhcp": {
+          "$ref": "#/definitions/device_settings_dhcp"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "multicast": {
+          "type": "object",
+          "properties": {
+            "igmp": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "IGMP_V2"
+                  ]
+                }
+              }
+            },
+            "igmpHostQueryIntervalSeconds": {
+              "type": "integer"
+            },
+            "igmpMaxQueryResponse": {
+              "type": "integer"
+            },
+            "pim": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "PIM_SM"
+                  ]
+                }
+              }
+            },
+            "pimHelloTimerSeconds": {
+              "type": "integer"
+            },
+            "pimKeepAliveTimerSeconds": {
+              "type": "integer"
+            },
+            "pimPruneIntervalSeconds": {
+              "type": "integer"
+            }
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "netmask": {
+          "type": "string"
+        },
+        "numDhcpAddr": {
+          "type": "integer"
+        },
+        "ospf": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "override": {
+              "type": "boolean"
+            },
+            "area": {
+              "type": "integer"
+            },
+            "passiveInterface": {
+              "type": "boolean"
+            }
+          }
+        },
+        "segmentId": {
+          "type": "integer"
+        },
+        "staticReserved": {
+          "type": "integer"
+        },
+        "vlanId": {
+          "type": "integer"
+        }
+      }
+    },
+    "device_settings_dhcp": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "dhcpRelay": {
+          "$ref": "#/definitions/device_settings_dhcp_relay"
+        },
+        "leaseTimeSeconds": {
+          "type": "integer"
+        },
+        "baseDhcpAddr": {
+          "type": "integer"
+        },
+        "numDhcpAddr": {
+          "type": "integer"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_dhcp_option"
+          }
+        },
+        "override": {
+          "type": "boolean"
+        }
+      }
+    },
+    "device_settings_dhcp_relay": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "device_settings_dhcp_option": {
+      "type": "object",
+      "properties": {
+        "option": {
+          "type": "integer"
+        },
+        "value": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "metaData": {
+          "type": "object",
+          "properties": {
+            "dataType": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "display": {
+              "type": "boolean"
+            },
+            "list": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "option": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "device_settings_multi_source_qos": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "highRatio": {
+          "type": "integer"
+        },
+        "normalRatio": {
+          "type": "integer"
+        },
+        "lowRatio": {
+          "type": "integer"
+        },
+        "maxCapThreshold": {
+          "type": "integer"
+        },
+        "minCapThreshold": {
+          "type": "integer"
+        }
+      }
+    },
+    "device_settings_ntp": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_ntp_server"
+          }
+        }
+      }
+    },
+    "device_settings_ntp_server": {
+      "type": "object",
+      "properties": {
+        "server": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_radio_settings": {
+      "type": "object",
+      "properties": {
+        "country": {
+          "type": "string"
+        },
+        "radios": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_radio"
+          }
+        }
+      }
+    },
+    "device_settings_radio": {
+      "type": "object",
+      "properties": {
+        "band": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "boolean"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "radioId": {
+          "type": "integer"
+        },
+        "width": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_routed_interface": {
+      "type": "object",
+      "properties": {
+        "override": {
+          "type": "boolean"
+        },
+        "addressing": {
+          "$ref": "#/definitions/device_settings_routed_interface_addressing"
+        },
+        "advertise": {
+          "type": "boolean"
+        },
+        "pingResponse": {
+          "type": "boolean",
+          "default": true
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "dhcpServer": {
+          "$ref": "#/definitions/device_settings_dhcp"
+        },
+        "encryptOverlay": {
+          "type": "boolean"
+        },
+        "l2": {
+          "$ref": "#/definitions/device_settings_routed_interface_l2"
+        },
+        "multicast": {
+          "type": "object",
+          "properties": {
+            "igmp": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "IGMP_V2"
+                  ]
+                }
+              }
+            },
+            "igmpHostQueryIntervalSeconds": {
+              "type": "integer"
+            },
+            "igmpMaxQueryResponse": {
+              "type": "integer"
+            },
+            "pim": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "PIM_SM"
+                  ]
+                }
+              }
+            },
+            "pimKeepAliveTimerSeconds": {
+              "type": "integer"
+            },
+            "pimPruneIntervalSeconds": {
+              "type": "integer"
+            },
+            "pimHelloTimerSeconds": {
+              "type": "integer"
+            }
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "natDirect": {
+          "type": "boolean"
+        },
+        "ospf": {
+          "$ref": "#/definitions/device_settings_routed_interface_ospf"
+        },
+        "radiusAuthentication": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "macBypass": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "segmentId": {
+          "type": "integer"
+        },
+        "subinterfaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_subinterface"
+          }
+        },
+        "rpf": {
+          "type": "string",
+          "enum": [
+            "SPECIFIC",
+            "LOOSE",
+            "DISABLED"
+          ]
+        },
+        "trusted": {
+          "type": "boolean"
+        },
+        "underlayAccounting": {
+          "type": "boolean",
+          "default": true
+        },
+        "vlanId": {
+          "type": "integer"
+        },
+        "wanOverlay": {
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "AUTO_DISCOVERED",
+            "USER_DEFINED"
+          ]
+        }
+      }
+    },
+    "device_settings_routed_interface_addressing": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "DHCP",
+            "STATIC",
+            "PPPOE"
+          ]
+        },
+        "cidrPrefix": {
+          "type": "integer"
+        },
+        "cidrIp": {
+          "type": "string"
+        },
+        "netmask": {
+          "type": "string"
+        },
+        "gateway": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_routed_interface_ospf": {
+      "type": "object",
+      "properties": {
+        "area": {
+          "type": "integer"
+        },
+        "authentication": {
+          "type": "boolean"
+        },
+        "authId": {
+          "type": "integer"
+        },
+        "authPassphrase": {
+          "type": "string"
+        },
+        "cost": {
+          "type": "integer"
+        },
+        "deadTimer": {
+          "type": "integer"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "exclusionRoutes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "helloTimer": {
+          "type": "integer"
+        },
+        "inboundRouteLearning": {
+          "$ref": "#/definitions/device_settings_routed_interface_ospf_filter"
+        },
+        "md5Authentication": {
+          "type": "boolean"
+        },
+        "MTU": {
+          "type": "integer"
+        },
+        "outboundRouteAdvertisement": {
+          "$ref": "#/definitions/device_settings_routed_interface_ospf_filter"
+        },
+        "passive": {
+          "type": "boolean"
+        },
+        "vlanId": {
+          "type": "integer"
+        }
+      }
+    },
+    "device_settings_routed_interface_ospf_filter": {
+      "type": "object",
+      "properties": {
+        "defaultAction": {
+          "type": "string",
+          "enum": [
+            "ADVERTISE",
+            "IGNORE",
+            "LEARN"
+          ]
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "cidrIp": {
+                "type": "string"
+              },
+              "cidrPrefix": {
+                "type": "string"
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "ADVERTISE",
+                  "IGNORE",
+                  "LEARN"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "device_settings_routed_interface_l2": {
+      "type": "object",
+      "properties": {
+        "autonegotiation": {
+          "type": "boolean"
+        },
+        "speed": {
+          "type": "string"
+        },
+        "duplex": {
+          "type": "string",
+          "enum": [
+            "FULL",
+            "HALF"
+          ]
+        },
+        "MTU": {
+          "type": "integer"
+        }
+      }
+    },
+    "device_settings_subinterface": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/device_settings_routed_interface"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subinterfaceId": {
+              "type": "integer"
+            },
+            "subinterfaceType": {
+              "type": "string",
+              "enum": [
+                "SECONDARY_IP",
+                "SUB_INTERFACE"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "device_settings_segment": {
+      "type": "object",
+      "properties": {
+        "authentication": {
+          "$ref": "#/definitions/device_settings_authentication"
+        },
+        "bgp": {
+          "$ref": "#/definitions/device_settings_bgp"
+        },
+        "css": {
+          "$ref": "#/definitions/device_settings_cloud_security"
+        },
+        "dns": {
+          "$ref": "#/definitions/device_settings_dns"
+        },
+        "handOffControllers": {
+          "$ref": "#/definitions/device_settings_handoff_gateways"
+        },
+        "handOffGateways": {
+          "$ref": "#/definitions/device_settings_handoff_gateways"
+        },
+        "multiSourceQos": {
+          "$ref": "#/definitions/device_settings_multi_source_qos"
+        },
+        "multicast": {
+          "$ref": "#/definitions/device_settings_multicast"
+        },
+        "nat": {
+          "$ref": "#/definitions/device_settings_nat"
+        },
+        "netflow": {
+          "$ref": "#/definitions/device_settings_netflow"
+        },
+        "ntp": {
+          "$ref": "#/definitions/device_settings_ntp"
+        },
+        "ospf": {
+          "$ref": "#/definitions/device_settings_ospf"
+        },
+        "routes": {
+          "type": "object",
+          "properties": {
+            "icmpProbes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/device_settings_icmp_probe"
+              }
+            },
+            "icmpResponders": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/device_settings_icmp_responder"
+              }
+            },
+            "static": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/device_settings_static_route"
+              }
+            }
+          }
+        },
+        "segment": {
+          "$ref": "#/definitions/configuration_module_segment_metadata"
+        },
+        "snmp": {
+          "$ref": "#/definitions/device_settings_snmp"
+        },
+        "syslog": {
+          "$ref": "#/definitions/device_settings_syslog"
+        },
+        "vpn": {
+          "$ref": "#/definitions/device_settings_vpn"
+        },
+        "vqm": {
+          "$ref": "#/definitions/device_settings_vqm"
+        },
+        "vrrp": {
+          "$ref": "#/definitions/device_settings_vrrp"
+        }
+      }
+    },
+    "device_settings_snmp": {
+      "type": "object",
+      "properties": {
+        "override": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "snmpv2c": {
+          "$ref": "#/definitions/device_settings_snmpv2c"
+        },
+        "snmpv3": {
+          "$ref": "#/definitions/device_settings_snmpv3"
+        }
+      }
+    },
+    "device_settings_snmpv2c": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "community": {
+          "type": "string"
+        },
+        "allowedIp": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "device_settings_snmpv3": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/device_settings_snmpv3_user"
+          }
+        }
+      }
+    },
+    "device_settings_snmpv3_user": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "passphrase": {
+          "type": "string"
+        },
+        "authAlg": {
+          "type": "string"
+        },
+        "privacy": {
+          "type": "boolean"
+        },
+        "encrAlg": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_software_update": {
+      "type": "object",
+      "properties": {
+        "windowed": {
+          "type": "boolean"
+        },
+        "window": {
+          "$ref": "#/definitions/device_settings_software_update_window"
+        }
+      }
+    },
+    "device_settings_software_update_window": {
+      "type": "object",
+      "properties": {
+        "day": {
+          "type": "integer"
+        },
+        "beginHour": {
+          "type": "integer"
+        },
+        "endHour": {
+          "type": "integer"
+        }
+      }
+    },
+    "device_settings_tacacs": {
+      "type": "object",
+      "properties": {
+        "ref": {
+          "type": "string",
+          "enum": [
+            "deviceSettings:tacacs"
+          ]
+        },
+        "sourceInterface": {
+          "type": "string"
+        }
+      }
+    },
+    "device_settings_vnfs": {
+      "type": "object",
+      "properties": {
+        "edge": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/logicalid_reference"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string",
+                  "pattern": "deviceSettings:vnfs:edge"
+                }
+              }
+            }
+          ]
+        },
+        "hasVnfs": {
+          "type": "boolean"
+        },
+        "securityVnf": {
+          "type": "object",
+          "properties": {
+            "vms": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/device_settings_security_vnf_vm"
+              }
+            }
+          }
+        }
+      }
+    },
+    "device_settings_security_vnf_vm": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "securityVnf"
+        },
+        "vendor": {
+          "type": "string",
+          "enum": [
+            "PaloAlto",
+            "CheckPoint",
+            "Fortinet",
+            "CentOS"
+          ]
+        },
+        "edge": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/logicalid_reference"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string",
+                  "pattern": "deviceSettings:vnfs:edge"
+                }
+              }
+            }
+          ]
+        },
+        "license": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/logicalid_reference"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string",
+                  "pattern": "deviceSettings:securityVnf:license"
+                }
+              }
+            }
+          ]
+        },
+        "service": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/logicalid_reference"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string",
+                  "pattern": "deviceSettings:securityVnf:service"
+                }
+              }
+            }
+          ]
+        },
+        "uuid": {
+          "type": "string"
+        },
+        "uuidTimestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "WAN": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/WAN_data"
+            },
+            "refs": {
+              "$ref": "#/definitions/genericRefs"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "WAN_data": {
+      "type": "object",
+      "properties": {
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "logicalId": {
+                "type": "string"
+              },
+              "internalId": {
+                "type": "string"
+              },
+              "discovery": {
+                "type": "string",
+                "enum": [
+                  "DISABLED",
+                  "AUTO_DISCOVERED",
+                  "USER_DEFINED"
+                ]
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "PUBLIC",
+                  "PRIVATE"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "WIRED",
+                  "WIRELESS"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "isp": {
+                "type": "string"
+              },
+              "publicIpAddress": {
+                "type": "string"
+              },
+              "sourceIpAddress": {
+                "type": "string"
+              },
+              "nextHopIpAddress": {
+                "type": "string"
+              },
+              "customVlanId": {
+                "type": "boolean"
+              },
+              "vlanId": {
+                "type": "integer"
+              },
+              "enable8021P": {
+                "type": "boolean"
+              },
+              "priority8021P": {
+                "type": "integer"
+              },
+              "virtualIpAddress": {
+                "type": "string"
+              },
+              "dynamicBwAdjustmentEnabled": {
+                "type": "boolean"
+              },
+              "bwMeasurement": {
+                "type": "string"
+              },
+              "upstreamMbps": {
+                "type": "string"
+              },
+              "downstreamMbps": {
+                "type": "string"
+              },
+              "backupOnly": {
+                "type": "boolean"
+              },
+              "overheadBytes": {
+                "type": "integer"
+              },
+              "udpHolePunching": {
+                "type": "boolean"
+              },
+              "MTU": {
+                "type": "integer"
+              },
+              "mplsNetwork": {
+                "type": "string"
+              },
+              "dscpTag": {
+                "type": "string"
+              },
+              "staticSlaEnabled": {
+                "type": "boolean"
+              },
+              "classesofServiceEnabled": {
+                "type": "boolean"
+              },
+              "encryptOverlay": {
+                "type": "boolean"
+              },
+              "staticSLA": {
+                "type": "object",
+                "properties": {
+                  "latencyMs": {
+                    "type": "integer"
+                  },
+                  "jitterMs": {
+                    "type": "integer"
+                  },
+                  "lossPct": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "classesOfService": {
+                "type": "object",
+                "properties": {
+                  "classId": {
+                    "type": "integer"
+                  },
+                  "classesOfService": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "dscpTags": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "staticSLA": {
+                          "type": "object",
+                          "properties": {
+                            "latencyMs": {
+                              "type": "integer"
+                            },
+                            "jitterMs": {
+                              "type": "integer"
+                            },
+                            "lossPct": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "bandwidthPct": {
+                          "type": "integer"
+                        },
+                        "bandwidthGuaranteed": {
+                          "type": "boolean"
+                        },
+                        "defaultClassOfService": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "interfaces": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "lastActive": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "networks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "logicalId": {
+                "type": "string"
+              },
+              "interface": {
+                "type": "string"
+              },
+              "internalId": {
+                "type": "string"
+              },
+              "ipAddress": {
+                "type": "string"
+              },
+              "isp": {
+                "type": "string"
+              },
+              "lastActive": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "metaData": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/metadata_data"
+            }
+          },
+          "required": [
+            "data"
+          ]
+        }
+      ]
+    },
+    "metadata_data": {
+      "type": "object",
+      "properties": {
+        "applications": {
+          "type": "object",
+          "properties": {
+            "logicalId": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "application": {
+      "properties": {
+        "class": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "knownIpPortMapping": {
+          "$ref": "#/definitions/ip_port_mapping"
+        },
+        "protocolPortMapping": {
+          "$ref": "#/definitions/protocol_port_mapping"
+        }
+      },
+      "required": [
+        "id",
+        "displayName",
+        "class",
+        "description",
+        "knownIpPortMapping",
+        "protocolPortMapping"
+      ],
+      "type": "object"
+    },
+    "application_metadata": {
+      "properties": {
+        "blobId": {
+          "type": "integer"
+        },
+        "created": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "fileName": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "manifest": {
+          "$ref": "#/definitions/application_metadata_manifest"
+        },
+        "modified": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "uploadDetails": {
+          "$ref": "#/definitions/application_metadata_upload_details"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "networkId",
+        "created",
+        "name",
+        "logicalId",
+        "type",
+        "description",
+        "version",
+        "manifest",
+        "blobId",
+        "modified",
+        "fileName",
+        "uploadDetails"
+      ],
+      "type": "object"
+    },
+    "application_metadata_manifest": {
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
+      "type": "object"
+    },
+    "application_metadata_upload_details": {
+      "additionalProperties": true,
+      "properties": {
+        "size": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "type": "object"
+    },
+    "auth_object": {
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "password2": {
+          "format": "password",
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "username",
+        "password"
+      ],
+      "type": "object"
+    },
+    "basic_metric": {
+      "enum": [
+        "packetsRx",
+        "packetsTx",
+        "totalPackets",
+        "bytesRx",
+        "bytesTx",
+        "totalBytes"
+      ],
+      "type": "string"
+    },
+    "basic_metrics": {
+      "items": {
+        "$ref": "#/definitions/basic_metric"
+      },
+      "type": "array"
+    },
+    "edge_link_metric": {
+      "type": "string",
+      "enum": [
+        "bytesRx",
+        "bytesTx",
+        "totalBytes",
+        "totalPackets",
+        "p1BytesRx",
+        "p1BytesTx",
+        "p1PacketsRx",
+        "p1PacketsTx",
+        "p2BytesRx",
+        "p2BytesTx",
+        "p2PacketsRx",
+        "p2PacketsTx",
+        "p3BytesRx",
+        "p3BytesTx",
+        "p3PacketsRx",
+        "p3PacketsTx",
+        "packetsRx",
+        "packetsTx",
+        "controlBytesRx",
+        "controlBytesTx",
+        "controlPacketsRx",
+        "controlPacketsTx",
+        "bestBwKbpsRx",
+        "bestBwKbpsTx",
+        "bestJitterMsRx",
+        "bestJitterMsTx",
+        "bestLatencyMsRx",
+        "bestLatencyMsTx",
+        "bestLossPctRx",
+        "bestLossPctTx",
+        "bpsOfBestPathRx",
+        "bpsOfBestPathTx",
+        "signalStrength",
+        "scoreTx",
+        "scoreRx"
+      ]
+    },
+    "model_configuration": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "edgeCount": {
+          "type": "integer"
+        },
+        "effective": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "modified": {
+          "type": "string"
+        },
+        "modules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/configuration_module_base_type"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "empty_object": {
+      "type": "object",
+      "properties": {}
+    },
+    "bgp_peer_status": {
+      "type": "object",
+      "properties": {
+        "neighborIp": {
+          "type": "string"
+        },
+        "neighborAS": {
+          "type": "integer"
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/bgp_peer_status_record"
+          }
+        }
+      }
+    },
+    "bgp_peer_status_record": {
+      "type": "object",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "IDLE",
+            "CONNECT",
+            "ACTIVE",
+            "OPENSENT",
+            "OPENCONFIRM",
+            "ESTABLISHED",
+            "CLEARING",
+            "IDLEADMIN",
+            "IDLEPRFXCT"
+          ]
+        },
+        "msgRcvd": {
+          "type": "integer"
+        },
+        "pfxRcvd": {
+          "type": "integer"
+        },
+        "msgSent": {
+          "type": "integer"
+        },
+        "upDownTime": {
+          "type": "integer"
+        }
+      }
+    },
+    "config_edge_bgp_filter_set": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "config_edge_bgp_neighbor": {
+      "type": "object",
+      "properties": {
+        "neighborAS": {
+          "type": "string"
+        },
+        "neighborIp": {
+          "type": "string"
+        },
+        "neighborTag": {
+          "type": "string",
+          "enum": [
+            "UPLINK"
+          ]
+        },
+        "inboundFilter": {
+          "$ref": "#/definitions/config_edge_bgp_filter_set"
+        },
+        "outboundFilter": {
+          "$ref": "#/definitions/config_edge_bgp_filter_set"
+        },
+        "allowAS": {
+          "type": "boolean"
+        },
+        "connect": {
+          "type": "string"
+        },
+        "defaultRoute": {
+          "type": "boolean"
+        },
+        "holdtime": {
+          "type": "string"
+        },
+        "keepalive": {
+          "type": "string"
+        },
+        "enableMd5": {
+          "type": "boolean"
+        },
+        "md5Password": {
+          "type": "string"
+        }
+      }
+    },
+    "configuration_clone_configuration_result": {
+      "properties": {
+        "id": {
+          "description": "The ID of the newly cloned configuration",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "configuration_clone_and_convert_configuration_result": {
+      "properties": {
+        "id": {
+          "description": "The ID of the newly cloned configuration",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "configuration_clone_enterprise_template_result": {
+      "properties": {
+        "id": {
+          "description": "The ID of the newly cloned configuration",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "configuration_delete_configuration_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "configuration_get_configuration_modules_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/configuration_module_base_type"
+        },
+        {
+          "required": [
+            "id",
+            "name",
+            "type",
+            "data",
+            "refs",
+            "description",
+            "configurationId"
+          ]
+        }
+      ]
+    },
+    "configuration_get_configuration_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/model_configuration"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "name",
+            "version",
+            "description",
+            "effective",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "configuration_get_routable_applications_result": {
+      "properties": {
+        "applicationClassToApplication": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/id_map_one_to_many"
+            }
+          ],
+          "description": "Maps application class IDs (strings) to application IDs (integers)"
+        },
+        "applicationToApplicationClass": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/id_map_one_to_many"
+            }
+          ],
+          "description": "Maps application IDs (strings) to class IDs (integers)"
+        },
+        "applicationClasses": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/id_map_one_to_one"
+            }
+          ],
+          "description": "Map of application class IDs to class names"
+        },
+        "applications": {
+          "items": {
+            "$ref": "#/definitions/application"
+          },
+          "type": "array"
+        },
+        "metaData": {
+          "$ref": "#/definitions/application_metadata"
+        }
+      },
+      "required": [
+        "applications",
+        "applicationClasses",
+        "applicationClassToApplication",
+        "applicationToApplicationClass",
+        "metaData"
+      ],
+      "type": "object"
+    },
+    "configuration_get_identifiable_applications_result": {
+      "properties": {
+        "applicationClassToApplication": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/id_map_one_to_many"
+            }
+          ],
+          "description": "Maps application class IDs (strings) to application IDs (integers)"
+        },
+        "applicationToApplicationClass": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/id_map_one_to_many"
+            }
+          ],
+          "description": "Maps application IDs (strings) to class IDs (integers)"
+        },
+        "applicationClasses": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/id_map_one_to_one"
+            }
+          ],
+          "description": "Map of application class IDs to class names"
+        },
+        "applications": {
+          "items": {
+            "$ref": "#/definitions/application"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "applications",
+        "applicationClasses",
+        "applicationClassToApplication",
+        "applicationToApplicationClass"
+      ],
+      "type": "object"
+    },
+    "configuration_insert_configuration_module_result": {
+      "properties": {
+        "id": {
+          "description": "The ID of the newly created configuration module",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "configuration_options_list": {
+      "items": {
+        "enum": [
+          "modules",
+          "edgeCount",
+          "enterprises",
+          "enterpriseCount",
+          "counts"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "configuration_update_configuration_module_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "base_enterprise_user": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "userType": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string",
+          "format": "password"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "officePhone": {
+          "type": "string"
+        },
+        "mobilePhone": {
+          "type": "string"
+        },
+        "isNative": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "isLocked": {
+          "type": "boolean"
+        },
+        "disableSecondFactor": {
+          "type": "boolean"
+        },
+        "email": {
+          "type": "string"
+        },
+        "lastLogin": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "destinations": {
+      "properties": {
+        "ip_addr": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "disaster_recovery_client_contact": {
+      "properties": {
+        "activeAddress": {
+          "type": "string"
+        },
+        "activeLastResponseTime": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "clientLogicalId": {
+          "type": "string"
+        },
+        "clientType": {
+          "enum": [
+            "EDGE",
+            "GATEWAY"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "modified": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "standbyAddress": {
+          "type": "string"
+        },
+        "standbyLastResponseTime": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "clientType",
+        "clientLogicalId",
+        "activeAddress",
+        "activeLastResponseTime",
+        "standbyAddress",
+        "standbyLastResponseTime",
+        "modified"
+      ],
+      "type": "object"
+    },
+    "disaster_recovery_configure_active_for_replication_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "disaster_recovery_demote_active_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "disaster_recovery_get_replication_blob": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/empty_object"
+        }
+      ]
+    },
+    "disaster_recovery_get_replication_blob_result": {
+      "properties": {
+        "activeAccessFromStandby": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "activeAccessFromStandby"
+      ],
+      "type": "object"
+    },
+    "disaster_recovery_get_replication_status_result": {
+      "properties": {
+        "activeAddress": {
+          "type": "string"
+        },
+        "activeReplicationAddress": {
+          "type": "string"
+        },
+        "clientContact": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/disaster_recovery_client_contact"
+          }
+        },
+        "clientCount": {
+          "type": "object",
+          "properties": {
+            "edgeCount": {
+              "type": "integer"
+            },
+            "gatewayCount": {
+              "type": "integer"
+            },
+            "currentActiveEdgeCount": {
+              "type": "integer"
+            },
+            "currentStandbyEdgeCount": {
+              "type": "integer"
+            },
+            "currentActiveGatewayCount": {
+              "type": "integer"
+            },
+            "currentStandbyGatewayCount": {
+              "type": "integer"
+            }
+          }
+        },
+        "drState": {
+          "enum": [
+            "UNCONFIGURED",
+            "ACTIVE_CONFIGURING",
+            "ACTIVE_CONFIGURED",
+            "LAUNCHING_STANDBY",
+            "LAUNCHED_STANDBY",
+            "ACTIVE_WAIT_STANDBY",
+            "PENDING_STANDBY_CANDIDATE",
+            "STANDBY_CANDIDATE",
+            "STANDBY_CONFIG_RQST",
+            "STANDBY_CONFIGURING",
+            "STANDBY_CONFIGURED",
+            "PENDING_STANDBY_UNCONFIG",
+            "STANDBY_UNCONFIG",
+            "PENDING_STANDBY_PROMOTION",
+            "STANDBY_PROMOTED",
+            "PENDING_ACTIVE_DEMOTION",
+            "COPYING_DB",
+            "COPY_DB_DONE",
+            "COPYING_FILES",
+            "COPY_FILES_DONE",
+            "SYNC_CONFIGURING",
+            "STANDBY_SYNC",
+            "STANDBY_BACKGROUND_IMPORT",
+            "STANDBY_RUNNING",
+            "UPGRADING",
+            "FAILURE_ACTIVE_CONFIGURING",
+            "FAILURE_LAUNCHING_STANDBY",
+            "FAILURE_STANDBY_CONFIGURING",
+            "FAILURE_GET_STANDBY_CONFIG",
+            "FAILURE_COPYING_DB",
+            "FAILURE_COPYING_FILES",
+            "FAILURE_SYNC_CONFIGURING",
+            "FAILURE_BACKGROUND_IMPORT",
+            "FAILURE_SYNCING_FILES",
+            "FAILURE_GET_STANDBY_STATUS",
+            "FAILURE_GET_ACTIVE_STATUS",
+            "FAILURE_MYSQL_ACTIVE_STATUS",
+            "FAILURE_MYSQL_STANDBY_STATUS",
+            "FAILURE_STANDBY_CANDIDATE",
+            "FAILURE_STANDBY_UNCONFIG",
+            "FAILURE_STANDBY_PROMOTION",
+            "FAILURE_ACTIVE_DEMOTION"
+          ],
+          "type": "string"
+        },
+        "drVCOUser": {
+          "type": "string"
+        },
+        "failureDescription": {
+          "type": "string"
+        },
+        "lastDrProtectedTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "role": {
+          "enum": [
+            "STANDALONE",
+            "ACTIVE",
+            "STANDBY",
+            "ZOMBIE"
+          ],
+          "type": "string"
+        },
+        "roleTimestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "standbyList": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "standbyAddress": {
+                "type": "string"
+              },
+              "standbyReplicationAddress": {
+                "type": "string"
+              },
+              "standbyUuid": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "stateHistory": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "from": {
+                "type": "string",
+                "enum": [
+                  "UNCONFIGURED",
+                  "ACTIVE_CONFIGURING",
+                  "ACTIVE_CONFIGURED",
+                  "LAUNCHING_STANDBY",
+                  "LAUNCHED_STANDBY",
+                  "ACTIVE_WAIT_STANDBY",
+                  "PENDING_STANDBY_CANDIDATE",
+                  "STANDBY_CANDIDATE",
+                  "STANDBY_CONFIG_RQST",
+                  "STANDBY_CONFIGURING",
+                  "STANDBY_CONFIGURED",
+                  "PENDING_STANDBY_UNCONFIG",
+                  "STANDBY_UNCONFIG",
+                  "PENDING_STANDBY_PROMOTION",
+                  "STANDBY_PROMOTED",
+                  "PENDING_ACTIVE_DEMOTION",
+                  "COPYING_DB",
+                  "COPY_DB_DONE",
+                  "COPYING_FILES",
+                  "COPY_FILES_DONE",
+                  "SYNC_CONFIGURING",
+                  "STANDBY_SYNC",
+                  "STANDBY_BACKGROUND_IMPORT",
+                  "STANDBY_RUNNING",
+                  "UPGRADING",
+                  "FAILURE_ACTIVE_CONFIGURING",
+                  "FAILURE_LAUNCHING_STANDBY",
+                  "FAILURE_STANDBY_CONFIGURING",
+                  "FAILURE_GET_STANDBY_CONFIG",
+                  "FAILURE_COPYING_DB",
+                  "FAILURE_COPYING_FILES",
+                  "FAILURE_SYNC_CONFIGURING",
+                  "FAILURE_BACKGROUND_IMPORT",
+                  "FAILURE_SYNCING_FILES",
+                  "FAILURE_GET_STANDBY_STATUS",
+                  "FAILURE_GET_ACTIVE_STATUS",
+                  "FAILURE_MYSQL_ACTIVE_STATUS",
+                  "FAILURE_MYSQL_STANDBY_STATUS",
+                  "FAILURE_STANDBY_CANDIDATE",
+                  "FAILURE_STANDBY_UNCONFIG",
+                  "FAILURE_STANDBY_PROMOTION",
+                  "FAILURE_ACTIVE_DEMOTION"
+                ]
+              },
+              "to": {
+                "type": "string",
+                "enum": [
+                  "UNCONFIGURED",
+                  "ACTIVE_CONFIGURING",
+                  "ACTIVE_CONFIGURED",
+                  "LAUNCHING_STANDBY",
+                  "LAUNCHED_STANDBY",
+                  "ACTIVE_WAIT_STANDBY",
+                  "PENDING_STANDBY_CANDIDATE",
+                  "STANDBY_CANDIDATE",
+                  "STANDBY_CONFIG_RQST",
+                  "STANDBY_CONFIGURING",
+                  "STANDBY_CONFIGURED",
+                  "PENDING_STANDBY_UNCONFIG",
+                  "STANDBY_UNCONFIG",
+                  "PENDING_STANDBY_PROMOTION",
+                  "STANDBY_PROMOTED",
+                  "PENDING_ACTIVE_DEMOTION",
+                  "COPYING_DB",
+                  "COPY_DB_DONE",
+                  "COPYING_FILES",
+                  "COPY_FILES_DONE",
+                  "SYNC_CONFIGURING",
+                  "STANDBY_SYNC",
+                  "STANDBY_BACKGROUND_IMPORT",
+                  "STANDBY_RUNNING",
+                  "UPGRADING",
+                  "FAILURE_ACTIVE_CONFIGURING",
+                  "FAILURE_LAUNCHING_STANDBY",
+                  "FAILURE_STANDBY_CONFIGURING",
+                  "FAILURE_GET_STANDBY_CONFIG",
+                  "FAILURE_COPYING_DB",
+                  "FAILURE_COPYING_FILES",
+                  "FAILURE_SYNC_CONFIGURING",
+                  "FAILURE_BACKGROUND_IMPORT",
+                  "FAILURE_SYNCING_FILES",
+                  "FAILURE_GET_STANDBY_STATUS",
+                  "FAILURE_GET_ACTIVE_STATUS",
+                  "FAILURE_MYSQL_ACTIVE_STATUS",
+                  "FAILURE_MYSQL_STANDBY_STATUS",
+                  "FAILURE_STANDBY_CANDIDATE",
+                  "FAILURE_STANDBY_UNCONFIG",
+                  "FAILURE_STANDBY_PROMOTION",
+                  "FAILURE_ACTIVE_DEMOTION"
+                ]
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "stateTimestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "vcoIp": {
+          "type": "string"
+        },
+        "vcoReplicationIp": {
+          "type": "string"
+        },
+        "vcoUuid": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "drState",
+        "failureDescription",
+        "role",
+        "roleTimestamp",
+        "activeAddress",
+        "standbyList",
+        "drVCOUser",
+        "vcoUuid",
+        "vcoIp"
+      ],
+      "type": "object"
+    },
+    "disaster_recovery_prepare_for_standby": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/empty_object"
+        }
+      ]
+    },
+    "disaster_recovery_prepare_for_standby_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "disaster_recovery_promote_standby_to_active_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "disaster_recovery_remove_standby": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/empty_object"
+        }
+      ]
+    },
+    "disaster_recovery_remove_standby_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "disaster_recovery_transition_to_standby_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "edge_delete_edge_bgp_neighbor_records_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "edge_delete_edge_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "edge_edge_cancel_reactivation_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "edge_edge_provision_result": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "activationKey": {
+          "type": "string"
+        },
+        "generatedCertificate": {
+          "type": "object",
+          "properties": {
+            "certificate": {
+              "type": "string"
+            },
+            "ca-certificate": {
+              "type": "string"
+            },
+            "privateKey": {
+              "type": "string"
+            },
+            "privateKeyPassword": {
+              "type": "string"
+            },
+            "csr": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [
+        "id",
+        "activationKey"
+      ]
+    },
+    "edge_edge_request_reactivation_result": {
+      "properties": {
+        "activationKey": {
+          "type": "string"
+        },
+        "activationKeyExpires": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "required": [
+        "activationKey",
+        "activationKeyExpires"
+      ]
+    },
+    "edge_get_edge_configuration_stack_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/model_configuration"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "name",
+            "version",
+            "description",
+            "modified",
+            "modules"
+          ]
+        }
+      ]
+    },
+    "edge_get_edge_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/edge_object"
+        },
+        {
+          "properties": {
+            "configuration": {
+              "$ref": "#/definitions/model_configuration"
+            },
+            "enterprise": {
+              "$ref": "#/definitions/enterprise"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/link"
+              }
+            },
+            "recentLinks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/link"
+              }
+            },
+            "site": {
+              "$ref": "#/definitions/site"
+            }
+          },
+          "required": [
+            "id",
+            "created",
+            "enterpriseId",
+            "siteId",
+            "activationKey",
+            "activationKeyExpires",
+            "activationState",
+            "activationTime",
+            "softwareVersion",
+            "buildNumber",
+            "softwareUpdated",
+            "selfMacAddress",
+            "deviceId",
+            "logicalId",
+            "serialNumber",
+            "modelNumber",
+            "deviceFamily",
+            "name",
+            "dnsName",
+            "description",
+            "alertsEnabled",
+            "operatorAlertsEnabled",
+            "edgeState",
+            "edgeStateTime",
+            "isLive",
+            "systemUpSince",
+            "serviceUpSince",
+            "lastContact",
+            "serviceState",
+            "endpointPkiMode",
+            "haState",
+            "haPreviousState",
+            "haLastContact",
+            "haSerialNumber",
+            "modified"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "edge_object": {
+      "properties": {
+        "activationKey": {
+          "type": "string"
+        },
+        "activationKeyExpires": {
+          "type": "string"
+        },
+        "activationState": {
+          "enum": [
+            "UNASSIGNED",
+            "PENDING",
+            "ACTIVATED",
+            "REACTIVATION_PENDING"
+          ],
+          "type": "string"
+        },
+        "activationTime": {
+          "type": "string"
+        },
+        "alertsEnabled": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "buildNumber": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "deviceFamily": {
+          "type": "string"
+        },
+        "deviceId": {
+          "type": "string"
+        },
+        "dnsName": {
+          "type": "string"
+        },
+        "edgeState": {
+          "enum": [
+            "NEVER_ACTIVATED",
+            "DEGRADED",
+            "OFFLINE",
+            "DISABLED",
+            "EXPIRED",
+            "CONNECTED"
+          ],
+          "type": "string"
+        },
+        "edgeStateTime": {
+          "type": "string"
+        },
+        "endpointPkiMode": {
+          "enum": [
+            "CERTIFICATE_DISABLED",
+            "CERTIFICATE_OPTIONAL",
+            "CERTIFICATE_REQUIRED"
+          ],
+          "type": "string"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "haLastContact": {
+          "type": "string"
+        },
+        "haPreviousState": {
+          "enum": [
+            "UNCONFIGURED",
+            "PENDING_INIT",
+            "PENDING_CONFIRMATION",
+            "PENDING_CONFIRMED",
+            "PENDING_DISSOCIATION",
+            "READY",
+            "FAILED"
+          ],
+          "type": "string"
+        },
+        "haSerialNumber": {
+          "type": "string"
+        },
+        "haState": {
+          "enum": [
+            "UNCONFIGURED",
+            "PENDING_INIT",
+            "PENDING_CONFIRMATION",
+            "PENDING_CONFIRMED",
+            "PENDING_DISSOCIATION",
+            "READY",
+            "FAILED"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "isLive": {
+          "type": "integer"
+        },
+        "lastContact": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "modelNumber": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "operatorAlertsEnabled": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "selfMacAddress": {
+          "type": "string"
+        },
+        "serialNumber": {
+          "type": "string"
+        },
+        "serviceState": {
+          "enum": [
+            "IN_SERVICE",
+            "OUT_OF_SERVICE",
+            "PENDING_SERVICE"
+          ],
+          "type": "string"
+        },
+        "serviceUpSince": {
+          "type": "string"
+        },
+        "siteId": {
+          "type": "integer"
+        },
+        "softwareUpdated": {
+          "type": "string"
+        },
+        "softwareVersion": {
+          "type": "string"
+        },
+        "systemUpSince": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "edge_set_edge_hand_off_gateways_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "edge_update_edge_admin_password_result": {
+      "properties": {
+        "id": {
+          "description": "The ID of the action queued",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "set_client_device_host_name_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "edge_update_edge_attributes_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "edge_update_edge_credentials_by_configuration_result": {
+      "properties": {
+        "actionIds": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "actionIds"
+      ],
+      "type": "object"
+    },
+    "edge_set_edge_operator_configuration_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_set_enterprise_operator_configuration_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "edge_set_edge_enterprise_configuration_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_alert_notification_user_data": {
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "emailEnabled": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "integer"
+        },
+        "enterpriseUserId": {
+          "type": "integer"
+        },
+        "mobileEnabled": {
+          "type": "integer"
+        },
+        "mobilePhone": {
+          "type": "string"
+        },
+        "smsEnabled": {
+          "type": "integer"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "emailEnabled",
+        "enabled",
+        "enterpriseUserId",
+        "mobileEnabled",
+        "mobilePhone",
+        "smsEnabled",
+        "username"
+      ],
+      "type": "object"
+    },
+    "enterprise_delete_enterprise_delete_enterprise_gateway_records_record": {
+      "properties": {
+        "gatewayId": {
+          "type": "integer"
+        },
+        "neighborIp": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "enterprise_delete_enterprise_gateway_records_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "enterprise_delete_enterprise_network_allocation_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "enterprise_delete_enterprise_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "enterprise_delete_enterprise_service_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "enterprise_enterprise_proxy": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_proxy"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "networkId",
+            "proxyType",
+            "operateGateways",
+            "logicalId",
+            "name",
+            "domain",
+            "prefix",
+            "description",
+            "contactName",
+            "contactPhone",
+            "contactMobile",
+            "contactEmail",
+            "streetAddress",
+            "streetAddress2",
+            "city",
+            "state",
+            "postalCode",
+            "country",
+            "lat",
+            "lon",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "enterprise_get_enterprise_addresses_result_item": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "entity": {
+          "enum": [
+            "ACTIVE_VCO",
+            "STANDBY_VCO",
+            "GATEWAY",
+            "DATACENTER"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "enterprise_get_enterprise_alert_configurations_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_alert_configuration"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "alertDefinitionId",
+            "enterpriseId",
+            "enabled",
+            "name",
+            "description",
+            "type",
+            "definition",
+            "firstNotificationSeconds",
+            "maxNotifications",
+            "notificationIntervalSeconds",
+            "resetIntervalSeconds",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "enterprise_get_enterprise_alerts_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_alert_trigger"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "triggerTime",
+            "enterpriseAlertConfigurationId",
+            "enterpriseId",
+            "edgeId",
+            "edgeName",
+            "linkId",
+            "linkName",
+            "enterpriseObjectId",
+            "enterpriseObjectName",
+            "name",
+            "type",
+            "state",
+            "stateSetTime",
+            "lastContact",
+            "firstNotificationSeconds",
+            "maxNotifications",
+            "notificationIntervalSeconds",
+            "resetIntervalSeconds",
+            "comment",
+            "nextNotificationTime",
+            "remainingNotifications",
+            "timezone",
+            "locale",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "enterprise_get_enterprise_all_alert_recipients_result": {
+      "properties": {
+        "emailEnabled": {
+          "type": "boolean"
+        },
+        "emailList": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enterpriseUsers": {
+          "items": {
+            "$ref": "#/definitions/enterprise_alert_notification_user_data"
+          },
+          "type": "array"
+        },
+        "mobileEnabled": {
+          "type": "boolean"
+        },
+        "mobileList": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "smsEnabled": {
+          "type": "boolean"
+        },
+        "smsList": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "snmpEnabled": {
+          "type": "boolean"
+        },
+        "snmpList": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "emailEnabled",
+        "emailList",
+        "enterpriseUsers",
+        "mobileEnabled",
+        "mobileList",
+        "smsEnabled",
+        "smsList"
+      ],
+      "type": "object"
+    },
+    "enterprise_get_enterprise_capabilities_result": {
+      "type": "object",
+      "properties": {
+        "edgeVnfs.enable": {
+          "type": "boolean"
+        },
+        "edgeVnfs.securityVnf.paloAlto": {
+          "type": "boolean"
+        },
+        "edgeVnfs.securityVnf.checkpoint": {
+          "type": "boolean"
+        },
+        "edgeVnfs.securityVnf.fortinet": {
+          "type": "boolean"
+        },
+        "enableBGP": {
+          "type": "boolean"
+        },
+        "enableCosMapping": {
+          "type": "boolean"
+        },
+        "enableEnterpriseAuth": {
+          "type": "boolean"
+        },
+        "enableFwLogs": {
+          "type": "boolean"
+        },
+        "enableStatefulFirewall": {
+          "type": "boolean"
+        },
+        "enableNetworks": {
+          "type": "boolean"
+        },
+        "enableOSPF": {
+          "type": "boolean"
+        },
+        "enablePKI": {
+          "type": "boolean"
+        },
+        "enablePremium": {
+          "type": "boolean"
+        },
+        "enableSegmentation": {
+          "type": "boolean"
+        },
+        "enableServiceRateLimiting": {
+          "type": "boolean"
+        },
+        "enableVQM": {
+          "type": "boolean"
+        }
+      },
+      "example": {
+        "edgeVnfs.enable": true,
+        "edgeVnfs.securityVnf.paloAlto": true,
+        "edgeVnfs.securityVnf.checkpoint": true,
+        "edgeVnfs.securityVnf.fortinet": true,
+        "enableBGP": false,
+        "enableCosMapping": true,
+        "enableEnterpriseAuth": true,
+        "enableFwLogs": false,
+        "enableStatefulFirewall": false,
+        "enableNetworks": true,
+        "enableOSPF": true,
+        "enablePKI": true,
+        "enablePremium": true,
+        "enableSegmentation": true,
+        "enableServiceRateLimiting": false,
+        "enableVQM": true
+      }
+    },
+    "enterprise_get_enterprise_configurations_with_policies": {
+      "title": "enterprise_get_enterprise_configurations_with_policies",
+      "type": "object",
+      "properties": {
+        "enterpriseId": {
+          "type": "integer"
+        }
+      }
+    },
+    "enterprise_get_enterprise_configurations_with_policies_result": {
+      "title": "enterprise_get_enterprise_configurations_with_policies_result",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "configurationType": {
+            "type": "string",
+            "enum": [
+              "NETWORK_BASED",
+              "SEGMENT_BASED"
+            ]
+          },
+          "created": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "edgeCount": {
+            "type": "integer"
+          },
+          "effective": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "isStaging": {
+            "type": "integer"
+          },
+          "logicalId": {
+            "type": "string"
+          },
+          "modified": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "policies": {
+            "type": "object",
+            "properties": {
+              "bizPolicyEnabled": {
+                "type": "boolean"
+              },
+              "deviceSettingsEnabled": {
+                "type": "boolean"
+              },
+              "firewall": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "enabled",
+                  "disabled"
+                ]
+              }
+            },
+            "required": [
+              "bizPolicyEnabled",
+              "deviceSettingsEnabled",
+              "firewall"
+            ]
+          },
+          "schemaVersion": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "enterprise_get_enterprise_configurations_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/model_configuration"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "name",
+            "version",
+            "description",
+            "effective",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "enterprise_get_enterprise_operator_configuration_type": {
+      "title": "enterprise_get_enterprise_operator_configuration_type",
+      "type": "object",
+      "properties": {
+        "enterpriseId": {
+          "type": "integer"
+        }
+      }
+    },
+    "enterprise_get_enterprise_operator_configuration_type_result": {
+      "title": "enterprise_get_enterprise_operator_configuration_type_result",
+      "type": "object",
+      "properties": {
+        "configurationType": {
+          "type": "string",
+          "enum": [
+            "NETWORK_BASED",
+            "SEGMENT_BASED"
+          ]
+        }
+      },
+      "required": [
+        "configurationType"
+      ]
+    },
+    "enterprise_get_enterprise_edges_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/edge_object"
+        },
+        {
+          "properties": {
+            "certificates": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/edge_certificate"
+              }
+            },
+            "configuration": {
+              "type": "object",
+              "properties": {
+                "operator": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "modules": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "isEdgeSpecific": {
+                            "type": "integer",
+                            "enum": [
+                              0,
+                              1
+                            ]
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "ENTERPRISE",
+                              "OPERATOR",
+                              "GATEWAY"
+                            ]
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "enterprise": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "modules": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "edgeSpecificData": {
+                            "type": "object"
+                          },
+                          "isEdgeSpecific": {
+                            "type": "integer",
+                            "enum": [
+                              0,
+                              1
+                            ]
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "ENTERPRISE",
+                              "OPERATOR",
+                              "GATEWAY"
+                            ]
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "ha": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ACTIVE_ACTIVE",
+                    "ACTIVE_STANDBY",
+                    "VRRP"
+                  ]
+                },
+                "data": {
+                  "type": "object"
+                }
+              }
+            },
+            "licenses": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/edge_license"
+              }
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/link"
+              }
+            },
+            "recentLinks": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/link"
+              }
+            },
+            "site": {
+              "$ref": "#/definitions/site"
+            },
+            "isHub": {
+              "type": "boolean"
+            },
+            "isSoftwareVersionSupportedByVco": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "id",
+            "created",
+            "enterpriseId",
+            "siteId",
+            "activationKey",
+            "activationKeyExpires",
+            "activationState",
+            "activationTime",
+            "softwareVersion",
+            "buildNumber",
+            "softwareUpdated",
+            "selfMacAddress",
+            "deviceId",
+            "logicalId",
+            "serialNumber",
+            "modelNumber",
+            "deviceFamily",
+            "name",
+            "dnsName",
+            "description",
+            "alertsEnabled",
+            "operatorAlertsEnabled",
+            "edgeState",
+            "edgeStateTime",
+            "isLive",
+            "systemUpSince",
+            "serviceUpSince",
+            "lastContact",
+            "serviceState",
+            "endpointPkiMode",
+            "haState",
+            "haPreviousState",
+            "haLastContact",
+            "haSerialNumber",
+            "modified"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "edge_list_ha_details_active_standby": {
+      "type": "object",
+      "properties": {
+        "haLastContact": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "haPreviousState": {
+          "type": "string",
+          "enum": [
+            "UNCONFIGURED",
+            "PENDING_INIT",
+            "PENDING_CONFIRMATION",
+            "PENDING_CONFIRMED",
+            "PENDING_DISSOCIATION",
+            "READY",
+            "FAILED"
+          ]
+        },
+        "haSerialNumber": {
+          "type": "string"
+        },
+        "haState": {
+          "type": "string",
+          "enum": [
+            "UNCONFIGURED",
+            "PENDING_INIT",
+            "PENDING_CONFIRMATION",
+            "PENDING_CONFIRMED",
+            "PENDING_DISSOCIATION",
+            "READY",
+            "FAILED"
+          ]
+        }
+      },
+      "required": [
+        "haLastContact",
+        "haPreviousState",
+        "haSerialNumber",
+        "haState"
+      ]
+    },
+    "edge_list_ha_details_active_active": {
+      "type": "object",
+      "properties": {
+        "clusterId": {
+          "type": "integer"
+        },
+        "clusterName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "clusterId",
+        "clusterName"
+      ]
+    },
+    "edge_list_ha_details_vrrp": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/device_settings_vrrp_virtual_router"
+      }
+    },
+    "enterprise_get_enterprise_network_allocation_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        }
+      ]
+    },
+    "enterprise_get_enterprise_network_allocations_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        }
+      ]
+    },
+    "enterprise_get_enterprise_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise"
+        },
+        {
+          "properties": {
+            "enterpriseProxy": {
+              "$ref": "#/definitions/enterprise_enterprise_proxy"
+            }
+          },
+          "required": [
+            "domain",
+            "contactPhone",
+            "locale",
+            "alertsEnabled",
+            "endpointPkiMode",
+            "contactEmail",
+            "prefix",
+            "contactName",
+            "timezone",
+            "id",
+            "gatewayPoolId",
+            "networkId",
+            "city",
+            "lon",
+            "state",
+            "streetAddress",
+            "postalCode",
+            "streetAddress2",
+            "description",
+            "accountNumber",
+            "contactMobile",
+            "lat",
+            "logicalId",
+            "operatorAlertsEnabled",
+            "name",
+            "created",
+            "country",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "enterprise_get_enterprise_route_configuration_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        }
+      ]
+    },
+    "exit_entity_type": {
+      "title": "exit_entity_type",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "logicalId",
+        "name"
+      ]
+    },
+    "enterprise_get_enterprise_route_table_result": {
+      "properties": {
+        "profiles": {
+          "items": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/model_configuration"
+              },
+              {
+                "required": [
+                  "id",
+                  "description",
+                  "name"
+                ]
+              }
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "subnets": {
+          "items": {
+            "$ref": "#/definitions/enterprise_route_collection"
+          },
+          "type": "array"
+        },
+        "exits": {
+          "type": "object",
+          "properties": {
+            "edges": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/exit_entity_type"
+              }
+            },
+            "hubs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/exit_entity_type"
+              }
+            },
+            "gateways": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/exit_entity_type"
+              }
+            },
+            "nvs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/exit_entity_type"
+              }
+            }
+          },
+          "required": [
+            "edges",
+            "hubs",
+            "nvs",
+            "gateways"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "enterprise_get_enterprise_services_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "profileCount": {
+              "type": "integer"
+            },
+            "edgeCount": {
+              "type": "integer"
+            },
+            "groupCount": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_object": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/site"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "gatewayPoolId": {
+              "type": "integer"
+            },
+            "networkId": {
+              "type": "integer"
+            },
+            "returnData": {
+              "type": "boolean"
+            },
+            "user": {
+              "$ref": "#/definitions/auth_object"
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_insert_enterprise_network_allocation_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_insert_enterprise_network_segment_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_insert_enterprise": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "configurationId": {
+              "type": "integer"
+            },
+            "enableEnterpriseDelegationToOperator": {
+              "type": "boolean"
+            },
+            "enableEnterpriseDelegationToProxy": {
+              "type": "boolean"
+            },
+            "enableEnterpriseUserManagementDelegationToOperator": {
+              "type": "boolean"
+            },
+            "licenses": {
+              "type": "object",
+              "properties": {
+                "ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          "required": [
+            "configurationId",
+            "name"
+          ]
+        }
+      ]
+    },
+    "enterprise_insert_enterprise_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_update_enterprise": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/site"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "gatewayPoolId": {
+              "type": "integer"
+            },
+            "networkId": {
+              "type": "integer"
+            },
+            "returnData": {
+              "type": "boolean"
+            },
+            "user": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "email": {
+                  "type": "string"
+                },
+                "username": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_update_enterprise_result": {
+      "$ref": "#/definitions/rows_modified_confirmation"
+    },
+    "enterprise_proxy_insert_enterprise_proxy_enterprise": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_insert_enterprise"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "enterpriseProxyId": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_proxy_insert_enterprise_proxy_enterprise_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_insert_enterprise_result"
+        }
+      ]
+    },
+    "enterprise_proxy_get_enterprise_proxy_enterprises_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "edgeCount": {
+              "type": "integer"
+            },
+            "edges": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_object"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "proxy_edge_inventory_object": {
+      "type": "object",
+      "properties": {
+        "enterpriseName": {
+          "type": "string"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "edgeName": {
+          "type": "string"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "edgeState": {
+          "type": "string",
+          "enum": [
+            "NEVER_ACTIVATED",
+            "DEGRADED",
+            "OFFLINE",
+            "DISABLED",
+            "EXPIRED",
+            "CONNECTED"
+          ]
+        },
+        "serialNumber": {
+          "type": "string"
+        },
+        "haSerialNumber": {
+          "type": "string"
+        },
+        "activationState": {
+          "type": "string",
+          "enum": [
+            "UNASSIGNED",
+            "PENDING",
+            "ACTIVATED",
+            "REACTIVATION_PENDING"
+          ]
+        },
+        "activationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "modelNumber": {
+          "type": "string"
+        },
+        "softwareVersion": {
+          "type": "string"
+        },
+        "softwareUpdated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastContact": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "enterpriseName",
+        "enterpriseId",
+        "edgeName",
+        "edgeId",
+        "created",
+        "edgeState",
+        "serialNumber",
+        "haSerialNumber",
+        "activationState",
+        "activationTime",
+        "modelNumber",
+        "softwareVersion",
+        "softwareUpdated",
+        "lastContact"
+      ]
+    },
+    "enterprise_proxy_get_enterprise_proxy_edge_inventory_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/proxy_edge_inventory_object"
+        }
+      ]
+    },
+    "enterprise_proxy_get_enterprise_proxy_operator_profiles_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/model_configuration"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "edges": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/edge_object"
+              }
+            },
+            "enterprises": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/configuration_enterprise"
+              }
+            }
+          },
+          "required": [
+            "id",
+            "created",
+            "name",
+            "version",
+            "description",
+            "effective",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "enterprise_insert_enterprise_service_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_insert_or_update_enterprise_alert_configurations_result": {
+      "type": "object",
+      "properties": {
+        "enterpriseAlertConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/enterprise_alert_configuration"
+          }
+        }
+      }
+    },
+    "enterprise_insert_or_update_enterprise_capability_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_set_enterprise_maximum_segments_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_insert_or_update_enterprise_property_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_property": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "isPassword": {
+          "type": "boolean"
+        },
+        "dataType": {
+          "type": "string",
+          "enum": [
+            "STRING",
+            "NUMBER",
+            "BOOLEAN",
+            "JSON",
+            "DATE",
+            "DATETIME"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "enterprise_get_enterprise_property_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_property"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "name",
+            "enterpriseId",
+            "value",
+            "isPassword",
+            "dataType",
+            "description",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "enterprise_get_enterprise_gateway_handoff_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/gateway_handoff"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "created": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "name": {
+              "type": "string"
+            },
+            "isPassword": {
+              "type": "boolean"
+            },
+            "dataType": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "modified": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "required": [
+            "enterpriseId",
+            "value"
+          ]
+        }
+      ]
+    },
+    "enterprise_insert_or_update_enterprise_gateway_handoff": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/gateway_handoff"
+        }
+      ]
+    },
+    "enterprise_insert_or_update_enterprise_gateway_handoff_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_proxy_get_enterprise_proxy_gateway_pools_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/gateway_pool"
+        },
+        {
+          "properties": {
+            "enterprises": {
+              "items": {
+                "$ref": "#/definitions/enterprise"
+              },
+              "type": "array"
+            },
+            "gateways": {
+              "items": {
+                "$ref": "#/definitions/gateway_pool_gateway"
+              },
+              "type": "array"
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_route_collection": {
+      "properties": {
+        "eligableExits": {
+          "items": {
+            "$ref": "#/definitions/enterprise_route"
+          },
+          "type": "array"
+        },
+        "preferredExits": {
+          "items": {
+            "$ref": "#/definitions/enterprise_route"
+          },
+          "type": "array"
+        },
+        "subnet": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "enterprise_set_enterprise_all_alert_recipients_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_get_enterprise_all_alert_recipients_result"
+        }
+      ]
+    },
+    "enterprise_update_enterprise_network_allocation_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "enterprise_update_enterprise_network_segment_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "enterprise_update_enterprise_route_configuration_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "enterprise_update_enterprise_route_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_route_collection"
+        },
+        {
+          "required": [
+            "subnet",
+            "preferredExits",
+            "eligableExits"
+          ]
+        }
+      ]
+    },
+    "enterprise_update_enterprise_security_policy_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "enterprise_update_enterprise_service_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "event_get_enterprise_events_result": {
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/enterprise_event"
+          },
+          "type": "array"
+        },
+        "metaData": {
+          "$ref": "#/definitions/list_metadata"
+        }
+      },
+      "required": [
+        "metaData",
+        "data"
+      ],
+      "type": "object"
+    },
+    "event_get_operator_events_result": {
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/operator_event"
+          },
+          "type": "array"
+        },
+        "metaData": {
+          "$ref": "#/definitions/list_metadata"
+        }
+      },
+      "required": [
+        "metaData",
+        "data"
+      ],
+      "type": "object"
+    },
+    "event_get_proxy_events_result": {
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/proxy_event"
+          },
+          "type": "array"
+        },
+        "metaData": {
+          "$ref": "#/definitions/list_metadata"
+        }
+      },
+      "required": [
+        "metaData",
+        "data"
+      ],
+      "type": "object"
+    },
+    "flow_metric_summary": {
+      "type": "object",
+      "properties": {
+        "bytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "bytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "flowCount": {
+          "type": "integer"
+        },
+        "packetsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "packetsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalBytes": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "totalPackets": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "time_series": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "max": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "metric": {
+          "$ref": "#/definitions/basic_metric"
+        },
+        "min": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tickInterval": {
+          "type": "integer"
+        },
+        "total": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "required": [
+        "data",
+        "metric",
+        "max",
+        "min",
+        "startTime",
+        "tickInterval",
+        "total"
+      ]
+    },
+    "time_series_metadata": {
+      "type": "object",
+      "properties": {
+        "series": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/time_series"
+          }
+        }
+      },
+      "required": [
+        "series"
+      ]
+    },
+    "enterprise_user_with_role_info": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base_enterprise_user"
+        },
+        {
+          "properties": {
+            "roleId": {
+              "type": "integer"
+            },
+            "roleName": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_user_with_role_and_assocs": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_user_with_role_info"
+        },
+        {
+          "properties": {
+            "enterpriseId": {
+              "type": "integer"
+            },
+            "enterpriseProxyId": {
+              "type": "integer"
+            },
+            "networkId": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "base_operator_user": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "operatorId": {
+          "type": "integer"
+        },
+        "userType": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string",
+          "format": "password"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "officePhone": {
+          "type": "string"
+        },
+        "mobilePhone": {
+          "type": "string"
+        },
+        "isNative": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "isLocked": {
+          "type": "boolean"
+        },
+        "disableSecondFactor": {
+          "type": "boolean"
+        },
+        "email": {
+          "type": "string"
+        },
+        "lastLogin": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "operator_user_with_role_info": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base_operator_user"
+        },
+        {
+          "properties": {
+            "roleId": {
+              "type": "integer"
+            },
+            "roleName": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "gateway_delete_gateway_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "gateway_gateway_provision_result": {
+      "properties": {
+        "activationKey": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "logicalId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "activationKey",
+        "logicalId"
+      ],
+      "type": "object"
+    },
+    "gateway_roles_object": {
+      "items": {
+        "properties": {
+          "gatewayRole": {
+            "enum": [
+              "DATA_PLANE",
+              "CONTROL_PLANE",
+              "VPN_TUNNEL",
+              "ON_PREMISE",
+              "CDE"
+            ],
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "gatewayRole"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "gateway_update_gateway_attributes_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "gateway_get_gateway_edge_assignments_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/edge_object"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "enterpriseName": {
+              "type": "string"
+            },
+            "enterpriseProxyId": {
+              "type": "integer"
+            },
+            "enterpriseProxyName": {
+              "type": "string"
+            },
+            "lat": {
+              "type": "number",
+              "format": "double"
+            },
+            "lon": {
+              "type": "number",
+              "format": "double"
+            },
+            "city": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "country": {
+              "type": "string"
+            },
+            "postalCode": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "id_map_one_to_many": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "id_map_one_to_one": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "string"
+    },
+    "js_date_formats": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "interval": {
+      "properties": {
+        "end": {
+          "$ref": "#/definitions/js_date_formats"
+        },
+        "start": {
+          "$ref": "#/definitions/js_date_formats"
+        }
+      },
+      "required": [
+        "start"
+      ],
+      "type": "object"
+    },
+    "ip_port_mapping": {
+      "properties": {
+        "subnets": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tcpPorts": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "udpPorts": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "link_quality_event_get_link_quality_events_result": {
+      "type": "object",
+      "properties": {
+        "overallLinkQuality": {
+          "$ref": "#/definitions/link_quality_object"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/link_quality_object"
+      }
+    },
+    "link_service_groups": {
+      "items": {
+        "enum": [
+          "ALL",
+          "PRIVATE_WIRED",
+          "PUBLIC_WIRED",
+          "PUBLIC_WIRELESS"
+        ],
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "list_metadata": {
+      "properties": {
+        "limit": {
+          "type": "integer"
+        },
+        "more": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "limit",
+        "more"
+      ],
+      "type": "object"
+    },
+    "live_mode_data": {
+      "properties": {
+        "linkStats": {
+          "$ref": "#/definitions/live_mode_data_link_stats"
+        }
+      },
+      "required": [
+        "linkStats"
+      ],
+      "type": "object"
+    },
+    "live_mode_data_link_stats": {
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/live_mode_data_link_stats_data"
+          },
+          "type": "array"
+        },
+        "timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "timestamp",
+        "data"
+      ],
+      "type": "object"
+    },
+    "live_mode_data_link_stats_data": {
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/live_mode_data_link_stats_data_data"
+          },
+          "type": "array"
+        },
+        "timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "timestamp",
+        "data"
+      ],
+      "type": "object"
+    },
+    "live_mode_data_link_stats_data_data": {
+      "properties": {
+        "backupOnly": {
+          "type": "integer"
+        },
+        "bestJitterMsRx": {
+          "type": "integer"
+        },
+        "bestJitterMsTx": {
+          "type": "integer"
+        },
+        "bestLatencyMsRx": {
+          "type": "integer"
+        },
+        "bestLatencyMsTx": {
+          "type": "integer"
+        },
+        "bestLossPctRx": {
+          "type": "number",
+          "format": "float"
+        },
+        "bestLossPctTx": {
+          "type": "number",
+          "format": "float"
+        },
+        "bpsOfBestPathRx": {
+          "type": "integer"
+        },
+        "bpsOfBestPathTx": {
+          "type": "integer"
+        },
+        "bytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "bytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlBytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlBytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlPacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlPacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "destinations": {
+          "items": {
+            "$ref": "#/definitions/destinations"
+          },
+          "type": "array"
+        },
+        "icmpBytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "icmpBytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "icmpPacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "icmpPacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "interface": {
+          "type": "string"
+        },
+        "internalId": {
+          "type": "string"
+        },
+        "localIpAddress": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "PUBLIC",
+            "PRIVATE"
+          ],
+          "type": "string"
+        },
+        "mtu": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "otherBytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "otherBytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "otherPacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "otherPacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "publicIpAddress": {
+          "type": "string"
+        },
+        "scoreRx": {
+          "type": "number",
+          "format": "float"
+        },
+        "scoreTx": {
+          "type": "number",
+          "format": "float"
+        },
+        "signalStrength": {
+          "type": "number",
+          "format": "float"
+        },
+        "state": {
+          "enum": [
+            "UNKNOWN",
+            "STABLE",
+            "UNSTABLE",
+            "DISCONNECTED",
+            "QUIET",
+            "INITIAL",
+            "STANDBY"
+          ],
+          "type": "string"
+        },
+        "tcpBytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "tcpBytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "tcpPacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "tcpPacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "type": {
+          "enum": [
+            "WIRED",
+            "WIRELESS"
+          ],
+          "type": "string"
+        },
+        "udpBytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "udpBytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "udpHolePunching": {
+          "type": "integer"
+        },
+        "udpPacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "udpPacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "vlanId": {
+          "type": "integer"
+        },
+        "vpnState": {
+          "enum": [
+            "UNKNOWN",
+            "STABLE",
+            "UNSTABLE",
+            "DEAD",
+            "STANDBY"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "live_mode_enter_live_mode_result": {
+      "properties": {
+        "actionId": {
+          "description": "The ID of the action queued",
+          "type": "integer"
+        },
+        "alreadyLive": {
+          "type": "boolean"
+        },
+        "lastContact": {
+          "type": "integer"
+        },
+        "refreshIntervalMs": {
+          "type": "integer"
+        },
+        "token": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "live_mode_exit_live_mode_result": {
+      "properties": {
+        "id": {
+          "description": "The ID of the action queued",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "live_mode_read_live_data_result": {
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/live_mode_data"
+        },
+        "status": {
+          "$ref": "#/definitions/live_mode_status"
+        },
+        "timestamp": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "timestamp",
+        "data",
+        "status"
+      ],
+      "type": "object"
+    },
+    "live_mode_status": {
+      "properties": {
+        "isActive": {
+          "type": "boolean"
+        },
+        "lastContact": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "isActive",
+        "lastContact"
+      ],
+      "type": "object"
+    },
+    "metrics_get_edge_app_link_metrics_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/flow_metric_summary"
+        },
+        {
+          "properties": {
+            "linkId": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "integer"
+            },
+            "serviceGroups": {
+              "$ref": "#/definitions/link_service_groups"
+            }
+          },
+          "required": [
+            "linkId",
+            "name",
+            "serviceGroups"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_app_link_series_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/time_series_metadata"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "integer"
+            },
+            "serviceGroups": {
+              "$ref": "#/definitions/link_service_groups"
+            }
+          },
+          "required": [
+            "name",
+            "serviceGroups"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_app_metrics_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/flow_metric_summary"
+        },
+        {
+          "properties": {
+            "application": {
+              "type": "integer"
+            },
+            "category": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "integer"
+            },
+            "linkId": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name",
+            "application"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_app_series_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/time_series_metadata"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_category_metrics_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/flow_metric_summary"
+        },
+        {
+          "properties": {
+            "category": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name",
+            "category"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_category_series_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/time_series_metadata"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_segment_metrics_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/flow_metric_summary"
+        },
+        {
+          "properties": {
+            "segment": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name",
+            "segment"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_segment_series_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/time_series_metadata"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_dest_metrics_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/flow_metric_summary"
+        },
+        {
+          "properties": {
+            "destDomain": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "destDomain",
+            "name"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_dest_series_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/time_series_metadata"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_device_metrics_device_edge_info": {
+      "properties": {
+        "edgeId": {
+          "type": "integer"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "hostName": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "ipAddress": {
+          "type": "string"
+        },
+        "lastContact": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "macAddress": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "metrics_get_edge_device_metrics_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/flow_metric_summary"
+        },
+        {
+          "properties": {
+            "edgeInfo": {
+              "$ref": "#/definitions/metrics_get_edge_device_metrics_device_edge_info"
+            },
+            "info": {
+              "$ref": "#/definitions/client_device"
+            },
+            "name": {
+              "type": "string"
+            },
+            "sourceMac": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "edgeInfo",
+            "info",
+            "name",
+            "sourceMac"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_device_series_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/time_series_metadata"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_link_metrics_result_item": {
+      "properties": {
+        "bestJitterMsRx": {
+          "type": "integer"
+        },
+        "bestJitterMsTx": {
+          "type": "integer"
+        },
+        "bestLatencyMsRx": {
+          "type": "integer"
+        },
+        "bestLatencyMsTx": {
+          "type": "integer"
+        },
+        "bestLossPctRx": {
+          "type": "number",
+          "format": "float"
+        },
+        "bestLossPctTx": {
+          "type": "number",
+          "format": "float"
+        },
+        "bpsOfBestPathRx": {
+          "type": "integer"
+        },
+        "bpsOfBestPathTx": {
+          "type": "integer"
+        },
+        "bytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "bytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlBytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlBytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlPacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlPacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "link": {
+          "$ref": "#/definitions/link"
+        },
+        "linkId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "p1BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "scoreRx": {
+          "type": "number",
+          "format": "float"
+        },
+        "scoreTx": {
+          "type": "number",
+          "format": "float"
+        },
+        "signalStrength": {
+          "type": "number",
+          "format": "float"
+        },
+        "state": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "link",
+        "linkId",
+        "name"
+      ],
+      "type": "object"
+    },
+    "metrics_get_edge_link_series_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/time_series_metadata"
+        },
+        {
+          "properties": {
+            "edgeId": {
+              "type": "integer"
+            },
+            "link": {
+              "$ref": "#/definitions/link"
+            },
+            "linkId": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "edgeId",
+            "linkId",
+            "link"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_os_metrics_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/flow_metric_summary"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "integer"
+            },
+            "os": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "os",
+            "name"
+          ]
+        }
+      ]
+    },
+    "metrics_get_edge_os_series_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/time_series_metadata"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "monitoring_get_aggregate_edge_link_metrics_result_item": {
+      "type": "object",
+      "properties": {
+        "bestJitterMsRx": {
+          "type": "integer"
+        },
+        "bestJitterMsTx": {
+          "type": "integer"
+        },
+        "bestLatencyMsRx": {
+          "type": "integer"
+        },
+        "bestLatencyMsTx": {
+          "type": "integer"
+        },
+        "bestLossPctRx": {
+          "type": "number",
+          "format": "float"
+        },
+        "bestLossPctTx": {
+          "type": "number",
+          "format": "float"
+        },
+        "bpsOfBestPathRx": {
+          "type": "integer"
+        },
+        "bpsOfBestPathTx": {
+          "type": "integer"
+        },
+        "bytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "bytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlBytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlBytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlPacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "controlPacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "link": {
+          "$ref": "#/definitions/monitored_link"
+        },
+        "linkId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "p1BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p1PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p2PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3BytesRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3BytesTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3PacketsRx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "p3PacketsTx": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "scoreRx": {
+          "type": "number",
+          "format": "float"
+        },
+        "scoreTx": {
+          "type": "number",
+          "format": "float"
+        },
+        "signalStrength": {
+          "type": "number",
+          "format": "float"
+        },
+        "state": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "link",
+        "linkId",
+        "name"
+      ]
+    },
+    "monitoring_get_aggregate_enterprise_events_result": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/aggregate_enterprise_event"
+          },
+          "type": "array"
+        },
+        "metaData": {
+          "$ref": "#/definitions/list_metadata"
+        }
+      },
+      "required": [
+        "metaData",
+        "data"
+      ]
+    },
+    "monitoring_get_aggregates_result": {
+      "type": "object",
+      "properties": {
+        "edgeCount": {
+          "type": "integer"
+        },
+        "edges": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "enterprises": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/enterprise_with_proxy_attributes"
+          }
+        }
+      }
+    },
+    "monitoring_get_enterprise_bgp_peer_status_result_item": {
+      "type": "object",
+      "properties": {
+        "gatewayName": {
+          "type": "string"
+        },
+        "gatewayLogicalId": {
+          "type": "string"
+        },
+        "neighbors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/bgp_peer_status"
+          }
+        }
+      }
+    },
+    "monitoring_get_enterprise_edge_bgp_peer_status_result_item": {
+      "type": "object",
+      "properties": {
+        "edgeName": {
+          "type": "string"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "edgeLogicalId": {
+          "type": "string"
+        },
+        "neighbors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/bgp_peer_status"
+          }
+        }
+      }
+    },
+    "monitored_link": {
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "edgeHASerialNumber": {
+          "type": "string"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "edgeLastContact": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "edgeLatitude": {
+          "type": "number",
+          "format": "double"
+        },
+        "edgeLongitude": {
+          "type": "number",
+          "format": "double"
+        },
+        "edgeModelNumber": {
+          "type": "string"
+        },
+        "edgeName": {
+          "type": "string"
+        },
+        "edgeSerialNumber": {
+          "type": "string"
+        },
+        "edgeServiceUpSince": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "edgeState": {
+          "enum": [
+            "NEVER_ACTIVATED",
+            "DEGRADED",
+            "OFFLINE",
+            "DISABLED",
+            "EXPIRED",
+            "CONNECTED"
+          ],
+          "type": "string"
+        },
+        "edgeSystemUpSince": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "enterpriseName": {
+          "type": "string"
+        },
+        "enterpriseProxyId": {
+          "type": "integer"
+        },
+        "enterpriseProxyName": {
+          "type": "string"
+        },
+        "interface": {
+          "type": "string"
+        },
+        "internalId": {
+          "type": "string"
+        },
+        "isp": {
+          "type": "string"
+        },
+        "linkId": {
+          "type": "integer"
+        },
+        "linkIpAddress": {
+          "type": "string"
+        },
+        "linkLastActive": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "linkState": {
+          "enum": [
+            "UNKNOWN",
+            "STABLE",
+            "UNSTABLE",
+            "DISCONNECTED",
+            "QUIET",
+            "INITIAL",
+            "STANDBY"
+          ],
+          "type": "string"
+        },
+        "linkVpnState": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "STABLE",
+            "UNSTABLE",
+            "DEAD",
+            "STANDBY"
+          ]
+        }
+      },
+      "required": [
+        "displayName",
+        "edgeHASerialNumber",
+        "edgeId",
+        "edgeLastContact",
+        "edgeLatitude",
+        "edgeLongitude",
+        "edgeModelNumber",
+        "edgeName",
+        "edgeSerialNumber",
+        "edgeServiceUpSince",
+        "edgeState",
+        "edgeSystemUpSince",
+        "enterpriseId",
+        "enterpriseName",
+        "enterpriseProxyId",
+        "enterpriseProxyName",
+        "interface",
+        "internalId",
+        "isp",
+        "linkId",
+        "linkIpAddress",
+        "linkLastActive",
+        "linkState",
+        "linkVpnState"
+      ]
+    },
+    "monitoring_get_enterprise_edge_link_status_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/monitored_link"
+        }
+      ]
+    },
+    "monitoring_get_enterprise_edge_vnf_status_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "vendor": {
+                  "type": "string"
+                },
+                "vendorSpecificData": {
+                  "type": "object"
+                }
+              }
+            },
+            "edgeCount": {
+              "type": "integer"
+            },
+            "edgeUsage": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "configurationId": {
+                    "type": "integer"
+                  },
+                  "edgeSpecificId": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "logicalId": {
+                    "type": "string"
+                  },
+                  "profileId": {
+                    "type": "integer"
+                  },
+                  "vnfStatus": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "vmStatus": {
+                        "type": "string"
+                      },
+                      "vnfInsertionEnabled": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "network_delete_network_gateway_pool_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "network_get_network_configurations_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/model_configuration"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "description",
+            "effective",
+            "modified",
+            "name",
+            "version"
+          ]
+        }
+      ]
+    },
+    "network_get_network_enterprises_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise"
+        },
+        {
+          "properties": {
+            "enterpriseProxyId": {
+              "type": "integer"
+            },
+            "enterpriseProxyName": {
+              "type": "string"
+            },
+            "edgeCount": {
+              "type": "integer"
+            },
+            "edges": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/edge_object"
+              }
+            },
+            "edgeConfigUpdate": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "enabledOnUpgrade": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "network_get_network_gateway_pools_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/gateway_pool"
+        },
+        {
+          "properties": {
+            "gateways": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/gateway_pool_gateway"
+              }
+            },
+            "enterprises": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/enterprise_with_proxy_attributes"
+              }
+            }
+          },
+          "required": [
+            "id",
+            "networkId",
+            "enterpriseProxyId",
+            "created",
+            "name",
+            "description",
+            "isDefault",
+            "handOffType",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "gateway_handoff_edge": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/edge_object"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "edgeId": {
+              "type": "integer"
+            },
+            "isPrimary": {
+              "type": "integer"
+            },
+            "pinned": {
+              "type": "integer"
+            },
+            "enterpriseLogicalId": {
+              "type": "string"
+            },
+            "enterpriseName": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "gateway_enterprise_assoc": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "enterpriseId": {
+              "type": "integer"
+            },
+            "enterpriseObjectId": {
+              "type": "integer"
+            },
+            "edgeId": {
+              "type": "integer"
+            },
+            "gatewayType": {
+              "type": "string",
+              "enum": [
+                "OTHER",
+                "SUPER",
+                "DATACENTER",
+                "HANDOFF",
+                "SUPER_ALT"
+              ]
+            },
+            "pinned": {
+              "type": "integer"
+            },
+            "enterpriseObjectName": {
+              "type": "string"
+            },
+            "enterpriseObjectType": {
+              "type": "string"
+            },
+            "edgeName": {
+              "type": "string"
+            },
+            "edgeLogicalId": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "edge_certificate": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "csrId": {
+          "type": "integer"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "certificate": {
+          "type": "string"
+        },
+        "serialNumber": {
+          "type": "string"
+        },
+        "subjectKeyId": {
+          "type": "string"
+        },
+        "fingerPrint": {
+          "type": "string"
+        },
+        "validFrom": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "validTo": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "gateway_certificate": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "csrId": {
+          "type": "integer"
+        },
+        "gatewayId": {
+          "type": "integer"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "certificate": {
+          "type": "string"
+        },
+        "serialNumber": {
+          "type": "string"
+        },
+        "subjectKeyId": {
+          "type": "string"
+        },
+        "fingerPrint": {
+          "type": "string"
+        },
+        "validFrom": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "validTo": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "gateway_site": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/site"
+        },
+        {
+          "type": "object",
+          "properties": {
+          }
+        }
+      ]
+    },
+    "gateway_gateway_pool": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/gateway_pool"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "gatewayPoolAssocId": {
+              "type": "integer"
+            },
+            "gatewayId": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "gateway_role": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "gatewayId": {
+          "type": "integer"
+        },
+        "gatewayRole": {
+          "type": "string",
+          "enum": [
+            "DATA_PLANE",
+            "CONTROL_PLANE",
+            "VPN_TUNNEL",
+            "ON_PREMISE",
+            "CDE"
+          ],
+          "x-alternate-name": "gatewayRoleProperty"
+        },
+        "required": {
+          "type": "integer"
+        }
+      }
+    },
+    "gateway_handoff_segment_metadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "segmentId": {
+          "type": "integer"
+        },
+        "segmentLogicalId": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "REGULAR",
+            "CDE"
+          ]
+        }
+      }
+    },
+    "gateway_handoff_value_bgp_priority_setup_auto_as": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "gateway_handoff_value_bgp_priority_setup_auto_med": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "gateway_handoff_value_vlan": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "cTag": {
+            "type": "integer"
+          },
+          "sTag": {
+            "type": "integer"
+          },
+          "transportLanVLAN": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "gateway_handoff_value_segments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/gateway_handoff_value"
+      }
+    },
+    "gateway_handoff_value": {
+      "type": "object",
+      "properties": {
+        "segments": {
+          "$ref": "#/definitions/gateway_handoff_value_segments"
+        },
+        "segment": {
+          "$ref": "#/definitions/gateway_handoff_segment_metadata"
+        },
+        "bgpPrioritySetup": {
+          "type": "object",
+          "properties": {
+            "autoAs": {
+              "$ref": "#/definitions/gateway_handoff_value_bgp_priority_setup_auto_as"
+            },
+            "autoMed": {
+              "$ref": "#/definitions/gateway_handoff_value_bgp_priority_setup_auto_med"
+            },
+            "communityMapping": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "priorityMode": {
+                  "type": "string",
+                  "enum": [
+                    "ALL_SEGMENTS",
+                    "PER_SEGMENT"
+                  ]
+                },
+                "priorities": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "community": {
+                        "type": "string"
+                      },
+                      "community2": {
+                        "type": "string"
+                      },
+                      "priority": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                },
+                "communityAdditive": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "802.1Q",
+            "802.1ad",
+            "QinQ (0x9100)",
+            "QinQ (0x8100)"
+          ]
+        },
+        "override": {
+          "type": "boolean"
+        },
+        "cTag": {
+          "type": "integer"
+        },
+        "sTag": {
+          "type": "integer"
+        },
+        "localAddress": {
+          "type": "object",
+          "properties": {
+            "cidrIp": {
+              "type": "string"
+            },
+            "cidrPrefix": {
+              "type": "integer"
+            },
+            "useForPrivate": {
+              "type": "boolean"
+            },
+            "advertiseViaBgp": {
+              "type": "boolean"
+            },
+            "override": {
+              "type": "boolean"
+            }
+          }
+        },
+        "staticRoutes": {
+          "type": "object",
+          "properties": {
+            "override": {
+              "type": "boolean"
+            },
+            "subnets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "cidrIp": {
+                    "type": "string"
+                  },
+                  "cidrPrefix": {
+                    "type": "integer"
+                  },
+                  "encrypt": {
+                    "type": "boolean"
+                  },
+                  "handOffType": {
+                    "type": "string",
+                    "enum": [
+                      "NAT",
+                      "VLAN"
+                    ]
+                  },
+                  "routeCost": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 255
+                  }
+                }
+              }
+            }
+          }
+        },
+        "bgp": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "ASN": {
+              "type": "string"
+            },
+            "neighborIp": {
+              "type": "string"
+            },
+            "neighborASN": {
+              "type": "string"
+            },
+            "encryption": {
+              "type": "boolean"
+            }
+          }
+        },
+        "bgpInboundMap": {
+          "$ref": "#/definitions/gateway_handoff_bgp_rules_map"
+        },
+        "bgpOutboundMap": {
+          "$ref": "#/definitions/gateway_handoff_bgp_rules_map"
+        },
+        "VLAN": {
+          "$ref": "#/definitions/gateway_handoff_value_vlan"
+        },
+        "overrides": {
+          "type": "object",
+          "properties": {
+            "VLAN": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "cTag": {
+                    "type": "integer"
+                  },
+                  "sTag": {
+                    "type": "integer"
+                  },
+                  "transportLanVLAN": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "bgp": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "ASN": {
+                    "type": "string"
+                  },
+                  "neighborIp": {
+                    "type": "string"
+                  },
+                  "neighborASN": {
+                    "type": "string"
+                  },
+                  "encryption": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "bgpInboundMap": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/gateway_handoff_bgp_rules_map"
+              }
+            },
+            "bgpOutboundMap": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/gateway_handoff_bgp_rules_map"
+              }
+            },
+            "localAddress": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "cidrIp": {
+                    "type": "string"
+                  },
+                  "cidrPrefix": {
+                    "type": "integer"
+                  },
+                  "useForPrivate": {
+                    "type": "boolean"
+                  },
+                  "advertiseViaBgp": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "subnets": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gateway_handoff": {
+      "type": "object",
+      "properties": {
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "value": {
+          "$ref": "#/definitions/gateway_handoff_value"
+        }
+      }
+    },
+    "gateway_handoff_bgp_rules_map": {
+      "type": "object",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gateway_handoff_bgp_rule"
+          }
+        },
+        "override": {
+          "type": "boolean"
+        }
+      }
+    },
+    "gateway_handoff_bgp_rule": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/bgp_filter_rule"
+        }
+      ]
+    },
+    "bgp_filter_rule": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "match": {
+          "type": "object",
+          "properties": {
+            "exactMatch": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "network_get_network_gateways_result_item": {
+      "type": "object",
+      "properties": {
+        "activationKey": {
+          "type": "string"
+        },
+        "activationState": {
+          "type": "string",
+          "enum": [
+            "UNASSIGNED",
+            "PENDING",
+            "ACTIVATED",
+            "REACTIVATION_PENDING"
+          ]
+        },
+        "activationTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "buildNumber": {
+          "type": "string"
+        },
+        "certificates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gateway_certificate"
+          }
+        },
+        "connectedEdges": {
+          "type": "integer"
+        },
+        "connectedEdgeList": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "vceid": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "dataCenters": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "description": {
+          "type": "string"
+        },
+        "deviceId": {
+          "type": "string"
+        },
+        "dnsName": {
+          "type": "string"
+        },
+        "endpointPkiMode": {
+          "type": "string",
+          "enum": [
+            "CERTIFICATE_DISABLED",
+            "CERTIFICATE_OPTIONAL",
+            "CERTIFICATE_REQUIRED"
+          ]
+        },
+        "enterpriseAssociations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gateway_enterprise_assoc"
+          }
+        },
+        "enterpriseAssociationCount": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "enterprises": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/enterprise"
+          }
+        },
+        "enterpriseProxyId": {
+          "type": "integer"
+        },
+        "gatewayState": {
+          "type": "string",
+          "enum": [
+            "NEVER_ACTIVATED",
+            "DEGRADED",
+            "QUIESCED",
+            "DISABLED",
+            "OUT_OF_SERVICE",
+            "CONNECTED",
+            "OFFLINE"
+          ]
+        },
+        "handOffDetail": {
+          "$ref": "#/definitions/gateway_handoff_detail"
+        },
+        "handOffEdges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gateway_handoff_edge"
+          }
+        },
+        "id": {
+          "type": "integer"
+        },
+        "ipAddress": {
+          "type": "string"
+        },
+        "ipsecGatewayDetail": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "strictHostCheck": {
+              "type": "boolean"
+            },
+            "strictHostCheckDN": {
+              "type": "string"
+            }
+          }
+        },
+        "isLoadBalanced": {
+          "type": "boolean"
+        },
+        "lastContact": {
+          "type": "string"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "pools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gateway_gateway_pool"
+          }
+        },
+        "privateIpAddress": {
+          "type": "string"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gateway_role"
+          }
+        },
+        "serviceState": {
+          "type": "string",
+          "enum": [
+            "IN_SERVICE",
+            "OUT_OF_SERVICE",
+            "PENDING_SERVICE",
+            "QUIESCED"
+          ]
+        },
+        "serviceUpSince": {
+          "type": "string"
+        },
+        "site": {
+          "$ref": "#/definitions/gateway_site"
+        },
+        "siteId": {
+          "type": "integer"
+        },
+        "softwareVersion": {
+          "type": "string"
+        },
+        "systemUpSince": {
+          "type": "string"
+        },
+        "utilization": {
+          "type": "number"
+        },
+        "utilizationDetail": {
+          "type": "object",
+          "properties": {
+            "load": {
+              "type": "number"
+            },
+            "overall": {
+              "type": "number"
+            },
+            "cpu": {
+              "type": "number"
+            },
+            "memory": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "enterprise_proxy_get_enterprise_proxy_gateways_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/network_get_network_gateways_result_item"
+        }
+      ]
+    },
+    "network_get_network_operator_users_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/operator_user_with_role_info"
+        }
+      ]
+    },
+    "network_insert_network_gateway_pool_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "network_update_network_gateway_pool_attributes_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "new_enterprise_user": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base_enterprise_user"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "enterpriseId": {
+              "type": "integer"
+            },
+            "enterpriseProxyId": {
+              "type": "integer"
+            },
+            "roleId": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "roleId",
+            "username",
+            "password"
+          ]
+        }
+      ]
+    },
+    "enterprise_proxy_insert_or_update_enterprise_proxy_property_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_proxy_property": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "enterpriseProxyId": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "isPassword": {
+          "type": "boolean"
+        },
+        "dataType": {
+          "type": "string",
+          "enum": [
+            "STRING",
+            "NUMBER",
+            "BOOLEAN",
+            "JSON",
+            "DATE",
+            "DATETIME"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "enterprise_proxy_get_enterprise_proxy_property_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_proxy_property"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "name",
+            "enterpriseProxyId",
+            "value",
+            "isPassword",
+            "dataType",
+            "description",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "new_enterprise_proxy_user": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/new_enterprise_user"
+        }
+      ]
+    },
+    "operator_user_insert_operator_user": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base_enterprise_user"
+        },
+        {
+          "properties": {
+            "networkId": {
+              "type": "integer"
+            },
+            "roleId": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "networkId",
+            "roleId",
+            "username",
+            "password"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "role_create_role_customization_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/empty_object"
+        }
+      ]
+    },
+    "role_delete_role_customization_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "role_get_user_type_roles_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/role"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "operatorId",
+            "networkId",
+            "enterpriseId",
+            "enterpriseProxyId",
+            "name",
+            "userType",
+            "fromUserType",
+            "isSuper",
+            "description",
+            "precedence",
+            "modified"
+          ]
+        }
+      ]
+    },
+    "set_delegated_result": {
+      "type": "object",
+      "properties": {
+        "isDelegated": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "isDelegated"
+      ]
+    },
+    "role_set_enterprise_delegated_to_enterprise_proxy_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/set_delegated_result"
+        }
+      ]
+    },
+    "role_set_enterprise_delegated_to_operator_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/set_delegated_result"
+        }
+      ]
+    },
+    "role_set_enterprise_proxy_delegated_to_operator_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/set_delegated_result"
+        }
+      ]
+    },
+    "role_set_enterprise_user_management_delegated_to_operator_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/set_delegated_result"
+        }
+      ]
+    },
+    "system_property": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "defaultValue": {
+          "type": "string"
+        },
+        "isReadOnly": {
+          "type": "boolean"
+        },
+        "isPassword": {
+          "type": "boolean"
+        },
+        "dataType": {
+          "type": "string",
+          "enum": [
+            "STRING",
+            "NUMBER",
+            "BOOLEAN",
+            "JSON",
+            "DATE",
+            "DATETIME"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "system_property_get_system_property_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/system_property"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "name",
+            "value",
+            "defaultValue",
+            "isReadOnly",
+            "isPassword",
+            "dataType",
+            "description"
+          ]
+        }
+      ]
+    },
+    "system_property_get_system_properties_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/system_property"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "name",
+            "value",
+            "defaultValue",
+            "isReadOnly",
+            "isPassword",
+            "dataType",
+            "description"
+          ]
+        }
+      ]
+    },
+    "system_property_insert_or_update_system_property_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "system_property_insert_system_property_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "system_property_update_system_property_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "enterprise_get_enterprise_users_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_user_with_role_info"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "userType",
+            "username",
+            "domain",
+            "password",
+            "firstName",
+            "lastName",
+            "officePhone",
+            "mobilePhone",
+            "email",
+            "isNative",
+            "isActive",
+            "isLocked",
+            "disableSecondFactor",
+            "lastLogin",
+            "modified",
+            "roleId",
+            "roleName"
+          ]
+        }
+      ]
+    },
+    "enterprise_insert_enterprise_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_user_delete_enterprise_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "enterprise_user_get_enterprise_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_user_with_role_and_assocs"
+        },
+        {
+          "required": [
+            "id",
+            "created",
+            "userType",
+            "username",
+            "domain",
+            "password",
+            "firstName",
+            "lastName",
+            "officePhone",
+            "mobilePhone",
+            "email",
+            "isNative",
+            "isActive",
+            "isLocked",
+            "lastLogin",
+            "modified",
+            "roleId",
+            "roleName",
+            "enterpriseId",
+            "enterpriseProxyId",
+            "networkId"
+          ]
+        }
+      ]
+    },
+    "enterprise_user_update_enterprise_user": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string",
+          "format": "password"
+        },
+        "password2": {
+          "type": "string",
+          "format": "password"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "officePhone": {
+          "type": "string"
+        },
+        "mobilePhone": {
+          "type": "string"
+        },
+        "isNative": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "disableSecondFactor": {
+          "type": "boolean"
+        },
+        "email": {
+          "type": "string"
+        },
+        "roleId": {
+          "type": "integer"
+        }
+      }
+    },
+    "enterprise_user_update_enterprise_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "enterprise_proxy_delete_enterprise_proxy_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "enterprise_proxy_get_enterprise_proxy_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_user_with_role_info"
+        },
+        {
+          "properties": {
+            "enterpriseProxyId": {
+              "type": "integer"
+            },
+            "networkId": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_proxy_insert_enterprise_proxy_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "enterprise_proxy_update_enterprise_proxy_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "enterprise_proxy_get_enterprise_proxy_users_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_user_with_role_info"
+        },
+        {
+          "properties": {
+            "enterpriseProxyId": {
+              "type": "integer"
+            },
+            "networkId": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "operator_user_delete_operator_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/deletion_confirmation"
+        }
+      ]
+    },
+    "operator_user_get_operator_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/operator_user_with_role_info"
+        }
+      ]
+    },
+    "operator_user_insert_operator_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/insertion_confirmation"
+        }
+      ]
+    },
+    "operator_user_update_operator_user": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string",
+          "format": "password"
+        },
+        "password2": {
+          "type": "string",
+          "format": "password"
+        },
+        "roleId": {
+          "type": "integer"
+        },
+        "email": {
+          "type": "string"
+        },
+        "mobilePhone": {
+          "type": "string"
+        },
+        "officePhone": {
+          "type": "string"
+        },
+        "operatorId": {
+          "type": "integer"
+        },
+        "userType": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "isNative": {
+          "type": "boolean"
+        },
+        "isLocked": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        }
+      }
+    },
+    "operator_user_update_operator_user_result": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/rows_modified_confirmation"
+        }
+      ]
+    },
+    "role": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "operatorId": {
+          "type": "integer"
+        },
+        "networkId": {
+          "type": "integer"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "enterpriseProxyId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userType": {
+          "type": "string",
+          "enum": [
+            "OPERATOR",
+            "MSP",
+            "PARTNER",
+            "ENTERPRISE",
+            "END_USER",
+            "CUSTOM"
+          ]
+        },
+        "fromUserType": {
+          "type": "string",
+          "enum": [
+            "OPERATOR",
+            "MSP",
+            "PARTNER",
+            "ENTERPRISE",
+            "END_USER",
+            "CUSTOM"
+          ]
+        },
+        "isSuper": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "precedence": {
+          "type": "integer"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "protocol_port_mapping": {
+      "properties": {
+        "tcpPorts": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "udpPorts": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "rows_modified_confirmation": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "description": "An error message explaining why the method failed",
+          "type": "string"
+        },
+        "rows": {
+          "description": "The number of rows modified",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "rows"
+      ],
+      "example": {
+        "rows": 1
+      }
+    },
+    "insertion_confirmation": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "The id of the newly-created object."
+        },
+        "rows": {
+          "description": "The number of rows modified",
+          "type": "integer"
+        },
+        "error": {
+          "description": "An error message explaining why the method failed",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rows"
+      ],
+      "example": {
+        "id": 123,
+        "rows": 1
+      }
+    },
+    "deletion_confirmation": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "The id of the deleted object."
+        },
+        "error": {
+          "description": "An error message explaining why the method failed",
+          "type": "string"
+        },
+        "rows": {
+          "description": "The number of rows modified",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "rows"
+      ],
+      "example": {
+        "id": 123,
+        "rows": 1
+      }
+    },
+    "license": {
+      "type": "object",
+      "properties": {
+        "tier": {
+          "type": "string"
+        },
+        "bandwidth": {
+          "type": "string"
+        },
+        "term": {
+          "type": "number"
+        },
+        "cloudGatewayRegions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "site": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "contactName": {
+          "type": "string"
+        },
+        "contactPhone": {
+          "type": "string"
+        },
+        "contactMobile": {
+          "type": "string"
+        },
+        "contactEmail": {
+          "type": "string"
+        },
+        "streetAddress": {
+          "type": "string"
+        },
+        "streetAddress2": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "postalCode": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "lat": {
+          "type": "number",
+          "format": "double"
+        },
+        "lon": {
+          "type": "number",
+          "format": "double"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "locale": {
+          "type": "string"
+        },
+        "shippingSameAsLocation": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "shippingContactName": {
+          "type": "string"
+        },
+        "shippingAddress": {
+          "type": "string"
+        },
+        "shippingAddress2": {
+          "type": "string"
+        },
+        "shippingCity": {
+          "type": "string"
+        },
+        "shippingState": {
+          "type": "string"
+        },
+        "shippingCountry": {
+          "type": "string"
+        },
+        "shippingPostalCode": {
+          "type": "string"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "firewall_get_enterprise_firewall_logs_result": {
+      "type": "object",
+      "properties": {
+        "metaData": {
+          "$ref": "#/definitions/list_metadata"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/firewall_log_data"
+          }
+        },
+        "rules": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/firewall_rule"
+          }
+        }
+      }
+    },
+    "firewall_log_data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "allow": {
+          "type": "integer"
+        },
+        "ruleLogicalId": {
+          "type": "string"
+        },
+        "interface": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "ICMP",
+            "TCP",
+            "UDP",
+            "GRE"
+          ]
+        },
+        "sourceIp": {
+          "type": "string"
+        },
+        "sourcePort": {
+          "type": "integer"
+        },
+        "destIp": {
+          "type": "string"
+        },
+        "destPort": {
+          "type": "integer"
+        },
+        "icmpType": {
+          "type": "string"
+        },
+        "length": {
+          "type": "integer"
+        }
+      }
+    },
+    "firewall_rule": {
+      "type": "object",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "data": {
+          "type": "string"
+        },
+        "deactivated": {
+          "type": "string"
+        },
+        "edgeLogicalId": {
+          "type": "string"
+        },
+        "enterpriseId": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "logicalId": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "INBOUND",
+            "OUTBOUND",
+            "SERVICE"
+          ]
+        }
+      }
+    },
+    "vco_inventory_get_inventory_items_result": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/inventory_item"
+      }
+    },
+    "inventory_item": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "deviceSerialNumber": {
+          "type": "string"
+        },
+        "deviceUuid": {
+          "type": "string"
+        },
+        "modelNumber": {
+          "type": "string"
+        },
+        "siteId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "acknowledged": {
+          "type": "integer"
+        },
+        "edgeId": {
+          "type": "integer"
+        },
+        "edge": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "edge": {
+              "type": "string"
+            },
+            "site": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "inventoryState": {
+          "type": "string"
+        },
+        "inventoryEdgeState": {
+          "type": "string"
+        },
+        "inventoryAction": {
+          "type": "string"
+        },
+        "vcoOwnerId": {
+          "type": "integer"
+        },
+        "vcoOwner": {
+          "type": "object",
+          "properties": {
+            "accountNumber": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "basic_metric_summary": {
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "average": {
+          "type": "number"
+        }
+      },
+      "type": "object",
+      "required": [
+        "min",
+        "max",
+        "average"
+      ]
+    },
+    "gateway_metric": {
+      "enum": [
+        "tunnelCount",
+        "memoryPct",
+        "flowCount",
+        "cpuPct",
+        "handoffQueueDrops",
+        "connectedEdges"
+      ],
+      "type": "string"
+    },
+    "gateway_metrics": {
+      "items": {
+        "$ref": "#/definitions/gateway_metric"
+      },
+      "type": "array"
+    },
+    "gateway_status_metrics_summary": {
+      "type": "object",
+      "title": "metrics_get_gateway_status_metrics_result",
+      "properties": {
+        "total": {
+          "type": "integer"
+        },
+        "tunnelCount": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "memoryPct": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "flowCount": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "cpuPct": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "handoffQueueDrops": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "connectedEdges": {
+          "$ref": "#/definitions/basic_metric_summary"
+        }
+      }
+    },
+    "gateway_status_metrics_time_series_item": {
+      "type": "object",
+      "title": "gateway_status_metrics_time_series_item",
+      "properties": {
+        "tunnelCount": {
+          "type": "integer"
+        },
+        "memoryPct": {
+          "type": "number"
+        },
+        "flowCount": {
+          "type": "number"
+        },
+        "cpuPct": {
+          "type": "number"
+        },
+        "handoffQueueDrops": {
+          "type": "integer"
+        },
+        "connectedEdges": {
+          "type": "integer"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "startTime"
+      ]
+    },
+    "get_gateway_status_metrics_time_series_result": {
+      "type": "object",
+      "title": "gateway_status_metrics_time_series_result",
+      "properties": {
+        "series": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gateway_status_metrics_time_series_item"
+          }
+        }
+      },
+      "required": [
+        "series"
+      ]
+    },
+    "monitoring_network_gateway_status_item": {
+      "type": "object",
+      "title": "monitoring_network_gateway_status_item",
+      "properties": {
+        "gatewayId": {
+          "type": "integer"
+        },
+        "tunnelCount": {
+          "type": "integer"
+        },
+        "memoryPct": {
+          "type": "number"
+        },
+        "flowCount": {
+          "type": "number"
+        },
+        "cpuPct": {
+          "type": "number"
+        },
+        "handoffQueueDrops": {
+          "type": "integer"
+        },
+        "connectedEdges": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "gatewayId"
+      ]
+    },
+    "monitoring_get_network_gateway_status_result": {
+      "type": "object",
+      "title": "monitoring_network_gateway_status_result",
+      "properties": {
+        "metaData": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": "integer"
+            },
+            "more": {
+              "type": "boolean"
+            }
+          }
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/monitoring_network_gateway_status_item"
+          }
+        }
+      },
+      "required": [
+        "metaData",
+        "data"
+      ]
+    },
+    "edge_metric": {
+      "enum": [
+        "tunnelCount",
+        "memoryPct",
+        "flowCount",
+        "cpuPct",
+        "handoffQueueDrops"
+      ],
+      "type": "string"
+    },
+    "edge_metrics": {
+      "items": {
+        "$ref": "#/definitions/edge_metric"
+      },
+      "type": "array"
+    },
+    "edge_status_metrics_summary": {
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "integer"
+        },
+        "tunnelCount": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "memoryPct": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "flowCount": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "cpuPct": {
+          "$ref": "#/definitions/basic_metric_summary"
+        },
+        "handoffQueueDrops": {
+          "$ref": "#/definitions/basic_metric_summary"
+        }
+      }
+    },
+    "edge_status_metrics_time_series_item": {
+      "type": "object",
+      "title": "edge_status_metrics_time_series_item",
+      "properties": {
+        "tunnelCount": {
+          "type": "integer"
+        },
+        "memoryPct": {
+          "type": "number"
+        },
+        "flowCount": {
+          "type": "number"
+        },
+        "cpuPct": {
+          "type": "number"
+        },
+        "handoffQueueDrops": {
+          "type": "integer"
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "startTime"
+      ]
+    },
+    "get_edge_status_metrics_time_series_result": {
+      "type": "object",
+      "title": "edge_status_metrics_time_series_result",
+      "properties": {
+        "series": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/edge_status_metrics_time_series_item"
+          }
+        }
+      },
+      "required": [
+        "series"
+      ]
+    },
+    "monitoring_enterprise_edge_status_item": {
+      "type": "object",
+      "title": "monitoring_enterprise_edge_status_item",
+      "properties": {
+        "edgeId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tunnelCount": {
+          "type": "integer"
+        },
+        "memoryPct": {
+          "type": "number"
+        },
+        "flowCount": {
+          "type": "number"
+        },
+        "cpuPct": {
+          "type": "number"
+        },
+        "handoffQueueDrops": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "edgeId"
+      ]
+    },
+    "monitoring_get_enterprise_edge_status_result": {
+      "type": "object",
+      "title": "monitoring_enterprise_edge_status_result",
+      "properties": {
+        "metaData": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": "integer"
+            },
+            "more": {
+              "type": "boolean"
+            }
+          }
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/monitoring_enterprise_edge_status_item"
+          }
+        }
+      },
+      "required": [
+        "metaData",
+        "data"
+      ]
+    },
+    "edge_get_edge_certificates_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/edge_certificate"
+        }
+      ]
+    },
+    "enterprise_get_enterprise_network_segments_result_item": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/network_segment"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "edgeCount": {
+              "type": "integer"
+            },
+            "edgeUsage": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "configurationId": {
+                    "type": "integer"
+                  },
+                  "edgeSpecificId": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "logicalId": {
+                    "type": "string"
+                  },
+                  "profileId": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "configuration": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "created": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "logicalId": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "configurationType": {
+                    "type": "string",
+                    "enum": [
+                      "NETWORK_BASED",
+                      "SEGMENT_BASED"
+                    ]
+                  },
+                  "schemaVersion": {
+                    "type": "string"
+                  },
+                  "effective": {
+                    "type": "string"
+                  },
+                  "modified": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "moduleId": {
+                    "type": "integer"
+                  },
+                  "segmentObjectId": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "enterprise_encode_enterprise_key_result": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key"
+      ]
+    },
+    "enterprise_decode_enterprise_key_result": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key"
+      ]
+    },
+    "network_segment": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/network_segment_data"
+            },
+            "profileCount": {
+              "type": "integer"
+            },
+            "handoffUsage": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "isAllMPGCDE": {
+              "type": "boolean"
+            },
+            "isAllCtrlCDE": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "network_segment_data": {
+      "type": "object",
+      "properties": {
+        "segmentId": {
+          "type": "integer"
+        },
+        "serviceVlan": {
+          "type": "integer"
+        },
+        "delegateToEnterprise": {
+          "type": "boolean"
+        },
+        "delegateToEnterpriseProxy": {
+          "type": "boolean"
+        }
+      }
+    },
+    "cloud_security_service": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/cloud_security_service_data"
+            }
+          }
+        }
+      ]
+    },
+    "cloud_security_service_data": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "cloudSecurityService"
+        },
+        "provider": {
+          "type": "string",
+          "enum": [
+            "symantecCloudSecurityService",
+            "zscalerWebSecurityService",
+            "genericCloudSecurityService"
+          ]
+        },
+        "config": {
+          "$ref": "#/definitions/cloud_security_service_provider_config"
+        }
+      }
+    },
+    "cloud_security_service_provider_config": {
+      "type": "object",
+      "properties": {
+        "primaryServer": {
+          "type": "string"
+        },
+        "secondaryServer": {
+          "type": "string"
+        },
+        "enableTunnels": {
+          "type": "boolean"
+        },
+        "sharedIkeAuth": {
+          "type": "boolean"
+        },
+        "maxTunnelsPerIkeIdentity": {
+          "type": "integer"
+        },
+        "automateDeployment": {
+          "type": "boolean"
+        },
+        "credentials": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "validated": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "cloud_security_service_site": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/cloud_security_service_site_data"
+            }
+          }
+        }
+      ]
+    },
+    "cloud_security_service_site_data": {
+      "type": "object"
+    },
+    "cloud_security_service_site_data_generic_ipsec": {
+      "type": "object",
+      "properties": {
+        "ikeId": {
+          "type": "string"
+        },
+        "ikeIdType": {
+          "type": "string"
+        },
+        "psk": {
+          "type": "string"
+        },
+        "pskType": {
+          "type": "string"
+        }
+      }
+    },
+    "cloud_security_service_site_data_zscaler_gre": {
+      "type": "object",
+      "properties": {
+        "customSourceIp": {
+          "type": "string"
+        },
+        "linkInternalLogicalId": {
+          "type": "string"
+        },
+        "primaryAddressing": {
+          "type": "object",
+          "properties": {
+            "internalRouterIp": {
+              "type": "string"
+            },
+            "internalRouterMask": {
+              "type": "string"
+            },
+            "internalZenIp": {
+              "type": "string"
+            },
+            "internalZenMask": {
+              "type": "string"
+            }
+          }
+        },
+        "secondaryAddressing": {
+          "type": "object",
+          "properties": {
+            "internalRouterIp": {
+              "type": "string"
+            },
+            "internalRouterMask": {
+              "type": "string"
+            },
+            "internalZenIp": {
+              "type": "string"
+            },
+            "internalZenMask": {
+              "type": "string"
+            }
+          }
+        },
+        "useCustomSourceIp": {
+          "type": "boolean"
+        }
+      }
+    },
+    "security_vnf_service": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/security_vnf_service_data"
+            }
+          }
+        }
+      ]
+    },
+    "security_vnf_service_data": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "securityVnfService"
+        },
+        "vendor": {
+          "type": "string",
+          "enum": [
+            "PaloAlto",
+            "CheckPoint",
+            "Fortinet",
+            "CentOS"
+          ]
+        },
+        "vendorSpecificData": {
+          "$ref": "#/definitions/security_vnf_service_data"
+        }
+      }
+    },
+    "security_vnf_service_vendor_specific_data": {
+      "type": "object"
+    },
+    "security_vnf_service_palo_alto_networks": {
+      "type": "object",
+      "properties": {
+        "managementServer": {
+          "type": "object",
+          "properties": {
+            "primary": {
+              "type": "string"
+            },
+            "secondary": {
+              "type": "string"
+            },
+            "authKey": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "security_vnf_service_check_point_software": {
+      "type": "object",
+      "properties": {
+        "managementServer": {
+          "type": "object",
+          "properties": {
+            "primary": {
+              "type": "string"
+            },
+            "sicKey": {
+              "type": "string"
+            }
+          }
+        },
+        "vmConfiguration": {
+          "type": "object",
+          "properties": {
+            "adminPassword": {
+              "type": "string"
+            }
+          }
+        },
+        "image": {
+          "$ref": "#/definitions/security_vnf_service_image_info"
+        }
+      }
+    },
+    "security_vnf_service_fortinet": {
+      "type": "object",
+      "properties": {
+        "managementServer": {
+          "type": "object",
+          "properties": {
+            "primary": {
+              "type": "string"
+            },
+            "serialNumber": {
+              "type": "string"
+            },
+            "registrationPassword": {
+              "type": "string"
+            }
+          }
+        },
+        "image": {
+          "$ref": "#/definitions/security_vnf_service_image_info"
+        }
+      }
+    },
+    "security_vnf_service_image_info": {
+      "type": "object",
+      "properties": {
+        "downloadType": {
+          "type": "string",
+          "enum": [
+            "s3",
+            "http",
+            "https"
+          ]
+        },
+        "fileLocation": {
+          "type": "string"
+        },
+        "fileChecksum": {
+          "type": "string"
+        },
+        "fileChecksumType": {
+          "type": "string"
+        },
+        "https": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            }
+          }
+        },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "accessKeyId": {
+              "type": "string"
+            },
+            "secretAccessKey": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "security_vnf_image": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/security_vnf_image_data"
+            }
+          }
+        }
+      ]
+    },
+    "security_vnf_image_data": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/logicalid_reference"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ref": {
+                  "type": "string",
+                  "pattern": "deviceSettings:securityVnf:service"
+                }
+              }
+            }
+          ]
+        },
+        "IN_PROGRESS": {
+          "$ref": "#/definitions/vnf_image_download_event_detail"
+        },
+        "COMPLETED": {
+          "$ref": "#/definitions/vnf_image_download_event_detail"
+        },
+        "FAILED": {
+          "$ref": "#/definitions/vnf_image_download_event_detail"
+        }
+      }
+    },
+    "security_vnf_license": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/security_vnf_license_data"
+            }
+          }
+        }
+      ]
+    },
+    "security_vnf_license_data": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "securityVnfLicense"
+        },
+        "vendor": {
+          "type": "string",
+          "enum": [
+            "PaloAlto",
+            "CheckPoint",
+            "Fortinet",
+            "CentOS"
+          ]
+        },
+        "vendorSpecificData": {
+          "$ref": "#/definitions/security_vnf_license_data"
+        }
+      }
+    },
+    "security_vnf_license_vendor_specific_data": {
+      "type": "object"
+    },
+    "security_vnf_license_palo_alto_networks": {
+      "type": "object",
+      "properties": {
+        "licenseServer": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string"
+            },
+            "apiKey": {
+              "type": "string"
+            }
+          }
+        },
+        "authCode": {
+          "type": "string"
+        }
+      }
+    },
+    "edge_vnf": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/enterprise_object_base"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/security_vnf_service_data"
+            }
+          }
+        }
+      ]
+    },
+    "edge_vnf_data": {
+      "type": "object",
+      "properties": {
+        "securityVnf": {
+          "type": "object",
+          "properties": {
+            "vms": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/edge_vnf_security_vnf_vm"
+              }
+            }
+          }
+        }
+      }
+    },
+    "edge_vnf_security_vnf_vm": {
+      "type": "object",
+      "properties": {
+        "cidrIp": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "edgeEvent": {
+          "type": "object",
+          "properties": {
+            "DEPLOYED": {
+              "$ref": "#/definitions/vnf_vm_event_detail"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "DEPLOYED",
+                "POWERED_ON",
+                "POWERED_OFF",
+                "DELETED",
+                "ERROR",
+                "UNKNOWN"
+              ]
+            }
+          }
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "insertionEnabled": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": "string",
+          "pattern": "deviceSettings:vnfs:edge"
+        },
+        "type": {
+          "type": "string",
+          "pattern": "securityVnf"
+        },
+        "vendor": {
+          "type": "string",
+          "enum": [
+            "PaloAlto",
+            "CheckPoint",
+            "Fortinet",
+            "CentOS"
+          ]
+        },
+        "vendorSpecificData": {
+          "$ref": "#/definitions/edge_vnf_security_vnf_vm_vendor_specific_data"
+        },
+        "vlanId": {
+          "type": "integer"
+        },
+        "vmDeploy": {
+          "type": "boolean"
+        },
+        "vmPowerOff": {
+          "type": "boolean"
+        }
+      }
+    },
+    "vnf_vm_event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/event_base"
+        },
+        {
+          "properties": {
+            "detail": {
+              "$ref": "#/definitions/vnf_vm_event_detail"
+            }
+          },
+          "required": [
+            "id",
+            "eventTime",
+            "event",
+            "category",
+            "severity",
+            "detail"
+          ]
+        }
+      ]
+    },
+    "vnf_vm_event_detail": {
+      "type": "object",
+      "properties": {
+        "configUuid": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object"
+        },
+        "edgeSerialNumber": {
+          "type": "string"
+        },
+        "isEdgeActive": {
+          "type": "boolean"
+        },
+        "runningConfig": {
+          "type": "object"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "DEPLOYED",
+            "POWERED_ON",
+            "POWERED_OFF",
+            "DELETED",
+            "ERROR",
+            "UNKNOWN"
+          ]
+        },
+        "uuid": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string",
+          "enum": [
+            "PaloAlto",
+            "CheckPoint",
+            "Fortinet",
+            "CentOS"
+          ]
+        },
+        "vnfEdgeLogicalId": {
+          "type": "string"
+        },
+        "vnfType": {
+          "type": "string",
+          "enum": [
+            "securityVnf"
+          ]
+        }
+      }
+    },
+    "edge_vnf_security_vnf_vm_vendor_specific_data": {
+      "type": "object"
+    },
+    "edge_vnf_security_vnf_vm_palo_alto_networks": {
+      "type": "object",
+      "properties": {
+        "deviceGroupName": {
+          "type": "string"
+        },
+        "deviceTemplateName": {
+          "type": "string"
+        }
+      }
+    },
+    "edge_vnf_security_vnf_vm_check_point_software": {
+      "type": "object"
+    },
+    "edge_vnf_security_vnf_vm_fortinet": {
+      "type": "object",
+      "properties": {
+        "inspectionMode": {
+          "type": "string",
+          "enum": [
+            "proxy",
+            "flow"
+          ]
+        },
+        "license": {
+          "type": "string"
+        }
+      }
+    },
+    "enterprise_user_do_all_users_have_phones": {
+      "type": "object",
+      "properties": {
+        "doUsersHavePhones": {
+          "type": "boolean"
+        },
+        "doesPhoneHasAtLeastOneUser": {
+          "type": "boolean"
+        }
+      }
+    },
+    "vpn_generate_vpn_gateway_configuration_result": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "object": {
+          "type": "string",
+          "enum": [
+            "NETWORK_ALLOCATION",
+            "NETWORK_SERVICE",
+            "CUSTOM_APPLICATION",
+            "ROUTING_CONFIGURATION",
+            "NETWORK_SEGMENT",
+            "HA_SERVICE",
+            "PRIVATE_NETWORK",
+            "CDE_GATEWAY",
+            "EDGE_LICENSE"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dns",
+            "authentication",
+            "dataCenter",
+            "dataCenterEdge",
+            "edgeHub",
+            "partnerGateway",
+            "edgeHubCluster",
+            "edgeBranchCluster",
+            "localUiCredentials",
+            "edgeBranchClusterMember",
+            "edgeHubClusterMember",
+            "securityVnf",
+            "edgeVrrpPairSet",
+            "cloudSecurityService",
+            "cloudSecurityServiceSite",
+            "securityVnfLicense",
+            "securityVnfService",
+            "primary",
+            "secondary",
+            "controllerGateway",
+            "tacacs",
+            "netflowCollector",
+            "iaasSubscription",
+            "netflowFilter",
+            "vnfImage",
+            "custom"
+          ]
+        },
+        "data": {
+          "$ref": "#/definitions/data_center_data"
+        }
+      }
+    },
+    "data_center_data": {
+      "type": "object",
+      "properties": {
+        "authentication": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        "isCDE": {
+          "type": "boolean"
+        },
+        "isServiceEnabled": {
+          "type": "boolean"
+        },
+        "primary": {
+          "$ref": "#/definitions/data_center_vpn_tunnel"
+        },
+        "secondary": {
+          "$ref": "#/definitions/data_center_vpn_tunnel"
+        },
+        "subnets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "advertise": {
+                "type": "boolean"
+              },
+              "cidrIp": {
+                "type": "string",
+                "format": "ipv4"
+              },
+              "cidrIpStart": {
+                "type": "string",
+                "format": "ipv4"
+              },
+              "cidrIpEnd": {
+                "type": "string",
+                "format": "ipv4"
+              },
+              "cidrPrefix": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "netMask": {
+                "type": "string",
+                "format": "ipv4"
+              }
+            }
+          }
+        },
+        "iaasProvider": {
+          "type": "object",
+          "properties": {
+            "subscriptionObjectId": {
+              "type": "integer"
+            },
+            "vendor": {
+              "type": "string"
+            },
+            "vendorSpecificData": {
+              "$ref": "#/definitions/data_center_iaas_provider_vendor_specific_data"
+            },
+            "tunnelsEnabledOnSync": {
+              "type": "boolean"
+            },
+            "syncStatus": {
+              "type": "object",
+              "properties": {
+                "state": {
+                  "type": "string"
+                },
+                "stateTimestamp": {
+                  "type": "integer"
+                },
+                "lastSyncTimestamp": {
+                  "type": "integer"
+                },
+                "errorDetail": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "response": {
+                      "$ref": "#/definitions/upstream_api_response"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "data_center_iaas_provider_vendor_specific_data": {
+      "type": "object"
+    },
+    "data_center_iaas_provider_microsoft_azure": {
+      "type": "object",
+      "properties": {
+        "virtualWanId": {
+          "type": "string"
+        },
+        "virtualHubId": {
+          "type": "string"
+        },
+        "primaryVpnSiteId": {
+          "type": "string"
+        },
+        "redundantVpnSiteId": {
+          "type": "string"
+        },
+        "deploymentState": {
+          "type": "string",
+          "enum": [
+            "VPN_SITE_CREATION_PENDING",
+            "VPN_SITE_CREATION_IN_PROGRESS",
+            "VPN_SITE_CREATION_FAILED",
+            "VPN_DEPLOYMENT_PENDING",
+            "VPN_DEPLOYMENT_IN_PROGRESS",
+            "VPN_DEPLOYMENT_FAILED",
+            "SUCCEEDED"
+          ]
+        }
+      }
+    },
+    "data_center_vpn_tunnel": {
+      "type": "object",
+      "properties": {
+        "IKESA": {
+          "type": "object",
+          "properties": {
+            "DHGroup": {
+              "type": "integer"
+            },
+            "authenticationAlgorithm": {
+              "type": "string"
+            },
+            "authenticationMethod": {
+              "type": "string"
+            },
+            "ikeVersion": {
+              "type": "integer"
+            },
+            "lifeTimeSeconds": {
+              "type": "integer"
+            },
+            "phaseOneNegotiationMode": {
+              "type": "string",
+              "enum": [
+                "main",
+                "aggressive"
+              ]
+            },
+            "sharedKey": {
+              "type": "string"
+            },
+            "sharedKeyType": {
+              "type": "string"
+            }
+          }
+        },
+        "IPSECDPD": {
+          "type": "object",
+          "properties": {
+            "intervalSeconds": {
+              "type": "integer"
+            },
+            "retries": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        },
+        "IPSECSA": {
+          "type": "object",
+          "properties": {
+            "authenticationAlgorithm": {
+              "type": "string"
+            },
+            "encryptionAlgorithm": {
+              "type": "string"
+            },
+            "lifeTimeSeconds": {
+              "type": "integer"
+            },
+            "mode": {
+              "type": "string"
+            },
+            "perfectForwardSecurity": {
+              "type": "string"
+            },
+            "protocol": {
+              "type": "string"
+            }
+          }
+        },
+        "dataCenterLinkIp": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "dataCenterPublicIp": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "fragmentationAvoidance": {
+          "type": "object",
+          "properties": {
+            "tcpMssAdjustmentBytes": {
+              "type": "integer"
+            },
+            "clearDontFragmentBit": {
+              "type": "string"
+            },
+            "fragmentationStyle": {
+              "type": "string"
+            }
+          }
+        },
+        "gatewayLinkIp": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "gatewayPublicIp": {
+          "type": "string",
+          "format": "ipv4"
+        },
+        "geoData": {
+          "type": "object",
+          "properties": {
+            "latitude": {
+              "type": "number"
+            },
+            "longitude": {
+              "type": "number"
+            }
+          }
+        },
+        "redundant": {
+          "$ref": "#/definitions/data_center_vpn_tunnel"
+        },
+        "serviceFQDN": {
+          "type": "string"
+        },
+        "tunnelInterface": {
+          "type": "object",
+          "properties": {
+            "MTU": {
+              "type": "integer"
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Cisco ISR",
+            "Cisco ASA",
+            "SonicWall",
+            "Palo Alto",
+            "Other",
+            "Generic Policy",
+            "Zscaler",
+            "GenericIKEv2Router",
+            "CheckPoint",
+            "Microsoft Azure Virtual Hub"
+          ]
+        },
+        "typeAlias": {
+          "type": "string",
+          "enum": [
+            "Cisco ISR",
+            "Cisco ASA",
+            "SonicWall",
+            "Palo Alto",
+            "Other",
+            "Generic Policy",
+            "Zscaler",
+            "GenericIKEv2Router",
+            "CheckPoint",
+            "Microsoft Azure Virtual Hub"
+          ]
+        }
+      }
+    },
+    "export_enterprise_edge_license_data_result": {
+      "type": "object",
+      "properties": {
+        "csv": {
+          "type": "string"
+        },
+        "fileName": {
+          "type": "string"
+        }
+      }
+    },
+    "export_network_edge_license_data_result": {
+      "type": "object",
+      "properties": {
+        "csv": {
+          "type": "string"
+        },
+        "fileName": {
+          "type": "string"
+        }
+      }
+    },
+    "export_enterprise_proxy_edge_license_data_result": {
+      "type": "object",
+      "properties": {
+        "csv": {
+          "type": "string"
+        },
+        "fileName": {
+          "type": "string"
+        }
+      }
+    },
+    "get_edge_license_details_by_enterprise_proxy_result": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "activatedEdgeCount": {
+            "type": "integer"
+          },
+          "edgeCount": {
+            "type": "integer"
+          },
+          "enterpriseCount": {
+            "type": "integer"
+          },
+          "enterpriseProxyId": {
+            "type": "integer"
+          },
+          "enterpriseProxyName": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "get_edge_license_details_by_enterprise_result": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "activatedEdgeCount": {
+            "type": "integer"
+          },
+          "edgeCount": {
+            "type": "integer"
+          },
+          "enterpriseCount": {
+            "type": "integer"
+          },
+          "enterpriseProxyId": {
+            "type": "integer"
+          },
+          "enterpriseProxyName": {
+            "type": "string"
+          },
+          "enterpriseName": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "set_edge_edge_licenses_result": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "edgeId": {
+            "type": "integer"
+          },
+          "edgeLicenseId": {
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "set_enterprise_edge_license_edition_result": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "original": {
+            "type": "string"
+          },
+          "replacement": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "update_enterprise_edge_licenses_result": {
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "valid": {
+          "type": "boolean"
+        }
+      }
+    },
+    "update_enterprise_proxy_edge_licenses_result": {
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "valid": {
+          "type": "boolean"
+        }
+      }
+    },
+    "edge_license": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "licenseId": {
+          "type": "integer"
+        },
+        "sku": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "alias": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        },
+        "quota": {
+          "type": "string"
+        },
+        "termMonths": {
+          "type": "integer"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "edition": {
+          "type": "string"
+        },
+        "bandwidthTier": {
+          "type": "string"
+        },
+        "active": {
+          "$ref": "#/definitions/tinyint"
+        },
+        "modified": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "get_enterprise_proxy_edge_licenses_result": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "activatedEdgeCount": {
+            "type": "integer"
+          },
+          "active": {
+            "type": "integer"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "bandwidthTier": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "detail": {
+            "type": "object",
+            "properties": {
+              "regions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "addOns": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "edgeCount": {
+            "type": "integer"
+          },
+          "edition": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "enterpriseCount": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "licenseId": {
+            "type": "integer"
+          },
+          "modified": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "quota": {
+            "type": "string"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "termMonths": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "get_enterprise_edge_licenses_result": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "activatedEdgeCount": {
+            "type": "integer"
+          },
+          "active": {
+            "type": "integer"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "bandwidthTier": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "detail": {
+            "type": "object",
+            "properties": {
+              "regions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "addOns": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "edgeCount": {
+            "type": "integer"
+          },
+          "edition": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "licenseId": {
+            "type": "integer"
+          },
+          "modified": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "quota": {
+            "type": "string"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "termMonths": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "get_network_edge_licenses_result": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "activatedEdgeCount": {
+            "type": "integer"
+          },
+          "active": {
+            "type": "integer"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "bandwidthTier": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "detail": {
+            "type": "object",
+            "properties": {
+              "regions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "addOns": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "edgeCount": {
+            "type": "integer"
+          },
+          "edition": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "enterpriseCount": {
+            "type": "integer"
+          },
+          "enterpriseProxyCount": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "licenseId": {
+            "type": "integer"
+          },
+          "modified": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "quota": {
+            "type": "string"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "termMonths": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "vco_diagnostic_bundle": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "requestId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "ageOutTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "blobId": {
+          "type": "integer"
+        },
+        "fileName": {
+          "type": "string"
+        },
+        "fileStore": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "jobId": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      }
+    },
+    "upstream_api_response": {
+      "type": "object",
+      "properties": {
+        "statusCode": {
+          "type": "integer"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "responseData": {
+          "type": "string"
+        }
+      }
+    },
+    "iaas_vendor_credentials": {
+      "type": "object"
+    },
+    "microsoft_azure_client_credentials": {
+      "type": "object",
+      "properties": {
+        "tenantId": {
+          "type": "string"
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "clientSecret": {
+          "type": "string"
+        }
+      }
+    },
+    "enterprise_rolemap": {
+      "type": "object",
+      "properties": {
+        "Enterprise Read Only": {
+          "type": "string"
+        },
+        "Enterprise Standard Admin": {
+          "type": "string"
+        },
+        "Enterprise Superuser": {
+          "type": "string"
+        },
+        "Enterprise Support": {
+          "type": "string"
+        }
+      }
+    },
+    "radius_operator_rolemap": {
+      "type": "object",
+      "properties": {
+        "Operator Standard Admin": {
+          "type": "string"
+        },
+        "Operator Superuser": {
+          "type": "string"
+        },
+        "Operator Support": {
+          "type": "string"
+        }
+      }
+    },
+    "radius_enterprise_authentication_configuration": {
+      "type": "object",
+      "properties": {
+        "domainAttribute": {
+          "type": "string"
+        },
+        "primaryServer": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "roleAttribute": {
+          "type": "string"
+        },
+        "secondaryServer": {
+          "type": "string"
+        },
+        "sharedSecret": {
+          "type": "string"
+        },
+        "timeoutMilliSeconds": {
+          "type": "integer"
+        },
+        "roleMap": {
+          "$ref": "#/definitions/enterprise_rolemap"
+        }
+      }
+    },
+    "radius_operator_authentication_configuration": {
+      "type": "object",
+      "properties": {
+        "domainAttribute": {
+          "type": "string"
+        },
+        "operatorDomain": {
+          "type": "string"
+        },
+        "primaryServer": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "roleAttribute": {
+          "type": "string"
+        },
+        "secondaryServer": {
+          "type": "string"
+        },
+        "sharedSecret": {
+          "type": "string"
+        },
+        "timeoutMilliSeconds": {
+          "type": "integer"
+        },
+        "roleMap": {
+          "$ref": "#/definitions/radius_operator_rolemap"
+        }
+      }
+    },
+    "operator_sso_authentication_configuration": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "configuration": {
+          "type": "object",
+          "properties": {
+            "authorizationEndpoint": {
+              "type": "string"
+            },
+            "clientId": {
+              "type": "string"
+            },
+            "clientSecret": {
+              "type": "string"
+            },
+            "issuer": {
+              "type": "string"
+            },
+            "provider": {
+              "type": "string"
+            },
+            "redirectEndpoint": {
+              "type": "string"
+            },
+            "tokenEndpoint": {
+              "type": "string"
+            },
+            "userInfoEndpoint": {
+              "type": "string"
+            },
+            "wellKnownConfigurationUrl": {
+              "type": "string"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "roleConfig": {
+              "type": "object",
+              "properties": {
+                "defaultRole": {
+                  "type": "string"
+                },
+                "oidcRolesEnabled": {
+                  "type": "boolean"
+                },
+                "roleAttribute": {
+                  "type": "string"
+                },
+                "vcoToIdpRoleMap": {
+                  "type": "object",
+                  "properties": {
+                    "Operator Business": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "Operator Standard Admin": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "Operator Superuser": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "Operator Support": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "enterprise_proxy_sso_authentication_configuration": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "configuration": {
+          "type": "object",
+          "properties": {
+            "authorizationEndpoint": {
+              "type": "string"
+            },
+            "clientId": {
+              "type": "string"
+            },
+            "clientSecret": {
+              "type": "string"
+            },
+            "issuer": {
+              "type": "string"
+            },
+            "provider": {
+              "type": "string"
+            },
+            "redirectEndpoint": {
+              "type": "string"
+            },
+            "tokenEndpoint": {
+              "type": "string"
+            },
+            "userInfoEndpoint": {
+              "type": "string"
+            },
+            "wellKnownConfigurationUrl": {
+              "type": "string"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "roleConfig": {
+              "type": "object",
+              "properties": {
+                "defaultRole": {
+                  "type": "string"
+                },
+                "oidcRolesEnabled": {
+                  "type": "boolean"
+                },
+                "roleAttribute": {
+                  "type": "string"
+                },
+                "vcoToIdpRoleMap": {
+                  "type": "object",
+                  "properties": {
+                    "MSP Business": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "MSP Standard Admin": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "MSP Superuser": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "MSP Support": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "enterprise_sso_authentication_configuration": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "configuration": {
+          "type": "object",
+          "properties": {
+            "authorizationEndpoint": {
+              "type": "string"
+            },
+            "clientId": {
+              "type": "string"
+            },
+            "clientSecret": {
+              "type": "string"
+            },
+            "issuer": {
+              "type": "string"
+            },
+            "provider": {
+              "type": "string"
+            },
+            "redirectEndpoint": {
+              "type": "string"
+            },
+            "tokenEndpoint": {
+              "type": "string"
+            },
+            "userInfoEndpoint": {
+              "type": "string"
+            },
+            "wellKnownConfigurationUrl": {
+              "type": "string"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "roleConfig": {
+              "type": "object",
+              "properties": {
+                "defaultRole": {
+                  "type": "string"
+                },
+                "oidcRolesEnabled": {
+                  "type": "boolean"
+                },
+                "roleAttribute": {
+                  "type": "string"
+                },
+                "vcoToIdpRoleMap": {
+                  "type": "object",
+                  "properties": {
+                    "Enterprise Read Only": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "Enterprise Standard Admin": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "Enterprise Superuser": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "Enterprise Support": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "enterprise_authentication_configuration": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "radius": {
+          "description": "",
+          "$ref": "#/definitions/radius_enterprise_authentication_configuration"
+        }
+      }
+    },
+    "operator_authentication_configuration": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "radius": {
+          "description": "Returns radius configuration or null (if no configuration available)",
+          "$ref": "#/definitions/radius_operator_authentication_configuration"
+        },
+        "sso": {
+          "description": "Returns sso configuration or null (if no configuration available)",
+          "$ref": "#/definitions/operator_sso_authentication_configuration"
+        }
+      }
+    },
+    "system_property_get_authentication_configuration_result": {
+      "type": "object",
+      "properties": {
+        "operator": {
+          "$ref": "#/definitions/operator_authentication_configuration"
+        },
+        "enterprise": {
+          "$ref": "#/definitions/enterprise_authentication_configuration"
+        }
+      }
+    },
+    "system_property_set_authentication_configuration_result": {
+      "type": "object",
+      "properties": {
+        "rows": {
+          "description": "The number of rows modified",
+          "type": "integer"
+        }
+      }
+    },
+    "sso_get_sso_properties_result": {
+      "type": "object",
+      "properties": {
+        "redirectUri": {
+          "type": "string"
+        }
+      }
+    },
+    "openid_well_known_config": {
+      "type": "object",
+      "properties": {
+        "issuer": {
+          "type": "string"
+        },
+        "authorization_endpoint": {
+          "type": "string"
+        },
+        "token_endpoint": {
+          "type": "string"
+        },
+        "revocation_endpoint": {
+          "type": "string"
+        },
+        "userinfo_endpoint": {
+          "type": "string"
+        },
+        "jwks_uri": {
+          "type": "string"
+        },
+        "scopes_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "response_types_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "response_modes_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claims_supported": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "sso_discover_openid_endpoints_result": {
+      "$ref": "#/definitions/openid_well_known_config"
+    },
+    "operator_user_get_operator_user_authentication_mode_result": {
+      "$ref": "#/definitions/system_property_get_system_property_result"
+    },
+    "enterprise_proxy_insert_or_update_enterprise_proxy_authentication_configuration_result": {
+      "type": "object",
+      "properties": {
+        "rows": {
+          "description": "The number of rows modified",
+          "type": "integer"
+        }
+      }
+    },
+    "enterprise_proxy_get_enterprise_proxy_authentication_configuration_result": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "sso": {
+          "$ref": "#/definitions/enterprise_proxy_sso_authentication_configuration",
+          "description": "Returns sso configuration or null (if no configuration available)"
+        }
+      }
+    },
+    "enterprise_insert_or_update_enterprise_authentication_configuration_result": {
+      "type": "object",
+      "properties": {
+        "rows": {
+          "description": "The number of rows modified",
+          "type": "integer"
+        }
+      }
+    },
+    "enterprise_get_enterprise_authentication_configuration_result": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "sso": {
+          "description": "Returns sso configuration or null (if no configuration available)",
+          "$ref": "#/definitions/enterprise_sso_authentication_configuration"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "auth_param": {
+      "name": "authorization",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/auth_object"
+      }
+    }
+  },
+  "responses": {
+    "generic_200": {
+      "description": "Request was successfully processed",
+      "schema": {
+        "type": "object"
+      }
+    },
+    "generic_400": {
+      "description": "Invalid Request: Please check your request schema",
+      "schema": {
+        "$ref": "#/definitions/error"
+      }
+    },
+    "generic_500": {
+      "description": "Error parsing or processing request",
+      "schema": {
+        "$ref": "#/definitions/error"
+      }
+    },
+    "no_credentials": {
+      "description": "Authorization Cookie not Received"
+    },
+    "forbidden": {
+      "description": "Insufficient Permissions"
+    }
+  }
+}

--- a/generator/model.go
+++ b/generator/model.go
@@ -156,6 +156,10 @@ func shallowValidationLookup(sch GenSchema) bool {
 	// and NeedsValidation (e.g. should have a Validate method with something in it).
 	// The latter was almost not used anyhow.
 
+	if sch.HasAdditionalProperties && sch.AdditionalProperties == nil {
+		log.Printf("warning: schema for additional properties in schema %q is empty. skipped", sch.Name)
+	}
+
 	if sch.IsArray && sch.HasValidations {
 		return true
 	}
@@ -183,11 +187,11 @@ func shallowValidationLookup(sch GenSchema) bool {
 	if sch.IsTuple && (sch.AdditionalItems != nil && (sch.AdditionalItems.HasValidations || sch.AdditionalItems.Required)) {
 		return true
 	}
-	if sch.HasAdditionalProperties && (sch.AdditionalProperties.IsInterface || sch.AdditionalProperties.IsStream) {
+	if sch.HasAdditionalProperties && sch.AdditionalProperties != nil && (sch.AdditionalProperties.IsInterface || sch.AdditionalProperties.IsStream) {
 		return false
 	}
 
-	if sch.HasAdditionalProperties && (sch.AdditionalProperties.HasValidations || sch.AdditionalProperties.Required || sch.AdditionalProperties.IsAliased && !(sch.AdditionalProperties.IsInterface || sch.AdditionalProperties.IsStream)) {
+	if sch.HasAdditionalProperties && sch.AdditionalProperties != nil && (sch.AdditionalProperties.HasValidations || sch.AdditionalProperties.Required || sch.AdditionalProperties.IsAliased && !(sch.AdditionalProperties.IsInterface || sch.AdditionalProperties.IsStream)) {
 		return true
 	}
 
@@ -271,6 +275,10 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 		// replace the ref with this new genschema
 		swsp := specDoc.Spec()
 		for i, ss := range schema.AllOf {
+			if pg.GenSchema.AllOf == nil {
+				log.Printf("warning: resolved schema for subtype %q.AllOf[%d] is empty. skipped", name, i)
+				continue
+			}
 			ref := ss.Ref
 			for ref.String() != "" {
 				var rsch *spec.Schema


### PR DESCRIPTION
* fixes #2161

> NOTE: this tests against the fixture brought by #2156, which comes with many still unsupported features
> (cascading subtyping, validation-only allOf schemas).
> This commit just makes sure there is no panic. I know that the models generated from the fixture are not correct.

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>