### PR TITLE
Add NOTE in swagger:meta for adhering to godoc standard

### DIFF
--- a/docs/use/spec/meta.md
+++ b/docs/use/spec/meta.md
@@ -95,6 +95,8 @@ Annotation | Format
 package classification
 ```
 
+> **NOTE:** If there is whitespace line between the comment and package (or type, function), swagger will generate an empty specification. This is due to the violation of the convention for Godoc. For more details refer [here](https://blog.golang.org/godoc)
+
 ##### Result
 
 ```yaml


### PR DESCRIPTION
Add NOTE in `swagger:meta` for adhering to godoc standard