### PR TITLE
fixed merging issues that caused linting/goimport failures

### DIFF
--- a/generator/bindata.go
+++ b/generator/bindata.go
@@ -58,7 +58,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -66,7 +66,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -1018,6 +1018,9 @@ var _bindata = map[string]func() (*asset, error){
 	"templates/validation/primitive.gotmpl":                       templatesValidationPrimitiveGotmpl,
 	"templates/validation/structfield.gotmpl":                     templatesValidationStructfieldGotmpl,
 }
+
+// AssetDebug is true if the assets were built with the debug flag enabled.
+const AssetDebug = false
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -462,6 +462,8 @@ func TestDateFormat_Spec1(t *testing.T) {
 	opts.defaultsEnsured = false
 	opts.IsClient = true
 	err = opts.EnsureDefaults()
+	require.NoError(t, err)
+
 	err = templates.MustGet("clientParameter").Execute(buf, op)
 	require.NoError(t, err)
 
@@ -484,8 +486,10 @@ func TestDateFormat_Spec2(t *testing.T) {
 	opts.defaultsEnsured = false
 	opts.IsClient = true
 	err = opts.EnsureDefaults()
+	require.NoError(t, err)
+
 	err = templates.MustGet("clientParameter").Execute(buf, op)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ff, err := opts.LanguageOpts.FormatContent("put_testing.go", buf.Bytes())
 	require.NoErrorf(t, err, buf.String())
@@ -1471,12 +1475,7 @@ func TestGenServer_2161_panic(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = appGen.GenOpts.LanguageOpts.FormatContent(op.Operations[selectedOp].Name+".go", buf.Bytes())
-	require.NoError(t, err)
-
+	require.NoErrorf(t, err, buf.String())
 	// NOTE(fred): I know that the generated model is wrong from this spec at the moment.
 	// The test with this fix simply asserts that there is no panic / internal error with building this.
-
-	if t.Failed() {
-		fmt.Println(buf.String())
-	}
 }


### PR DESCRIPTION
Automatic merge caused some goimport/linting errors to appear.

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>