### PR TITLE
Fix generation of server responses when response has date-time format

### DIFF
--- a/generator/templates/server/responses.gotmpl
+++ b/generator/templates/server/responses.gotmpl
@@ -234,6 +234,7 @@ import (
   "github.com/go-openapi/errors"
   "github.com/go-openapi/runtime"
   "github.com/go-openapi/runtime/security"
+  "github.com/go-openapi/strfmt"
   "github.com/go-openapi/swag"
   "github.com/go-openapi/validate"
   "github.com/go-openapi/runtime/middleware"


### PR DESCRIPTION
Signed-off-by: Ben Wells <b.v.wells@gmail.com>

Fix generation of server responses when response has date-time format.