### PR TITLE
added validation guards against inconsistent validations

### DIFF
--- a/fixtures/enhancements/1771/.gitignore
+++ b/fixtures/enhancements/1771/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/enhancements/1771/fixture-1771.yaml
+++ b/fixtures/enhancements/1771/fixture-1771.yaml
@@ -1,0 +1,76 @@
+---
+  swagger: "2.0"
+  info:
+    title: "invalid slice validations in simple parameters"
+    version: "0.0.1"
+    description: "repro issue 1771"
+    license:
+      name: "Apache 2.0"
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  paths:
+    /getRecords:
+      get:
+        summary: retrieves a batch of key data
+        parameters:
+        - name: keys
+          description: a list of keys to retrieve data for
+          in: query
+          type: array
+          required: true
+          items:
+            minItems: 1
+            maxItems: 10
+            type: string
+          collectionFormat: multi
+        - name: fault1
+          in: query
+          type: string
+          minimum: 12
+          exclusiveMinimum: true
+          maximum: 15
+          exclusiveMaximum: true
+          multipleOf: 2
+          minLength: 10
+        - name: fault2
+          in: query
+          type: number
+          minLength: 1
+          pattern: "abc"
+          maxLength: 15
+          uniqueItems: true
+          maximum: 20
+        - name: fault3
+          in: query
+          type: integer
+          minLength: 1
+          pattern: "abc"
+          maxLength: 15
+          uniqueItems: true
+          maximum: 20
+        - name: fault4
+          in: query
+          type: boolean
+          minLength: 1
+          pattern: "abc"
+          maxLength: 15
+          uniqueItems: true
+          maximum: 20
+        responses:
+          200:
+            description: "OK"
+
+    /getFiles:
+      get:
+        consumes: [ multipart/form-data ]
+        parameters:
+        - name: upload
+          in: formData
+          type: file
+          minLength: 1
+          pattern: "abc"
+          maxLength: 15
+          uniqueItems: true
+          maximum: 20
+        responses:
+          200:
+            description: "OK"

--- a/fixtures/enhancements/1771/gen-fixtures.sh
+++ b/fixtures/enhancements/1771/gen-fixtures.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="fixture-1771.yaml"
+for opts in  "" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    serverName="codegensrv"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Model generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    # 1>x.log 2>&1
+    #
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/fixtures/enhancements/2163/.gitignore
+++ b/fixtures/enhancements/2163/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/enhancements/2163/fixture-2163.yaml
+++ b/fixtures/enhancements/2163/fixture-2163.yaml
@@ -1,0 +1,83 @@
+---
+  swagger: "2.0"
+  info:
+    title: "validations inconsistent with schema type"
+    version: "0.0.1"
+    description: "inconsistent validations"
+    license:
+      name: "Apache 2.0"
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  definitions:
+    obj:
+      type: object
+      properties:
+        a:
+          type: number
+          format: double
+          maximum: 1000000000
+          minimum: 1
+          pattern: "[-]?\\d+(.\\d{1,2})?"
+          maxLength: 13
+          minLength: 1
+        b:
+          type: string
+          minimum: 13
+          maxLength: 5
+        c:
+          type: string
+          maximum: 144
+          maxLength: 5
+          multipleOf: 12
+          enum: [ 'a', 'b' ]
+        d:
+          type: boolean
+          maximum: 15
+          exclusiveMaximum: true
+          minimum: 1
+          exclusiveMinimum: true
+          minProperties: 12
+        e:
+          type: object
+          maximum: 15
+          minProperties: 12
+          uniqueItems: true
+          enum: [ {"x": 1} ]
+        f:
+          type: array
+          uniqueItems: true
+          minimum: 15
+          items:
+            type: object
+            minProperties: 13
+            maximum: 15
+        g:
+          type: integer
+          maximum: 10
+          minimum: 1
+          pattern: "[-]?\\d+(.\\d{1,2})?"
+          maxLength: 13
+          minLength: 1
+          maxProperties: 12
+
+        #h:
+        #  type: file
+        #  maximum: 10
+        #  minimum: 1
+        #  pattern: "[-]?\\d+(.\\d{1,2})?"
+        #  maxLength: 13
+        #  minLength: 1
+        #  maxProperties: 12
+
+  paths:
+    /getRecords:
+      get:
+        operationId: getRecords
+        parameters:
+          - name: records
+            in: body
+            required: true
+            schema:
+              $ref: '#/definitions/obj'
+        responses:
+          200:
+            description: "OK"

--- a/fixtures/enhancements/2163/gen-fixtures.sh
+++ b/fixtures/enhancements/2163/gen-fixtures.sh
@@ -1,0 +1,76 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="fixture-2163.yaml"
+#testcases="${testcases} ../1487/fixture-844-variations.yaml"
+#testcases="${testcases} ../1487/fixture-itching.yaml"
+for opts in  "" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    serverName="codegensrv"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Model generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    # 1>x.log 2>&1
+    #
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/generator/build_test.go
+++ b/generator/build_test.go
@@ -46,6 +46,12 @@ func TestGenerateAndBuild(t *testing.T) {
 		"issue 2278": {
 			"../fixtures/bugs/2278/fixture-2278.yaml",
 		},
+		"issue 2163": {
+			"../fixtures/enhancements/2163/fixture-2163.yaml",
+		},
+		"issue 1771": {
+			"../fixtures/enhancements/1771/fixture-1771.yaml",
+		},
 	}
 
 	for name, cas := range cases {

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -927,7 +927,9 @@ func gatherExtraSchemas(extraMap map[string]GenSchema) (extras GenSchemaList) {
 	return
 }
 
-func sharedValidationsFromSimple(v spec.CommonValidations, isRequired bool) (sh sharedValidations) {
+func sharedValidationsFromSimple(tpe resolvedType, v spec.CommonValidations, isRequired bool) (sh sharedValidations) {
+	guardSimpleValidations(tpe.SwaggerType, &v)
+
 	sh = sharedValidations{
 		Required:         isRequired,
 		Maximum:          v.Maximum,
@@ -947,6 +949,8 @@ func sharedValidationsFromSimple(v spec.CommonValidations, isRequired bool) (sh 
 }
 
 func sharedValidationsFromSchema(v spec.Schema, isRequired bool) (sh sharedValidations) {
+	// validation guards have already been carried out directly by the type resolver
+
 	sh = sharedValidations{
 		Required:         isRequired,
 		Maximum:          v.Maximum,

--- a/hack/codegen-fixtures.yaml
+++ b/hack/codegen-fixtures.yaml
@@ -211,3 +211,13 @@
 - dir: fixtures/bugs/2342
   skipped:
     skipModel: true
+- dir: fixtures/enhancements/2163
+  skipped:
+    skipServer: true
+    skipClient: true
+    skipExpand: true
+- dir: fixtures/enhancements/1771
+  skipped:
+    skipModel: true
+    skiClient: true
+    skipExpand: true


### PR DESCRIPTION
* for schemas and simple schemas (parameters and headers)
* protects codegen against invalid specifications, with validation not supported by the specified type
* the guard is non-blocking: a warning is issued during codegen and the invalid validation is skipped
* enum validation is always allowed

Examples:
- minimum on a string
- maxitems on a number
- ...

* fixes #2163 (schemas)
* fixes #1771 (simple types)

* [x] added unit tests
* [x] added CI build tests

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>