### PR TITLE
Fixed required aliased type

### DIFF
--- a/fixtures/bugs/1487/gen-fixtures.sh
+++ b/fixtures/bugs/1487/gen-fixtures.sh
@@ -1,4 +1,4 @@
-#! /bin/bash 
+#! /bin/bash
 if [[ ${1} == "--clean" ]] ; then
     clean=1
 fi
@@ -65,7 +65,7 @@ for testcase in ${testcases} ; do
     rm -rf ${target}
     mkdir ${target}
     echo "Model generation for ${spec} with opts=${opts}"
-    swagger generate model --skip-validation ${opts} --spec=${spec} --target=${target} --output=${testcase%.*}.log
+    swagger generate model --skip-validation ${opts} --spec=${spec} --target=${target} --log-output=${testcase%.*}.log
     # 1>x.log 2>&1
     #
     if [[ $? != 0 ]] ; then
@@ -92,21 +92,21 @@ for testcase in ${testcases} ; do
             fi
         fi
         echo "${spec}: Build OK"
-        if [[ -n ${clean} ]] ; then 
+        if [[ -n ${clean} ]] ; then
              rm -rf ${target}
         fi
     fi
 done
 done
-if [[ ! -z ${failures} ]] ; then 
+if [[ ! -z ${failures} ]] ; then
     echo ${failures}|tr ' ' '\n'
 else
     echo "No failures"
 fi
 exit
 # Non reg codegen
-# NOTE(fredbi): 
-# - azure: invalid spec 
+# NOTE(fredbi):
+# - azure: invalid spec
 # - bitbucket: model does not compile
 # - issue72: invalid spec
 # - todolist.discriminator: ok now
@@ -117,7 +117,7 @@ for testcase in ${testcases} ; do
     target=./gen-${testcase%.*}
     if [[ -f ../../codegen/${testcase} ]] ; then
       spec=../../codegen/${testcase}
-    else 
+    else
       spec=${testcase}
     fi
     serverName="nrcodegen"
@@ -125,7 +125,7 @@ for testcase in ${testcases} ; do
     mkdir ${target}
     echo "Server generation for ${spec}"
     swagger generate server --skip-validation --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
-    #--output=${testcase%.*}.log
+    #--log-output=${testcase%.*}.log
     if [[ $? != 0 ]] ; then
         echo "Generation failed for ${spec}"
         exit 1
@@ -137,7 +137,7 @@ for testcase in ${testcases} ; do
         exit 1
     fi
     echo "${spec}: Build OK"
-    if [[ -n ${clean} ]] ; then 
+    if [[ -n ${clean} ]] ; then
         rm -rf ${target}
     fi
 done
@@ -162,7 +162,7 @@ for testcase in ${testcases} ; do
         exit 1
     fi
     echo "${spec}: Build OK"
-    if [[ -n ${clean} ]] ; then 
+    if [[ -n ${clean} ]] ; then
         rm -rf ${target}
     fi
 done

--- a/fixtures/bugs/2364/.gitignore
+++ b/fixtures/bugs/2364/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/bugs/2364/fixture-2364.yaml
+++ b/fixtures/bugs/2364/fixture-2364.yaml
@@ -31,6 +31,14 @@ definitions:
           type: array
           items:
             $ref: "#/definitions/ItemBundleSectionResponse"
+        nullableSections:
+            type: array
+            items:
+              $ref: "#/definitions/NullableItemBundleSectionResponse"
+        otherSections:
+            type: array
+            items:
+              $ref: "#/definitions/OtherItemBundleSectionResponse"
 
   BundleType:
     type: string
@@ -63,3 +71,28 @@ definitions:
             items:
               $ref: "#/definitions/BundleItemResponse"
     x-nullable: false
+
+  NullableItemBundleSectionResponse:
+    allOf:
+      - $ref: "#/definitions/BundleSectionResponse"
+      - type: object
+        x-omitempty: false
+        properties:
+          items:
+            description: Array of bundle items inside a section of the bundle
+            type: array
+            items:
+              $ref: "#/definitions/BundleItemResponse"
+    x-nullable: true
+
+  OtherItemBundleSectionResponse:
+    allOf:
+      - $ref: "#/definitions/BundleSectionResponse"
+      - type: object
+        x-omitempty: false
+        properties:
+          items:
+            description: Array of bundle items inside a section of the bundle
+            type: array
+            items:
+              $ref: "#/definitions/BundleItemResponse"

--- a/fixtures/bugs/2364/gen-fixtures.sh
+++ b/fixtures/bugs/2364/gen-fixtures.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="fixture-2364.yaml"
+for opts in  "" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    serverName="codegensrv"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Model generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    # 1>x.log 2>&1
+    #
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/fixtures/bugs/2381/fixture-2381.yaml
+++ b/fixtures/bugs/2381/fixture-2381.yaml
@@ -28,6 +28,9 @@ definitions:
       - required_string
       - required_referenced_object
       - required_referenced_string
+      - required_referenced_struct
+      - required_referenced_array
+      - required_referenced_map
     properties:
       required_string:
         type: string
@@ -35,7 +38,29 @@ definitions:
         $ref: '#/definitions/my_object_ref'
       required_referenced_string:
         $ref: '#/definitions/my_string_ref'
-  my_object_ref:
+      required_referenced_struct:
+        $ref: '#/definitions/my_struct_ref'
+      required_referenced_array:
+        $ref: '#/definitions/my_array_ref'
+      required_referenced_map:
+        $ref: '#/definitions/my_map_ref'
+  my_object_ref:  # <- interface
     type: object
-  my_string_ref:
+  my_string_ref:  # <- aliased type
     type: string
+  my_struct_ref:  # <- struct
+    type: object
+    properties:
+      x:
+        type: integer
+  my_array_ref:  # <- slice
+    type: array
+    items:
+      type: object
+  my_map_ref:  # <- map
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        'y':
+          type: integer

--- a/fixtures/bugs/2400/.gitignore
+++ b/fixtures/bugs/2400/.gitignore
@@ -1,0 +1,3 @@
+gen-*
+!gen-fixtures.sh
+*.log

--- a/fixtures/bugs/2400/fixture-2400.yaml
+++ b/fixtures/bugs/2400/fixture-2400.yaml
@@ -1,0 +1,42 @@
+---
+  swagger: "2.0"
+  info:
+    title: "required aliased primitive"
+    version: "0.0.1"
+    description: "repro issue 2400"
+    license:
+      name: "Apache 2.0"
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+
+  definitions:
+    SignupRequest:
+      properties:
+        email:
+          type: string
+      required:
+        - email
+
+    Email:
+      type: string
+
+    SignupRequest2:
+      properties:
+        email:
+          $ref: "#/definitions/Email"
+      required:
+        - email
+  paths:
+    /getRecords:
+      get:
+        operationId: getRecords
+        parameters:
+          - name: records
+            in: body
+            required: true
+            schema:
+              $ref: '#/definitions/SignupRequest2'
+        responses:
+          200:
+            description: "OK"
+            schema:
+              $ref: '#/definitions/SignupRequest2'

--- a/fixtures/bugs/2400/gen-fixtures.sh
+++ b/fixtures/bugs/2400/gen-fixtures.sh
@@ -1,0 +1,76 @@
+#! /bin/bash
+if [[ ${1} == "--clean" ]] ; then
+    clean=1
+fi
+continueOnError=
+# A small utility to build fixture servers
+# Fixtures with models only
+testcases="fixture-2400.yaml"
+#testcases="${testcases} ../1487/fixture-844-variations.yaml"
+#testcases="${testcases} ../1487/fixture-itching.yaml"
+for opts in  "" "--with-expand" ; do
+for testcase in ${testcases} ; do
+    grep -q discriminator ${testcase}
+    discriminated=$?
+    if [[ ${discriminated} -eq 0 && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: discriminator not supported with ${opts}"
+        continue
+    fi
+    if [[ ${testcase} == "../1479/fixture-1479-part.yaml" && ${opts} == "--with-expand" ]] ; then
+        echo "Skipped ${testcase} with ${opts}: known issue with enum in anonymous allOf not validated. See you next PR"
+        continue
+    fi
+
+    spec=${testcase}
+    testcase=`basename ${testcase}`
+    if [[ -z ${opts} ]]; then
+        target=./gen-${testcase%.*}-flatten
+    else
+        target=./gen-${testcase%.*}-expand
+    fi
+    serverName="codegensrv"
+    rm -rf ${target}
+    mkdir ${target}
+    echo "Model generation for ${spec} with opts=${opts}"
+    serverName="nrcodegen"
+    swagger generate server --skip-validation ${opts} --spec ${spec} --target ${target} --name=${serverName} 1>${testcase%.*}.log 2>&1
+    # 1>x.log 2>&1
+    #
+    if [[ $? != 0 ]] ; then
+        echo "Generation failed for ${spec}"
+        if [[ ! -z ${continueOnError} ]] ; then
+            failures="${failures} codegen:${spec}"
+            continue
+        else
+            exit 1
+        fi
+    fi
+    echo "${spec}: Generation OK"
+    if [[ ! -d ${target}/models ]] ; then
+        echo "No model in this spec! Continue building server"
+    fi
+    if [[ -d ${target}/cmd/${serverName}"-server" ]] ; then
+        (cd ${target}/cmd/${serverName}"-server"; go build)
+        #(cd ${target}/models; go build)
+        if [[ $? != 0 ]] ; then
+            echo "Build failed for ${spec}"
+            if [[ ! -z ${continueOnError} ]] ; then
+                failures="${failures} build:${spec}"
+                continue
+            else
+                exit 1
+            fi
+        fi
+        echo "${spec}: Build OK"
+        if [[ -n ${clean} ]] ; then
+             rm -rf ${target}
+        fi
+    fi
+done
+done
+if [[ ! -z ${failures} ]] ; then
+    echo ${failures}|tr ' ' '\n'
+else
+    echo "No failures"
+fi
+exit

--- a/generator/moreschemavalidation_fixtures_test.go
+++ b/generator/moreschemavalidation_fixtures_test.go
@@ -14,22 +14,48 @@
 
 package generator
 
+func initFixture2400() {
+	f := newModelFixture("../fixtures/bugs/2400/fixture-2400.yaml", "required aliased primitive")
+	flattenRun := f.AddRun(false).WithMinimalFlatten(true)
+
+	flattenRun.AddExpectations("signup_request.go", []string{
+		`type SignupRequest struct {`,
+		`Email *string`,
+	}, todo, noLines, noLines)
+	flattenRun.AddExpectations("signup_request2.go", []string{
+		`type SignupRequest2 struct {`,
+		`Email *Email`,
+	}, todo, noLines, noLines)
+}
+
 func initFixture2381() {
 	f := newModelFixture("../fixtures/bugs/2381/fixture-2381.yaml", "required $ref primitive")
 	flattenRun := f.AddRun(false).WithMinimalFlatten(true)
 	expandRun := f.AddRun(true)
 
 	flattenRun.AddExpectations("my_object.go", []string{
+		`RequiredReferencedObject MyObjectRef`,  // this is an interface{}
+		`RequiredReferencedString *MyStringRef`, // alias to primitive
+		`RequiredString *string`,                // unaliased primitive
+		`RequiredReferencedArray MyArrayRef`,    // no need to use a pointer
+		`RequiredReferencedMap MyMapRef`,        // no need to use a pointer
+		`RequiredReferencedStruct *MyStructRef`, // pointer to struct
 		`func (m *MyObject) validateRequiredReferencedObject(formats strfmt.Registry) error {`,
 		`	if m.RequiredReferencedObject == nil {`,
 		`		return errors.Required("required_referenced_object", "body", nil)`,
 		`func (m *MyObject) validateRequiredReferencedString(formats strfmt.Registry) error {`,
-		`	if err := validate.Required("required_referenced_string", "body", MyStringRef(m.RequiredReferencedString)); err != nil {`,
+		`	if err := validate.Required("required_referenced_string", "body", m.RequiredReferencedString); err != nil {`,
 		`	if err := m.RequiredReferencedString.Validate(formats); err != nil {`,
 		`		if ve, ok := err.(*errors.Validation); ok {`,
 		`			return ve.ValidateName("required_referenced_string")`,
 		`func (m *MyObject) validateRequiredString(formats strfmt.Registry) error {`,
 		`	if err := validate.Required("required_string", "body", m.RequiredString); err != nil {`,
+		`func (m *MyObject) validateRequiredReferencedStruct(formats strfmt.Registry) error {`,
+		`if err := validate.Required("required_referenced_struct", "body", m.RequiredReferencedStruct); err != nil {`,
+		`func (m *MyObject) validateRequiredReferencedArray(formats strfmt.Registry) error {`,
+		`if err := validate.Required("required_referenced_array", "body", m.RequiredReferencedArray); err != nil {`,
+		`func (m *MyObject) validateRequiredReferencedMap(formats strfmt.Registry) error {`,
+		`if err := validate.Required("required_referenced_map", "body", m.RequiredReferencedMap); err != nil {`,
 	}, todo, noLines, noLines)
 
 	expandRun.AddExpectations("my_object.go", []string{
@@ -11281,6 +11307,8 @@ func initFixture2364() {
 		`type BundleAttributesResponse struct {`,
 		`Items []BundleItemResponse`,
 		`Sections []ItemBundleSectionResponse`,
+		`NullableSections []*NullableItemBundleSectionResponse`,
+		`OtherSections []*OtherItemBundleSectionResponse`,
 		`Type BundleType`,
 	},
 		// not expected

--- a/generator/moreschemavalidation_test.go
+++ b/generator/moreschemavalidation_test.go
@@ -228,6 +228,9 @@ func initModelFixtures() {
 
 	// required $ref primitive
 	initFixture2381()
+
+	// required aliased primitive
+	initFixture2400()
 }
 
 /* Template initTxxx() to prepare and load a fixture:

--- a/generator/pointer_test.go
+++ b/generator/pointer_test.go
@@ -27,7 +27,7 @@ func TestTypeResolver_NestedAliasedSlice(t *testing.T) {
 	rt, err := tr.ResolveSchema(&schema, false, false)
 	require.NoError(t, err)
 
-	assert.Equal(t, "[][][]models.StatixItems0", rt.AliasedType)
+	assert.Equal(t, "[][][]*models.StatixItems0", rt.AliasedType)
 }
 
 func TestTypeResolver_PointerLifting(t *testing.T) {

--- a/generator/typeresolver_test.go
+++ b/generator/typeresolver_test.go
@@ -237,7 +237,9 @@ func TestTypeResolver_Refs(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, rt.IsArray)
-		assert.Equal(t, "[]"+val.Expected, rt.GoType)
+		// now this behavior has moved down to the type resolver:
+		// * it used to be hidden to the type resolver, but rendered like that eventually
+		assert.Equal(t, "[]*"+val.Expected, rt.GoType)
 	}
 	// for named objects
 	// referenced objects
@@ -263,7 +265,9 @@ func TestTypeResolver_Refs(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, rt.IsArray)
-		assert.Equal(t, "[]"+val.Expected, rt.GoType)
+		// now this behavior has moved down to the type resolver:
+		// * it used to be hidden to the type resolver, but rendered like that eventually
+		assert.Equal(t, "[]*"+val.Expected, rt.GoType)
 	}
 }
 
@@ -397,7 +401,7 @@ func TestTypeResolver_Notables(t *testing.T) {
 	assert.True(t, rest.IsArray)
 	assert.False(t, rest.IsAnonymous)
 	assert.False(t, rest.IsNullable)
-	assert.Equal(t, "[]models.Notable", rest.GoType)
+	assert.Equal(t, "[]*models.Notable", rest.GoType)
 }
 
 func specResolver(t testing.TB, path string) (*loads.Document, *typeResolver, error) {
@@ -646,7 +650,7 @@ func TestTypeResolver_ExistingModel(t *testing.T) {
 	assert.False(t, rest.IsAnonymous)
 	assert.False(t, rest.IsComplexObject)
 	assert.False(t, rest.IsCustomFormatter)
-	assert.Equal(t, "[]jwk.Key", rest.GoType)
+	assert.Equal(t, "[]*jwk.Key", rest.GoType)
 	assert.Equal(t, "", rest.Pkg)
 	assert.Equal(t, "", rest.PkgAlias)
 }


### PR DESCRIPTION
Whenever a required property is an aliased type, it is rendered with a pointer type (not if interface{}).

* Changed the nullability assessment of aliased types: it now inherits from the nullable decision taken at a lower level (within $ref)
* Fixed ability to override nullability for AllOf, now x-nullable extensions in AllOf are honored

* fixes #2400

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>