### PR TITLE
test: model tests go parallel

### DIFF
--- a/fixtures/bugs/1897/.gitignore
+++ b/fixtures/bugs/1897/.gitignore
@@ -1,0 +1,1 @@
+external/

--- a/generator/.gitignore
+++ b/generator/.gitignore
@@ -1,0 +1,1 @@
+generated/

--- a/generator/build_test.go
+++ b/generator/build_test.go
@@ -1,16 +1,13 @@
 package generator_test
 
 import (
-	"bytes"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-swagger/go-swagger/cmd/swagger/commands/generate"
@@ -24,6 +21,15 @@ const (
 )
 
 func TestGenerateAndBuild(t *testing.T) {
+	// This test generates and actually compiles the output
+	// of generated clients.
+	//
+	// We run this in parallel now. Therefore it is no more
+	// possible to assert the output on stdout.
+	//
+	// NOTE: test cases are randomized (map)
+	t.Parallel()
+
 	defer func() {
 		log.SetOutput(os.Stdout)
 	}()
@@ -54,33 +60,28 @@ func TestGenerateAndBuild(t *testing.T) {
 		},
 	}
 
-	for name, cas := range cases {
-		var captureLog bytes.Buffer
-		log.SetOutput(&captureLog)
+	t.Run("build client", func(t *testing.T) {
+		for name, cas := range cases {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				log.SetOutput(ioutil.Discard)
 
-		t.Run(name, func(t *testing.T) {
-			spec := filepath.FromSlash(cas.spec)
+				spec := filepath.FromSlash(cas.spec)
 
-			generated, err := ioutil.TempDir(filepath.Dir(spec), "generated")
-			if err != nil {
-				t.Fatalf("TempDir()=%s", generated)
-			}
-			defer func() { _ = os.RemoveAll(generated) }()
+				generated, err := ioutil.TempDir(filepath.Dir(spec), "generated")
+				require.NoErrorf(t, err, "TempDir()=%s", generated)
+				defer func() { _ = os.RemoveAll(generated) }()
 
-			err = newTestClient(spec, generated).Execute(nil)
-			require.NoErrorf(t, err, "Execute()=%s", err)
+				require.NoErrorf(t, newTestClient(spec, generated).Execute(nil), "Execute()=%s", err)
 
-			assert.Contains(t, strings.ToLower(captureLog.String()), "generation completed")
+				packages := filepath.Join(generated, "...")
 
-			packages := filepath.Join(generated, "...")
+				goExecInDir(t, "", "get")
 
-			p, err := exec.Command("go", "get", packages).CombinedOutput()
-			require.NoErrorf(t, err, "go get %s: %s\n%s", packages, err, p)
-
-			p, err = exec.Command("go", "build", packages).CombinedOutput()
-			require.NoErrorf(t, err, "go build %s: %s\n%s", packages, err, p)
-		})
-	}
+				goExecInDir(t, "", "build", packages)
+			})
+		}
+	})
 }
 
 func newTestClient(input, output string) *generate.Client {
@@ -93,4 +94,11 @@ func newTestClient(input, output string) *generate.Client {
 	c.Models.ModelPackage = defaultModelPackage
 	c.ClientPackage = defaultClientPackage
 	return c
+}
+
+func goExecInDir(t testing.TB, target string, args ...string) {
+	cmd := exec.Command("go", args...)
+	cmd.Dir = target
+	p, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "unexpected error: %s: %v\n%s", cmd.String(), err, string(p))
 }

--- a/generator/discriminators_test.go
+++ b/generator/discriminators_test.go
@@ -34,7 +34,7 @@ func TestGenerateModel_DiscriminatorSlices(t *testing.T) {
 	assert.True(t, genModel.HasBaseType)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("has_discriminator.go", buf.Bytes())
@@ -65,7 +65,7 @@ func TestGenerateModel_Discriminators(t *testing.T) {
 		assert.Equal(t, k, genModel.DiscriminatorValue)
 
 		buf := bytes.NewBuffer(nil)
-		err = templates.MustGet("model").Execute(buf, genModel)
+		err = opts.templates.MustGet("model").Execute(buf, genModel)
 		require.NoError(t, err)
 
 		b, err := opts.LanguageOpts.FormatContent("discriminated.go", buf.Bytes())
@@ -117,7 +117,7 @@ func TestGenerateModel_Discriminators(t *testing.T) {
 	assert.Equal(t, "Dog", genModel.Discriminates["Dog"])
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("with_discriminator.go", buf.Bytes())
@@ -154,7 +154,7 @@ func TestGenerateModel_UsesDiscriminator(t *testing.T) {
 	require.True(t, genModel.HasBaseType)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("has_discriminator.go", buf.Bytes())
@@ -174,6 +174,7 @@ func TestGenerateClient_OKResponseWithDiscriminator(t *testing.T) {
 	method, path, op, ok := analysis.New(specDoc.Spec()).OperationForName("modelOp")
 	require.True(t, ok)
 
+	opts := opts()
 	bldr := codeGenOpBuilder{
 		Name:          "modelOp",
 		Method:        method,
@@ -188,7 +189,7 @@ func TestGenerateClient_OKResponseWithDiscriminator(t *testing.T) {
 		Authed:        false,
 		DefaultScheme: "http",
 		ExtraSchemas:  make(map[string]GenSchema),
-		GenOpts:       opts(),
+		GenOpts:       opts,
 	}
 
 	genOp, err := bldr.MakeOperation()
@@ -196,7 +197,7 @@ func TestGenerateClient_OKResponseWithDiscriminator(t *testing.T) {
 
 	assert.True(t, genOp.Responses[0].Schema.IsBaseType)
 	var buf bytes.Buffer
-	err = templates.MustGet("clientResponse").Execute(&buf, genOp)
+	err = opts.templates.MustGet("clientResponse").Execute(&buf, genOp)
 	require.NoError(t, err)
 
 	res := buf.String()
@@ -212,6 +213,7 @@ func TestGenerateServer_Parameters(t *testing.T) {
 	method, path, op, ok := analysis.New(specDoc.Spec()).OperationForName("modelOp")
 	require.True(t, ok)
 
+	opts := opts()
 	bldr := codeGenOpBuilder{
 		Name:          "modelOp",
 		Method:        method,
@@ -226,14 +228,14 @@ func TestGenerateServer_Parameters(t *testing.T) {
 		Authed:        false,
 		DefaultScheme: "http",
 		ExtraSchemas:  make(map[string]GenSchema),
-		GenOpts:       opts(),
+		GenOpts:       opts,
 	}
 	genOp, err := bldr.MakeOperation()
 	require.NoError(t, err)
 
 	assert.True(t, genOp.Responses[0].Schema.IsBaseType)
 	var buf bytes.Buffer
-	err = templates.MustGet("serverParameter").Execute(&buf, genOp)
+	err = opts.templates.MustGet("serverParameter").Execute(&buf, genOp)
 	require.NoErrorf(t, err, buf.String())
 
 	res := buf.String()
@@ -255,7 +257,7 @@ func TestGenerateModel_Discriminator_Billforward(t *testing.T) {
 	require.True(t, genModel.IsSubType)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("has_discriminator.go", buf.Bytes())
@@ -286,7 +288,7 @@ func TestGenerateModel_Bitbucket_Repository(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("repository.go", buf.Bytes())
@@ -309,7 +311,7 @@ func TestGenerateModel_Bitbucket_WebhookSubscription(t *testing.T) {
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("webhook_subscription.go", buf.Bytes())
@@ -333,7 +335,7 @@ func TestGenerateModel_Issue319(t *testing.T) {
 	require.Equal(t, "map[string]Base", genModel.Properties[0].GoType)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("ifacedmap.go", buf.Bytes())
@@ -356,7 +358,7 @@ func TestGenerateModel_Issue541(t *testing.T) {
 	require.NotEmpty(t, genModel.AllOf)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("lion.go", buf.Bytes())
@@ -380,7 +382,7 @@ func TestGenerateModel_Issue436(t *testing.T) {
 	require.NotEmpty(t, genModel.AllOf)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("lion.go", buf.Bytes())
@@ -407,7 +409,7 @@ func TestGenerateModel_Issue740(t *testing.T) {
 	require.NotEmpty(t, genModel.AllOf)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("bar.go", buf.Bytes())
@@ -431,7 +433,7 @@ func TestGenerateModel_Issue743(t *testing.T) {
 	require.NotEmpty(t, genModel.AllOf)
 
 	buf := bytes.NewBuffer(nil)
-	err = templates.MustGet("model").Execute(buf, genModel)
+	err = opts.templates.MustGet("model").Execute(buf, genModel)
 	require.NoError(t, err)
 
 	b, err := opts.LanguageOpts.FormatContent("awol.go", buf.Bytes())

--- a/generator/enum_test.go
+++ b/generator/enum_test.go
@@ -443,21 +443,22 @@ func TestGenerateModel_Issue303(t *testing.T) {
 		assert.Equal(t, name, genModel.Name)
 		assert.Equal(t, name, genModel.GoType)
 		assert.True(t, genModel.IsEnumCI)
+
 		extension := genModel.Extensions["x-go-enum-ci"]
-		assert.NotNil(t, extension)
+		require.NotNil(t, extension)
+
 		xGoEnumCI, ok := extension.(bool)
 		assert.True(t, ok)
 		assert.True(t, xGoEnumCI)
 
 		buf := bytes.NewBuffer(nil)
-		err = tt.template.Execute(buf, genModel)
-		require.NoError(t, err)
+		require.NoError(t, tt.template.Execute(buf, genModel))
 
 		ff, err := opts.LanguageOpts.FormatContent("case_insensitive_enum_definition.go", buf.Bytes())
 		require.NoErrorf(t, err, buf.String())
 
 		res := string(ff)
-		assertInCode(t, `		if err := validate.EnumCase(path, location, value, vegetableEnum, false); err != nil {`, res)
+		assertInCode(t, `if err := validate.EnumCase(path, location, value, vegetableEnum, false); err != nil {`, res)
 	}
 }
 

--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -2,71 +2,145 @@ package generator
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestGenerateAndTest(t *testing.T) {
+	defer discardOutput()()
+
+	cwd := testCwd(t)
+	const root = "generated"
+	defer func() {
+		_ = os.RemoveAll(filepath.Join(cwd, root))
+	}()
+
+	t.Run("server build", func(t *testing.T) {
+		for name, cas := range generateFixtures(t) {
+			thisCas := cas
+			thisName := name
+
+			t.Run(thisName, func(t *testing.T) {
+				t.Parallel()
+
+				log.SetOutput(ioutil.Discard)
+				defer thisCas.warnFailed(t)
+
+				// default opts
+				opts := testGenOpts()
+
+				// create directory layout, defer clean
+				defer thisCas.prepareTarget(t, thisName, "server_test", root, opts)()
+
+				// preparation before generation
+				if thisCas.prepare != nil {
+					thisCas.prepare(t, opts)
+				}
+
+				t.Logf("generating test server at: %s, from %s", opts.Target, opts.Spec)
+
+				err := GenerateServer("", nil, nil, opts)
+				if thisCas.wantError {
+					require.Errorf(t, err, "expected an error for server build fixture: %s", opts.Spec)
+				} else {
+					require.NoError(t, err, "unexpected error for server build fixture: %s", opts.Spec)
+				}
+
+				// verify
+				if thisCas.verify != nil {
+					thisCas.verify(t, opts.Target)
+				}
+
+				// fixture-specific clean
+				if thisCas.clean != nil {
+					thisCas.clean()
+				}
+			})
+		}
+	})
+}
+
 type generateFixture struct {
-	name   string
-	spec   string
-	target string
-	//template  string
+	name      string
+	spec      string
+	target    string
 	wantError bool
-	prepare   func(opts *GenOpts)
+	prepare   func(testing.TB, *GenOpts)
 	verify    func(testing.TB, string)
 	clean     func()
 }
 
-func (f generateFixture) prepareTarget(name, base string, opts *GenOpts) func() {
+func (f generateFixture) base(t testing.TB, root string) (string, func()) {
+	// base generation target
+	cwd := testCwd(t)
+
+	base := filepath.Join(cwd, root)
+	require.NoErrorf(t, os.MkdirAll(base, 0700), "error in test creating target dir")
+
+	generated, err := ioutil.TempDir(base, "generated")
+	require.NoErrorf(t, err, "error in test creating temp dir")
+
+	return generated, func() {
+		_ = os.RemoveAll(generated)
+	}
+}
+
+func (f generateFixture) prepareTarget(t testing.TB, name, base, root string, opts *GenOpts) func() {
 	if name == "" {
 		name = f.name
 	}
+
 	spec := filepath.FromSlash(f.spec)
-	if f.target == "" {
-		opts.Target = filepath.Join(filepath.Dir(spec), opts.LanguageOpts.ManglePackageName(name, base))
-	} else {
-		opts.Target = f.target
-	}
 	opts.Spec = spec
-	_ = os.MkdirAll(opts.Target, 0700)
-	return func() {
-		if f.target == "" {
-			_ = os.RemoveAll(filepath.Join(opts.Target))
-			return
-		}
-		_ = os.RemoveAll(filepath.Join(f.target, defaultServerTarget))
-		_ = os.RemoveAll(filepath.Join(f.target, "cmd"))
-		_ = os.RemoveAll(filepath.Join(f.target, defaultModelsTarget))
+
+	generated, clean := f.base(t, root)
+
+	if f.target == "" {
+		opts.Target = filepath.Join(generated, opts.LanguageOpts.ManglePackageName(name, base))
+	} else {
+		opts.Target = filepath.Join(generated, filepath.Base(f.target))
 	}
+
+	require.NoErrorf(t, os.MkdirAll(opts.Target, 0700), "error in test creating target dir")
+
+	return clean
 }
 
-func (f generateFixture) warnFailed(t testing.TB, buf fmt.Stringer) func() {
+func (f generateFixture) warnFailed(t testing.TB) func() {
 	return func() {
 		if t.Failed() {
-			t.Logf("ERROR: generation failed:\n%s", buf.String())
+			t.Log("ERROR: generation failed")
 		}
 	}
 }
 
-func TestGenerateAndTest(t *testing.T) {
-	defer func() {
-		log.SetOutput(os.Stdout)
-	}()
-
-	cases := map[string]generateFixture{
+func generateFixtures(t testing.TB) map[string]generateFixture {
+	return map[string]generateFixture{
 		"issue 1943": {
 			spec:   "../fixtures/bugs/1943/fixture-1943.yaml",
 			target: "../fixtures/bugs/1943",
-			prepare: func(opts *GenOpts) {
+			prepare: func(_ testing.TB, opts *GenOpts) {
+				input, err := ioutil.ReadFile("../fixtures/bugs/1943/datarace_test.go")
+				require.NoError(t, err)
+
+				// rewrite imports for the relocated test program
+				cwd := testCwd(t)
+				rebased := bytes.ReplaceAll(
+					input,
+					[]byte("/fixtures/bugs/1943"),
+					[]byte(filepath.ToSlash(strings.TrimPrefix(opts.Target, filepath.Dir(cwd)))),
+				)
+
+				require.NoError(t, ioutil.WriteFile(filepath.Join(opts.Target, "datarace_test.go"), rebased, 0600))
 				opts.ExcludeSpec = false
 			},
 			verify: func(t testing.TB, target string) {
@@ -75,68 +149,66 @@ func TestGenerateAndTest(t *testing.T) {
 					t.Logf("warn: race test skipped on windows")
 					return
 				}
-				packages := filepath.Join(target, "...")
-				testPrg := filepath.Join(target, "datarace_test.go")
 
-				if p, err := exec.Command("go", "get", packages).CombinedOutput(); err != nil {
-					if !assert.NoError(t, err, "go get %s: %s\n%s", packages, err, p) {
-						return
-					}
-				}
+				const packages = "./..."
+				testPrg := "datarace_test.go"
+
+				goExecInDir(t, target, "get", packages)
 
 				t.Log("running data race test on generated server")
-				if p, err := exec.Command("go", "test", "-v", "-race", testPrg).CombinedOutput(); err != nil {
-					if !assert.NoError(t, err, "go test -race %s: %s\n%s", packages, err, p) {
-						return
-					}
-				}
-
+				goExecInDir(t, target, "test", "-v", "-race", testPrg)
 			},
 		},
 		"packages_mangling": {
 			spec: "../fixtures/bugs/2111/fixture-2111.yaml",
-			prepare: func(opts *GenOpts) {
+			prepare: func(_ testing.TB, opts *GenOpts) {
 				opts.IncludeMain = true
 			},
 			verify: func(t testing.TB, target string) {
 				require.True(t, fileExists(target, defaultServerTarget))
 				assert.True(t, fileExists(filepath.Join(target, "cmd", "unsafe-tag-names-server"), "main.go"))
 
-				target = filepath.Join(target, defaultServerTarget)
+				srvTarget := filepath.Join(target, defaultServerTarget)
+				opsTarget := filepath.Join(srvTarget, defaultOperationsTarget)
+				require.True(t, fileExists(opsTarget, ""))
 
-				buf, err := ioutil.ReadFile(filepath.Join(target, "configure_unsafe_tag_names.go"))
+				for _, fileOrDir := range []string{
+					"abc_linux", "abc_test",
+					"api",
+					"custom",
+					"hash_tag_donuts",
+					"nr123abc", "nr_at_donuts", "plus_donuts",
+					"strfmt",
+					"forced",
+					"gtl",
+					"nr12nasty",
+					"override",
+					"get_notag.go",
+					"operationsops",
+				} {
+					assert.True(t, fileExists(opsTarget, fileOrDir))
+				}
+
+				buf, err := ioutil.ReadFile(filepath.Join(srvTarget, "configure_unsafe_tag_names.go"))
 				require.NoError(t, err)
 
-				target = filepath.Join(target, defaultOperationsTarget)
-				require.True(t, fileExists(target, ""))
-
-				assert.True(t, fileExists(target, "abc_linux"))
-				assert.True(t, fileExists(target, "abc_test"))
-				assert.True(t, fileExists(target, "api"))
-				assert.True(t, fileExists(target, "custom"))
-				assert.True(t, fileExists(target, "hash_tag_donuts"))
-				assert.True(t, fileExists(target, "nr123abc"))
-				assert.True(t, fileExists(target, "nr_at_donuts"))
-				assert.True(t, fileExists(target, "plus_donuts"))
-				assert.True(t, fileExists(target, "strfmt"))
-				assert.True(t, fileExists(target, "forced"))
-				assert.True(t, fileExists(target, "gtl"))
-				assert.True(t, fileExists(target, "nr12nasty"))
-				assert.True(t, fileExists(target, "override"))
-				assert.True(t, fileExists(target, "get_notag.go"))
-				assert.True(t, fileExists(target, "operationsops"))
-
-				buf2, err := ioutil.ReadFile(filepath.Join(target, "unsafe_tag_names_api.go"))
-				require.NoError(t, err)
+				code := string(buf)
 
 				// assert imports, with deconfliction
-				code := string(buf)
-				baseImport := `github.com/go-swagger/go-swagger/fixtures/bugs/2111/packages_mangling/restapi/operations`
+				cwd := testCwd(t)
+				base := path.Join("github.com", "go-swagger", "go-swagger",
+					filepath.ToSlash(strings.TrimPrefix(target, filepath.Dir(cwd))),
+				)
+
+				baseImport := path.Join(base, `restapi/operations`)
 				assertImports(t, baseImport, code)
 
 				assertInCode(t, `api.APIGetConflictHandler = apiops.GetConflictHandlerFunc(`, code)
 				assertInCode(t, `api.StrfmtGetAnotherConflictHandler = strfmtops.GetAnotherConflictHandlerFunc(`, code)
 				assertInCode(t, `api.GetNotagHandler = operations.GetNotagHandlerFunc(`, code)
+
+				buf2, err := ioutil.ReadFile(filepath.Join(opsTarget, "unsafe_tag_names_api.go"))
+				require.NoError(t, err)
 
 				api := string(buf2)
 				assertImports(t, baseImport, api)
@@ -164,48 +236,54 @@ func TestGenerateAndTest(t *testing.T) {
 		},
 		"packages_flattening": {
 			spec: "../fixtures/bugs/2111/fixture-2111.yaml",
-			prepare: func(opts *GenOpts) {
+			prepare: func(_ testing.TB, opts *GenOpts) {
 				opts.SkipTagPackages = true
 			},
 			verify: func(t testing.TB, target string) {
 				require.True(t, fileExists(target, defaultServerTarget))
 
-				target = filepath.Join(target, defaultServerTarget)
-				buf, err := ioutil.ReadFile(filepath.Join(target, "configure_unsafe_tag_names.go"))
+				srvTarget := filepath.Join(target, defaultServerTarget)
+				opsTarget := filepath.Join(srvTarget, defaultOperationsTarget)
+				require.True(t, fileExists(opsTarget, ""))
+
+				for _, fileOrDir := range []string{
+					"abc_linux", "abc_test",
+					"api",
+					"custom",
+					"hash_tag_donuts",
+					"nr123abc", "nr_at_donuts", "plus_donuts",
+					"strfmt",
+					"forced",
+					"gtl",
+					"nr12nasty",
+					"override",
+					"operationsops",
+				} {
+					assert.Falsef(t, fileExists(opsTarget, fileOrDir), "did not expect %s in %s", fileOrDir, opsTarget)
+				}
+
+				assert.Truef(t, fileExists(opsTarget, "get_notag.go"), "expected %s in %s", "get_notag.go", opsTarget)
+
+				buf, err := ioutil.ReadFile(filepath.Join(srvTarget, "configure_unsafe_tag_names.go"))
 				require.NoError(t, err)
-
-				target = filepath.Join(target, defaultOperationsTarget)
-				require.True(t, fileExists(target, ""))
-
-				assert.False(t, fileExists(target, "abc_linux"))
-				assert.False(t, fileExists(target, "abc_test"))
-				assert.False(t, fileExists(target, "api"))
-				assert.False(t, fileExists(target, "custom"))
-				assert.False(t, fileExists(target, "hash_tag_donuts"))
-				assert.False(t, fileExists(target, "nr123abc"))
-				assert.False(t, fileExists(target, "nr_at_donuts"))
-				assert.False(t, fileExists(target, "plus_donuts"))
-				assert.False(t, fileExists(target, "strfmt"))
-				assert.False(t, fileExists(target, "forced"))
-				assert.False(t, fileExists(target, "gtl"))
-				assert.False(t, fileExists(target, "nr12nasty"))
-				assert.False(t, fileExists(target, "override"))
-				assert.False(t, fileExists(target, "operationsops"))
-
-				assert.True(t, fileExists(target, "get_notag.go"))
-
-				buf2, err := ioutil.ReadFile(filepath.Join(target, "unsafe_tag_names_api.go"))
-				require.NoError(t, err)
-
 				code := string(buf)
-				baseImport := `github.com/go-swagger/go-swagger/fixtures/bugs/2111/packages_flattening/restapi/operations`
+
+				cwd := testCwd(t)
+				base := path.Join("github.com", "go-swagger", "go-swagger",
+					filepath.ToSlash(strings.TrimPrefix(target, filepath.Dir(cwd))),
+				)
+
+				baseImport := path.Join(base, `restapi/operations`)
 				assertRegexpInCode(t, baseImport, code)
 
 				assertInCode(t, `api.GetConflictHandler = operations.GetConflictHandlerFunc(`, code)
 				assertInCode(t, `api.GetAnotherConflictHandler = operations.GetAnotherConflictHandlerFunc(`, code)
 				assertInCode(t, `api.GetNotagHandler = operations.GetNotagHandlerFunc(`, code)
 
+				buf2, err := ioutil.ReadFile(filepath.Join(opsTarget, "unsafe_tag_names_api.go"))
+				require.NoError(t, err)
 				api := string(buf2)
+
 				assertInCode(t, `GetConflictHandler: GetConflictHandlerFunc(func(params GetConflictParams) middleware.Responder {`, api)
 				assertInCode(t, `GetAnotherConflictHandler: GetAnotherConflictHandlerFunc(func(params GetAnotherConflictParams) middleware.Responder {`, api)
 				assertInCode(t, `NotagHandler: GetNotagHandlerFunc(func(params GetNotagParams) middleware.Responder {`, api)
@@ -229,7 +307,7 @@ func TestGenerateAndTest(t *testing.T) {
 		},
 		"main_package": {
 			spec: "../fixtures/bugs/2111/fixture-2111.yaml",
-			prepare: func(opts *GenOpts) {
+			prepare: func(_ testing.TB, opts *GenOpts) {
 				opts.IncludeMain = true
 				opts.MainPackage = "custom-api"
 				opts.SkipTagPackages = true
@@ -239,307 +317,185 @@ func TestGenerateAndTest(t *testing.T) {
 			},
 		},
 		"external_model": {
-			spec:   "../fixtures/bugs/1897/fixture-1897.yaml",
-			target: "../fixtures/bugs/1897/codegen",
-			prepare: func(opts *GenOpts) {
-				modelOpts := testGenOpts()
+			spec: "../fixtures/bugs/1897/fixture-1897.yaml",
+			prepare: func(t testing.TB, opts *GenOpts) {
+				modelOpts := *opts
 				modelOpts.AcceptDefinitionsOnly = true
 				modelOpts.Spec = "../fixtures/bugs/1897/model.yaml"
-				modelOpts.Target = "../fixtures/bugs/1897"
 				modelOpts.ModelPackage = "external"
-				err := GenerateModels(nil, modelOpts)
-				require.NoError(t, err)
+				modelOpts.Target = filepath.Dir(modelOpts.Spec)
+
+				require.NoError(t, GenerateModels(nil, &modelOpts))
+
 				t.Logf("generated external model")
+				require.True(t, fileExists(modelOpts.Target, filepath.Join("external")))
+				require.True(t, fileExists(modelOpts.Target, filepath.Join("external", "error.go")))
+
 				opts.IncludeMain = true
 			},
 			verify: func(t testing.TB, target string) {
-				defer func() {
-					_ = os.RemoveAll(target)
-				}()
-				require.True(t, fileExists(target, filepath.Join("..", "external")))
-				defer func() {
-					_ = os.RemoveAll(filepath.Join(target, "..", "external"))
-				}()
-
-				require.True(t, fileExists(target, filepath.Join("..", "external", "error.go")))
-				require.True(t, fileExists(target, filepath.Join("cmd", "repro1897-server")))
-
-				cwd, err := os.Getwd()
-				require.NoError(t, err)
-
-				err = os.Chdir(filepath.Join(target, "cmd", "repro1897-server"))
-				require.NoError(t, err)
-				defer func() {
-					_ = os.Chdir(cwd)
-				}()
+				location := filepath.Join(target, "cmd", "repro1897-server")
+				require.True(t, fileExists("", location))
 
 				t.Log("building generated server")
-				p, err := exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
+				goExecInDir(t, location, "build")
+			},
+			clean: func() {
+				// remove generated external models
+				_ = os.RemoveAll(filepath.Join("..", "fixtures", "bugs", "1897", "external"))
 			},
 		},
 		"external_models_hints": {
 			spec:   "../fixtures/enhancements/2224/fixture-2224.yaml",
-			target: "../fixtures/enhancements/2224/codegen",
-			prepare: func(opts *GenOpts) {
-				modelOpts := testGenOpts()
+			target: "2224-hints",
+			prepare: func(t testing.TB, opts *GenOpts) {
+				modelOpts := *opts
 				modelOpts.AcceptDefinitionsOnly = true
 				modelOpts.Spec = "../fixtures/enhancements/2224/fixture-2224-models.yaml"
-				modelOpts.Target = "../fixtures/enhancements/2224"
 				modelOpts.ModelPackage = "external"
-				err := GenerateModels(nil, modelOpts)
-				require.NoError(t, err)
+				modelOpts.Target = filepath.Dir(modelOpts.Spec)
+
+				require.NoError(t, GenerateModels(nil, &modelOpts))
+
 				t.Logf("generated external model")
+				require.True(t, fileExists(modelOpts.Target, filepath.Join("external")))
+
+				for _, model := range []string{
+					"access_point.go", "base.go",
+					"hotspot.go", "hotspot_type.go",
+					"incorrect.go", "json_message.go",
+					"json_object.go", "json_object_with_alias.go",
+					"object_with_embedded.go", "object_with_externals.go",
+					"raw.go", "request.go",
+					"request_pointer.go", "time_as_object.go", "time.go",
+				} {
+					require.True(t, fileExists(modelOpts.Target, filepath.Join("external", model)))
+				}
+
 				opts.IncludeMain = true
 			},
 			verify: func(t testing.TB, target string) {
-				defer func() {
-					_ = os.RemoveAll(target)
-				}()
-				require.True(t, fileExists(target, filepath.Join("..", "external")))
-				defer func() {
-					_ = os.RemoveAll(filepath.Join(target, "..", "external"))
-				}()
-
-				for _, model := range []string{
-					"access_point.go",
-					"base.go",
-					"hotspot.go",
-					"hotspot_type.go",
-					"incorrect.go",
-					"json_message.go",
-					"json_object.go",
-					"json_object_with_alias.go",
-					"object_with_embedded.go",
-					"object_with_externals.go",
-					"raw.go",
-					"request.go",
-					"request_pointer.go",
-					"time_as_object.go",
-					"time.go",
-				} {
-					require.True(t, fileExists(target, filepath.Join("..", "external", model)))
-				}
+				// generated models (not external)
 				require.True(t, fileExists(target, filepath.Join("models")))
 				for _, model := range []string{"error.go", "external_with_embed.go"} {
 					require.True(t, fileExists(target, filepath.Join("models", model)))
 				}
-				require.True(t, fileExists(target, filepath.Join("cmd", "external-types-with-hints-server")))
 
-				cwd, err := os.Getwd()
-				require.NoError(t, err)
-
-				err = os.Chdir(filepath.Join(target, "cmd", "external-types-with-hints-server"))
-				require.NoError(t, err)
-				defer func() {
-					_ = os.Chdir(cwd)
-				}()
+				location := filepath.Join(target, "cmd", "external-types-with-hints-server")
+				require.True(t, fileExists("", location))
 
 				t.Log("building generated server")
-				p, err := exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
+				goExecInDir(t, location, "build")
+			},
+			clean: func() {
+				// remove generated external models
+				_ = os.RemoveAll(filepath.Join("..", "fixtures", "enhancements", "2224", "external"))
 			},
 		},
 		"conflict_name_api_issue_2405_1": {
 			spec:   "../examples/todo-list/swagger.yml",
-			target: "codegen/2405-1",
-			prepare: func(opts *GenOpts) {
-				opts.Target = "codegen/2405-1"
+			target: "2405-1",
+			prepare: func(_ testing.TB, opts *GenOpts) {
 				opts.ServerPackage = "api"
 				opts.IncludeMain = true
 			},
 			verify: func(t testing.TB, target string) {
-				cwd, err := os.Getwd()
-				require.NoError(t, err)
-
-				require.True(t, fileExists(target, filepath.Join("cmd", "simple-to-do-list-api-server")))
-
-				err = os.Chdir(filepath.Join(target, "cmd", "simple-to-do-list-api-server"))
-				require.NoError(t, err)
-				defer func() {
-					_ = os.Chdir(cwd)
-				}()
+				location := filepath.Join(target, "cmd", "simple-to-do-list-api-server")
+				require.True(t, fileExists("", location))
 
 				t.Log("building generated server")
-				p, err := exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
-			},
-			clean: func() {
-				_ = os.RemoveAll("codegen")
+				goExecInDir(t, location, "build")
 			},
 		},
 		"conflict_name_api_issue_2405_2": {
 			spec:   "../examples/todo-list/swagger.yml",
-			target: "codegen/2405-2",
-			prepare: func(opts *GenOpts) {
-				opts.Target = "codegen/2405-2"
+			target: "2405-2",
+			prepare: func(_ testing.TB, opts *GenOpts) {
 				opts.ServerPackage = "loads"
 				opts.IncludeMain = true
 			},
 			verify: func(t testing.TB, target string) {
-				cwd, err := os.Getwd()
-				require.NoError(t, err)
-
-				require.True(t, fileExists(target, filepath.Join("cmd", "simple-to-do-list-api-server")))
-
-				err = os.Chdir(filepath.Join(target, "cmd", "simple-to-do-list-api-server"))
-				require.NoError(t, err)
-				defer func() {
-					_ = os.Chdir(cwd)
-				}()
+				location := filepath.Join(target, "cmd", "simple-to-do-list-api-server")
+				require.True(t, fileExists("", location))
 
 				t.Log("building generated server")
-				p, err := exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
-			},
-			clean: func() {
-				_ = os.RemoveAll("codegen")
+				goExecInDir(t, location, "build")
 			},
 		},
 		"conflict_name_api_issue_2405_3": {
 			spec:   "../fixtures/bugs/2405/fixture-2405.yaml",
-			target: "codegen/2405-3",
-			prepare: func(opts *GenOpts) {
-				opts.Target = "codegen/2405-3"
+			target: "2405-3",
+			prepare: func(_ testing.TB, opts *GenOpts) {
 				opts.ServerPackage = "server"
 				opts.APIPackage = "api"
 				opts.IncludeMain = true
 			},
 			verify: func(t testing.TB, target string) {
-				cwd, err := os.Getwd()
-				require.NoError(t, err)
-
-				require.True(t, fileExists(target, filepath.Join("cmd", "simple-to-do-list-api-server")))
-
-				err = os.Chdir(filepath.Join(target, "cmd", "simple-to-do-list-api-server"))
-				require.NoError(t, err)
-				defer func() {
-					_ = os.Chdir(cwd)
-				}()
+				location := filepath.Join(target, "cmd", "simple-to-do-list-api-server")
+				require.True(t, fileExists("", location))
 
 				t.Log("building generated server")
-				p, err := exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
-			},
-			clean: func() {
-				_ = os.RemoveAll("codegen")
+				goExecInDir(t, location, "build")
 			},
 		},
 		"ext_types_issue_2385": {
 			spec:   "../fixtures/bugs/2385/fixture-2385.yaml",
-			target: "codegen/2385",
-			prepare: func(opts *GenOpts) {
-				opts.Target = "codegen/2385"
+			target: "2385",
+			prepare: func(t testing.TB, opts *GenOpts) {
 				opts.MainPackage = "nrcodegen-server"
 				opts.IncludeMain = true
 				location := filepath.Join(opts.Target, "models")
+
+				// add some custom model to the generated models
 				addModelsToLocation(t, location, "my_type.go")
 			},
-			verify: func(t testing.TB, target string) {
-				cwd, err := os.Getwd()
-				require.NoError(t, err)
-
-				require.True(t, fileExists(target, filepath.Join("cmd", "nrcodegen-server")))
-
-				err = os.Chdir(filepath.Join(target, "cmd", "nrcodegen-server"))
-				require.NoError(t, err)
-				defer func() {
-					_ = os.Chdir(cwd)
-				}()
+			verify: func(_ testing.TB, target string) {
+				location := filepath.Join(target, "cmd", "nrcodegen-server")
+				require.True(t, fileExists("", location))
 
 				t.Log("building generated server")
-				p, err := exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
+				goExecInDir(t, location, "build")
 
-				err = os.Chdir(filepath.Join(cwd, target, "models"))
-				require.NoError(t, err)
+				location = filepath.Join(target, "models")
 
 				t.Log("building generated models")
-				p, err = exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
-			},
-			clean: func() {
-				_ = os.RemoveAll("codegen")
+				goExecInDir(t, location, "build")
 			},
 		},
 		"ext_types_full_example": {
 			spec:   "../examples/external-types/example-external-types.yaml",
-			target: "codegen/external",
-			prepare: func(opts *GenOpts) {
-				opts.Target = "codegen/external"
+			target: "external-full",
+			prepare: func(_ testing.TB, opts *GenOpts) {
 				opts.MainPackage = "nrcodegen-server"
 				opts.IncludeMain = true
-				opts.ValidateSpec = false
+				opts.ValidateSpec = false // the spec contains AdditionalItems
 				location := filepath.Join(opts.Target, "models")
+
+				// add some custom model to the generated models
 				addModelsToLocation(t, location, "my_type.go")
 			},
 			verify: func(t testing.TB, target string) {
-				cwd, err := os.Getwd()
-				require.NoError(t, err)
-
-				require.True(t, fileExists(target, filepath.Join("cmd", "nrcodegen-server")))
-
-				err = os.Chdir(filepath.Join(target, "cmd", "nrcodegen-server"))
-				require.NoError(t, err)
-				defer func() {
-					_ = os.Chdir(cwd)
-				}()
+				location := filepath.Join(target, "cmd", "nrcodegen-server")
+				require.True(t, fileExists("", location))
 
 				t.Log("building generated server")
-				p, err := exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
+				goExecInDir(t, location, "build")
 
-				err = os.Chdir(filepath.Join(cwd, target, "models"))
-				require.NoError(t, err)
+				location = filepath.Join(target, "models")
 
 				t.Log("building generated models")
-				p, err = exec.Command("go", "build").CombinedOutput()
-				require.NoErrorf(t, err, string(p))
-			},
-			clean: func() {
-				_ = os.RemoveAll("codegen")
+				goExecInDir(t, location, "build")
 			},
 		},
-	}
-
-	for name, cas := range cases {
-		thisCas := cas
-
-		t.Run(name, func(t *testing.T) {
-			var captureLog bytes.Buffer
-			log.SetOutput(&captureLog)
-			defer thisCas.warnFailed(t, &captureLog)
-
-			opts := testGenOpts()
-			defer thisCas.prepareTarget(name, "server_test", opts)()
-
-			if thisCas.prepare != nil {
-				thisCas.prepare(opts)
-			}
-
-			t.Logf("generating test server at: %s", opts.Target)
-			err := GenerateServer("", nil, nil, opts)
-			if thisCas.wantError {
-				require.Errorf(t, err, "expected an error for server build fixture: %s", opts.Spec)
-			} else {
-				require.NoError(t, err, "unexpected error for server build fixture: %s", opts.Spec)
-			}
-
-			if thisCas.verify != nil {
-				thisCas.verify(t, opts.Target)
-			}
-
-			if thisCas.clean != nil {
-				thisCas.clean()
-			}
-		})
 	}
 }
 
 func addModelsToLocation(t testing.TB, location, file string) {
-	emkd := os.MkdirAll(location, 0700)
-	require.NoError(t, emkd)
-	erf := ioutil.WriteFile(filepath.Join(location, file), []byte(`
+	// writes some external model to a file to supplement codegen
+	// (test external types)
+	require.NoError(t, os.MkdirAll(location, 0700))
+
+	require.NoError(t, ioutil.WriteFile(filepath.Join(location, file), []byte(`
 package models
 
 import (
@@ -579,6 +535,5 @@ func (MyOtherType) ContextValidate(context.Context, strfmt.Registry) error { ret
 // MyStreamer ...
 type MyStreamer io.Reader
 `),
-		os.ModePerm)
-	require.NoError(t, erf)
+		os.ModePerm))
 }

--- a/generator/schemavalidation_test.go
+++ b/generator/schemavalidation_test.go
@@ -16,7 +16,6 @@ package generator
 
 import (
 	"bytes"
-	"regexp"
 	"testing"
 
 	"github.com/go-openapi/loads"
@@ -24,64 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// testing utilities for codegen assertions
-
-func reqm(str string) *regexp.Regexp {
-	return regexp.MustCompile(regexp.QuoteMeta(str))
-}
-
-func reqOri(str string) *regexp.Regexp {
-	return regexp.MustCompile(str)
-}
-
-func assertInCode(t testing.TB, expr, code string) bool {
-	return assert.Regexp(t, reqm(expr), code)
-}
-
-func assertRegexpInCode(t testing.TB, expr, code string) bool {
-	return assert.Regexp(t, reqOri(expr), code)
-}
-
-func assertNotInCode(t testing.TB, expr, code string) bool {
-	return assert.NotRegexp(t, reqm(expr), code)
-}
-
-// Unused
-// func assertRegexpNotInCode(t testing.TB, expr, code string) bool {
-// 	return assert.NotRegexp(t, reqOri(expr), code)
-// }
-
-func requireValidation(t testing.TB, pth, expr string, gm GenSchema) {
-	if !assertValidation(t, pth, expr, gm) {
-		t.FailNow()
-	}
-}
-
-func assertValidation(t testing.TB, pth, expr string, gm GenSchema) bool {
-	if !assert.True(t, gm.HasValidations, "expected the schema to have validations") {
-		return false
-	}
-	if !assert.Equal(t, pth, gm.Path, "paths don't match") {
-		return false
-	}
-	if !assert.Equal(t, expr, gm.ValueExpression, "expressions don't match") {
-		return false
-	}
-	return true
-}
-
-func funcBody(code string, signature string) string {
-	submatches := regexp.MustCompile(
-		"\\nfunc \\([a-zA-Z_][a-zA-Z0-9_]* " + regexp.QuoteMeta(signature) + " {\\n" + // function signature
-			"((([^}\\n][^\\n]*)?\\n)*)}\\n", // function body
-	).FindStringSubmatch(code)
-
-	if submatches == nil {
-		return ""
-	}
-	return submatches[1]
-}
 
 func TestSchemaValidation_RequiredProps(t *testing.T) {
 	specDoc, err := loads.Spec("../fixtures/codegen/todolist.schemavalidation.yml")

--- a/generator/server_test.go
+++ b/generator/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -65,8 +64,7 @@ func testAppGenerator(t testing.TB, specPath, name string) (*appGenerator, error
 }
 
 func TestServer_UrlEncoded(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/codegen/simplesearch.yml", "search")
 	require.NoError(t, err)
@@ -75,7 +73,7 @@ func TestServer_UrlEncoded(t *testing.T) {
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
-	require.NoError(t, templates.MustGet("serverBuilder").Execute(buf, app))
+	require.NoError(t, app.GenOpts.templates.MustGet("serverBuilder").Execute(buf, app))
 
 	formatted, err := app.GenOpts.LanguageOpts.FormatContent("search_api.go", buf.Bytes())
 	require.NoErrorf(t, err, buf.String())
@@ -84,18 +82,16 @@ func TestServer_UrlEncoded(t *testing.T) {
 	assert.Regexp(t, "UrlformConsumer:\\s+runtime\\.DiscardConsumer", res)
 
 	buf = bytes.NewBuffer(nil)
-	require.NoError(t, templates.MustGet("serverConfigureapi").Execute(buf, app))
+	require.NoError(t, app.GenOpts.templates.MustGet("serverConfigureapi").Execute(buf, app))
 
 	formatted, err = app.GenOpts.LanguageOpts.FormatContent("configure_search_api.go", buf.Bytes())
 	require.NoErrorf(t, err, buf.String())
 
-	res = string(formatted)
-	assertInCode(t, "api.UrlformConsumer = runtime.DiscardConsumer", res)
+	assertInCode(t, "api.UrlformConsumer = runtime.DiscardConsumer", string(formatted))
 }
 
 func TestServer_MultipartForm(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/codegen/shipyard.yml", "shipyard")
 	require.NoError(t, err)
@@ -104,27 +100,24 @@ func TestServer_MultipartForm(t *testing.T) {
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
-	require.NoError(t, templates.MustGet("serverBuilder").Execute(buf, app))
+	require.NoError(t, app.GenOpts.templates.MustGet("serverBuilder").Execute(buf, app))
 
 	formatted, err := app.GenOpts.LanguageOpts.FormatContent("shipyard_api.go", buf.Bytes())
 	require.NoErrorf(t, err, buf.String())
 
-	res := string(formatted)
-	assert.Regexp(t, "MultipartformConsumer:\\s+runtime\\.DiscardConsumer", res)
+	assert.Regexp(t, "MultipartformConsumer:\\s+runtime\\.DiscardConsumer", string(formatted))
 
 	buf = bytes.NewBuffer(nil)
-	require.NoError(t, templates.MustGet("serverConfigureapi").Execute(buf, app))
+	require.NoError(t, app.GenOpts.templates.MustGet("serverConfigureapi").Execute(buf, app))
 
 	formatted, err = app.GenOpts.LanguageOpts.FormatContent("configure_shipyard_api.go", buf.Bytes())
 	require.NoErrorf(t, err, buf.String())
 
-	res = string(formatted)
-	assertInCode(t, "api.MultipartformConsumer = runtime.DiscardConsumer", res)
+	assertInCode(t, "api.MultipartformConsumer = runtime.DiscardConsumer", string(formatted))
 }
 
 func TestServer_InvalidSpec(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	opts := testGenOpts()
 	opts.Spec = invalidSpecExample
@@ -134,8 +127,7 @@ func TestServer_InvalidSpec(t *testing.T) {
 }
 
 func TestServer_TrailingSlash(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/bugs/899/swagger.yml", "trailing slash")
 	require.NoError(t, err)
@@ -144,18 +136,16 @@ func TestServer_TrailingSlash(t *testing.T) {
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
-	require.NoError(t, templates.MustGet("serverBuilder").Execute(buf, app))
+	require.NoError(t, app.GenOpts.templates.MustGet("serverBuilder").Execute(buf, app))
 
 	formatted, err := app.GenOpts.LanguageOpts.FormatContent("shipyard_api.go", buf.Bytes())
 	require.NoError(t, err, buf.String())
 
-	res := string(formatted)
-	assertInCode(t, `o.handlers["GET"]["/trailingslashpath"]`, res)
+	assertInCode(t, `o.handlers["GET"]["/trailingslashpath"]`, string(formatted))
 }
 
 func TestServer_Issue987(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/bugs/987/swagger.yml", "deeper consumes produces")
 	require.NoError(t, err)
@@ -164,7 +154,7 @@ func TestServer_Issue987(t *testing.T) {
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
-	require.NoError(t, templates.MustGet("serverBuilder").Execute(buf, app))
+	require.NoError(t, app.GenOpts.templates.MustGet("serverBuilder").Execute(buf, app))
 
 	formatted, err := app.GenOpts.LanguageOpts.FormatContent("shipyard_api.go", buf.Bytes())
 	require.NoErrorf(t, err, buf.String())
@@ -177,8 +167,7 @@ func TestServer_Issue987(t *testing.T) {
 }
 
 func TestServer_FilterByTag(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/codegen/simplesearch.yml", "search")
 	require.NoError(t, err)
@@ -188,7 +177,7 @@ func TestServer_FilterByTag(t *testing.T) {
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
-	require.NoError(t, templates.MustGet("serverBuilder").Execute(buf, app))
+	require.NoError(t, app.GenOpts.templates.MustGet("serverBuilder").Execute(buf, app))
 
 	formatted, err := app.GenOpts.LanguageOpts.FormatContent("search_api.go", buf.Bytes())
 	require.NoErrorf(t, err, buf.String())
@@ -198,67 +187,48 @@ func TestServer_FilterByTag(t *testing.T) {
 	assertNotInCode(t, `o.handlers["POST"]["/tasks"]`, res)
 }
 
-// Checking error handling code: panic on mismatched template
-// High level test with AppGenerator
-func badTemplateCall() {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+func TestServer_BadTemplate(t *testing.T) {
+	// Checking error handling code: panic on mismatched template
+
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(nil, "../fixtures/bugs/899/swagger.yml", "trailing slash")
-	if err != nil {
-		return
-	}
+	require.NoError(t, err)
+
 	app, err := gen.makeCodegenApp()
-	log.SetOutput(ioutil.Discard)
-	if err != nil {
-		return
+	require.NoError(t, err)
+
+	badTemplateCall := func() {
+		buf := bytes.NewBuffer(nil)
+		_ = app.GenOpts.templates.MustGet("serverBuilderX").Execute(buf, app)
 	}
-	buf := bytes.NewBuffer(nil)
-	r := templates.MustGet("serverBuilderX").Execute(buf, app)
-
-	// Should never reach here
-	log.Printf("%+v\n", r)
-}
-
-func TestServer_BadTemplate(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
 
 	assert.Panics(t, badTemplateCall, "templates.MustGet() did not panic() as currently expected")
 }
 
-// Checking error handling code: panic on bad parsing template
-// High level test with AppGenerator
-func badParseCall() {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+func TestServer_ErrorParsingTemplate(t *testing.T) {
+	// Checking error handling code: panic on bad parsing template
+	// High level test with AppGenerator
+
+	defer discardOutput()()
 
 	var badParse = `{{{ define "T1" }}T1{{end}}{{ define "T2" }}T2{{end}}`
 
-	_ = templates.AddFile("badparse", badParse)
-	gen, _ := testAppGenerator(nil, "../fixtures/bugs/899/swagger.yml", "trailing slash")
-	app, _ := gen.makeCodegenApp()
-	log.SetOutput(ioutil.Discard)
-	tpl := templates.MustGet("badparse")
+	gen, err := testAppGenerator(nil, "../fixtures/bugs/899/swagger.yml", "trailing slash")
+	require.NoError(t, err)
 
-	// Should never reach here
-	buf := bytes.NewBuffer(nil)
-	r := tpl.Execute(buf, app)
+	require.Error(t, gen.GenOpts.templates.AddFile("badparse", badParse)) // template is not loaded
 
-	log.Printf("%+v\n", r)
-}
-
-func TestServer_ErrorParsingTemplate(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	badParseCall := func() {
+		_ = templates.MustGet("badparse") // MustGet panics
+	}
 
 	assert.Panics(t, badParseCall, "templates.MustGet() did not panic() as currently expected")
 }
 
 func TestServer_OperationGroups(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
+	defer discardOutput()()
 	defer func() {
-		log.SetOutput(os.Stdout)
 		_ = os.RemoveAll(filepath.Join(".", "restapi"))
 		_ = os.RemoveAll(filepath.Join(".", "search"))
 		_ = os.RemoveAll(filepath.Join(".", "tasks"))
@@ -278,8 +248,9 @@ func TestServer_OperationGroups(t *testing.T) {
 			FileName: "{{ (snakize (pascalize .Name)) }}_opgroup_test.gol",
 		},
 	}
+
 	err = gen.Generate()
-	require.Error(t, err)                                                      // This attempts fails: template not declared
+	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "template doesn't exist") // Tolerates case variations on error message
 
 	var opGroupTpl = `
@@ -288,17 +259,19 @@ func TestServer_OperationGroups(t *testing.T) {
 {{ range .Operations }}
 	// OperationName={{.Name}}
 {{end}}`
-	_ = templates.AddFile("opGroupTest", opGroupTpl)
-	err = gen.Generate()
-	require.NoError(t, err)
-	genContent, erf := ioutil.ReadFile("./search/search_opgroup_test.gol")
-	assert.NoError(t, erf, "Generator should have written a file")
+	_ = gen.GenOpts.templates.AddFile("opGroupTest", opGroupTpl)
+	require.NoError(t, gen.Generate())
+
+	genContent, err := ioutil.ReadFile("./search/search_opgroup_test.gol")
+	require.NoError(t, err, "Generator should have written a file")
+
 	assert.Contains(t, string(genContent), "// OperationGroupName=search")
 	assert.Contains(t, string(genContent), "// RootPackage=operations")
 	assert.Contains(t, string(genContent), "// OperationName=search")
 
-	genContent, erf = ioutil.ReadFile("./tasks/tasks_opgroup_test.gol")
-	require.NoError(t, erf, "Generator should have written a file")
+	genContent, err = ioutil.ReadFile("./tasks/tasks_opgroup_test.gol")
+	require.NoError(t, err, "Generator should have written a file")
+
 	assert.Contains(t, string(genContent), "// OperationGroupName=tasks")
 	assert.Contains(t, string(genContent), "// RootPackage=operations")
 	assert.Contains(t, string(genContent), "// OperationName=createTask")
@@ -308,8 +281,7 @@ func TestServer_OperationGroups(t *testing.T) {
 }
 
 func TestServer_Issue1301(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/enhancements/1301/swagger.yml", "custom producers")
 	require.NoError(t, err)
@@ -318,9 +290,11 @@ func TestServer_Issue1301(t *testing.T) {
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
-	require.NoError(t, templates.MustGet("serverBuilder").Execute(buf, app))
+	require.NoError(t, app.GenOpts.templates.MustGet("serverBuilder").Execute(buf, app))
+
 	formatted, err := app.GenOpts.LanguageOpts.FormatContent("shipyard_api.go", buf.Bytes())
 	require.NoErrorf(t, err, buf.String())
+
 	res := string(formatted)
 
 	// initialisation in New<Name>API function
@@ -337,8 +311,7 @@ func TestServer_Issue1301(t *testing.T) {
 }
 
 func TestServer_PreServerShutdown_Issue2108(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/enhancements/2108/swagger.yml", "pre server shutdown")
 	require.NoError(t, err)
@@ -369,8 +342,7 @@ func TestServer_PreServerShutdown_Issue2108(t *testing.T) {
 }
 
 func TestServer_Issue1557(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/enhancements/1557/swagger.yml", "generate consumer/producer handlers that are not whitelisted")
 	require.NoError(t, err)
@@ -398,8 +370,7 @@ func TestServer_Issue1557(t *testing.T) {
 }
 
 func TestServer_Issue1648(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	gen, err := testAppGenerator(t, "../fixtures/bugs/1648/fixture-1648.yaml", "generate format with missing type in model")
 	require.NoError(t, err)
@@ -409,34 +380,38 @@ func TestServer_Issue1648(t *testing.T) {
 }
 
 func TestServer_Issue1746(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
+	defer discardOutput()()
+
 	targetdir, err := ioutil.TempDir(".", "swagger_server")
 	require.NoErrorf(t, err, "failed to create a test target directory: %v", err)
-	err = os.Chdir(targetdir)
-	require.NoErrorf(t, err, "failed to create a test target directory: %v", err)
 	defer func() {
-		log.SetOutput(os.Stdout)
-		_ = os.Chdir("..")
 		_ = os.RemoveAll(targetdir)
 	}()
 
-	opts := testGenOpts()
+	cwd := testCwd(t)
+	require.NoErrorf(t, os.Chdir(targetdir), "failed to create a test target directory: %v", err)
+	defer func() {
+		_ = os.Chdir(cwd)
+	}()
 
+	opts := testGenOpts()
 	opts.Target = filepath.Join("x")
-	_ = os.Mkdir(opts.Target, 0755)
 	opts.Spec = filepath.Join("..", "..", "fixtures", "bugs", "1746", "fixture-1746.yaml")
 	tgtSpec := regexp.QuoteMeta(filepath.Join("..", "..", opts.Spec))
 
-	err = GenerateServer("", nil, nil, opts)
-	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(opts.Target, 0755))
+
+	require.NoError(t, GenerateServer("", nil, nil, opts))
 
 	gulp, err := ioutil.ReadFile(filepath.Join("x", "restapi", "configure_example_swagger_server.go"))
 	require.NoError(t, err)
 
+	res := string(gulp)
+
 	tgtPath := regexp.QuoteMeta(filepath.Join("..", "..", opts.Target))
-	assertRegexpInCode(t, `go:generate swagger generate server.+\-\-target `+tgtPath, string(gulp))
-	assertRegexpInCode(t, `go:generate swagger generate server.+\-\-name\s+ExampleSwaggerServer`, string(gulp))
-	assertRegexpInCode(t, `go:generate swagger generate server.+\-\-spec\s+`+tgtSpec, string(gulp))
+	assertRegexpInCode(t, `go:generate swagger generate server.+\-\-target `+tgtPath, res)
+	assertRegexpInCode(t, `go:generate swagger generate server.+\-\-name\s+ExampleSwaggerServer`, res)
+	assertRegexpInCode(t, `go:generate swagger generate server.+\-\-spec\s+`+tgtSpec, res)
 }
 
 func doGenAppTemplate(t testing.TB, fixture, template string) string {
@@ -456,8 +431,7 @@ func doGenAppTemplate(t testing.TB, fixture, template string) string {
 }
 
 func TestServer_Issue1816(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	// fixed regression: gob encoding in $ref
 	res := doGenAppTemplate(t, "../fixtures/bugs/1816/fixture-1816.yaml", "swaggerJsonEmbed")

--- a/generator/support.go
+++ b/generator/support.go
@@ -229,7 +229,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 		baseImport,
 		a.GenOpts.LanguageOpts.ManglePackagePath(a.OperationsPackage, defaultOperationsTarget))
 
-	log.Println("planning definitions")
+	log.Printf("planning definitions (found: %d)", len(a.Models))
 
 	genModels := make(GenDefinitions, 0, len(a.Models))
 	for mn, m := range a.Models {
@@ -258,7 +258,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 	}
 	sort.Sort(genModels)
 
-	log.Println("planning operations")
+	log.Printf("planning operations (found: %d)", len(a.Operations))
 
 	genOps := make(GenOperations, 0, len(a.Operations))
 	for operationName, opp := range a.Operations {
@@ -326,15 +326,16 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 	}
 	sort.Sort(genOps)
 
-	log.Println("grouping operations into packages")
-
 	opsGroupedByPackage := make(map[string]GenOperations, len(genOps))
 	for _, operation := range genOps {
 		opsGroupedByPackage[operation.PackageAlias] = append(opsGroupedByPackage[operation.PackageAlias], operation)
 	}
 
+	log.Printf("grouping operations into packages (packages: %d)", len(opsGroupedByPackage))
+
 	opGroups := make(GenOperationGroups, 0, len(opsGroupedByPackage))
 	for k, v := range opsGroupedByPackage {
+		log.Printf("operations for package packages %q (found: %d)", k, len(v))
 		sort.Sort(v)
 		// trim duplicate extra schemas within the same package
 		vv := make(GenOperations, 0, len(v))

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -121,8 +121,7 @@ func TestBaseImport(t *testing.T) {
 
 		// Create Paths
 		for _, paths := range item.path {
-			err = os.MkdirAll(paths, 0700)
-			require.NoError(t, err)
+			require.NoError(t, os.MkdirAll(paths, 0700))
 		}
 
 		if item.symlinksrc == "" {
@@ -130,8 +129,7 @@ func TestBaseImport(t *testing.T) {
 		}
 
 		// Create Symlink
-		err := os.Symlink(item.symlinkdest, item.symlinksrc)
-		require.NoErrorf(t, err,
+		require.NoErrorf(t, os.Symlink(item.symlinkdest, item.symlinksrc),
 			"WARNING:TestBaseImport with symlink could not be carried on. Symlink creation failed for %s -> %s: %v\n%s",
 			item.symlinksrc, item.symlinkdest, err,
 			"NOTE:TestBaseImport with symlink on Windows requires extended privileges (admin or a user with SeCreateSymbolicLinkPrivilege)",

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -2,9 +2,6 @@ package generator
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"log"
-	"os"
 	"strconv"
 	"testing"
 
@@ -328,10 +325,7 @@ func makeResolveExternalTypes() []externalTypeFixture {
 }
 
 func TestShortCircuitResolveExternal(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer func() {
-		log.SetOutput(os.Stdout)
-	}()
+	defer discardOutput()()
 
 	for i, toPin := range makeResolveExternalTypes() {
 		fixture := toPin
@@ -354,6 +348,7 @@ func TestShortCircuitResolveExternal(t *testing.T) {
 			extType, ok := hasExternalType(schema.Extensions)
 			require.Truef(t, ok, "fixture %d", i)
 			require.NotNil(t, extType)
+			//require.EqualValues(t, fixture.expected, extType) // TODO(fred)
 
 			tpe, pkg, alias := r.knownDefGoType("A", schema, r.goTypeName)
 			require.EqualValuesf(t, fixture.knownDefs, struct{ tpe, pkg, alias string }{tpe, pkg, alias}, "fixture %d", i)

--- a/generator/utils_test.go
+++ b/generator/utils_test.go
@@ -1,0 +1,95 @@
+package generator
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testing utilities for codegen assertions
+
+func reqm(str string) *regexp.Regexp {
+	return regexp.MustCompile(regexp.QuoteMeta(str))
+}
+
+func reqOri(str string) *regexp.Regexp {
+	return regexp.MustCompile(str)
+}
+
+func assertInCode(t testing.TB, expr, code string) bool {
+	return assert.Regexp(t, reqm(expr), code)
+}
+
+func assertRegexpInCode(t testing.TB, expr, code string) bool {
+	return assert.Regexp(t, reqOri(expr), code)
+}
+
+func assertNotInCode(t testing.TB, expr, code string) bool {
+	return assert.NotRegexp(t, reqm(expr), code)
+}
+
+// Unused
+// func assertRegexpNotInCode(t testing.TB, expr, code string) bool {
+// 	return assert.NotRegexp(t, reqOri(expr), code)
+// }
+
+func requireValidation(t testing.TB, pth, expr string, gm GenSchema) {
+	if !assertValidation(t, pth, expr, gm) {
+		t.FailNow()
+	}
+}
+
+func assertValidation(t testing.TB, pth, expr string, gm GenSchema) bool {
+	if !assert.True(t, gm.HasValidations, "expected the schema to have validations") {
+		return false
+	}
+	if !assert.Equal(t, pth, gm.Path, "paths don't match") {
+		return false
+	}
+	if !assert.Equal(t, expr, gm.ValueExpression, "expressions don't match") {
+		return false
+	}
+	return true
+}
+
+func funcBody(code string, signature string) string {
+	submatches := regexp.MustCompile(
+		"\\nfunc \\([a-zA-Z_][a-zA-Z0-9_]* " + regexp.QuoteMeta(signature) + " {\\n" + // function signature
+			"((([^}\\n][^\\n]*)?\\n)*)}\\n", // function body
+	).FindStringSubmatch(code)
+
+	if submatches == nil {
+		return ""
+	}
+	return submatches[1]
+}
+
+// testing utilities for codegen build
+
+func goExecInDir(t testing.TB, target string, args ...string) {
+	cmd := exec.Command("go", args...)
+	cmd.Dir = target
+	p, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "unexpected error: %s: %v\n%s", cmd.String(), err, string(p))
+}
+
+func testCwd(t testing.TB) string {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	return cwd
+}
+
+func discardOutput() func() {
+	// discards log output then sends a function to set it back to stdout
+	log.SetOutput(ioutil.Discard)
+
+	return func() {
+		log.SetOutput(os.Stdout)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/go-openapi/analysis v0.19.16
 	github.com/go-openapi/errors v0.19.9
 	github.com/go-openapi/inflect v0.19.0
-	github.com/go-openapi/loads v0.19.7
+	github.com/go-openapi/loads v0.20.0
 	github.com/go-openapi/runtime v0.19.24
-	github.com/go-openapi/spec v0.19.15
+	github.com/go-openapi/spec v0.20.0
 	github.com/go-openapi/strfmt v0.19.11
 	github.com/go-openapi/swag v0.19.12
-	github.com/go-openapi/validate v0.19.15
+	github.com/go-openapi/validate v0.20.0
 	github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/gorilla/handlers v1.5.1
@@ -34,7 +34,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/toqueteos/webbrowser v1.2.0
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
 	golang.org/x/sys v0.0.0-20201126233918-771906719818 // indirect
 	golang.org/x/tools v0.0.0-20201125231158-b5590deeca9b

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ github.com/go-openapi/loads v0.19.6 h1:6IAtnx22MNSjPocZZ2sV7EjgF6wW5rDC9r6ZkNxji
 github.com/go-openapi/loads v0.19.6/go.mod h1:brCsvE6j8mnbmGBh103PT/QLHfbyDxA4hsKvYBNEGVc=
 github.com/go-openapi/loads v0.19.7 h1:6cALLpCAq4tYhaic7TMbEzjv8vq/wg+0AFivNy/Bma8=
 github.com/go-openapi/loads v0.19.7/go.mod h1:brCsvE6j8mnbmGBh103PT/QLHfbyDxA4hsKvYBNEGVc=
+github.com/go-openapi/loads v0.20.0 h1:Pymw1O8zDmWeNv4kVsHd0W3cvgdp8juRa4U/U/8D/Pk=
+github.com/go-openapi/loads v0.20.0/go.mod h1:2LhKquiE513rN5xC6Aan6lYOSddlL8Mp20AW9kpviM4=
 github.com/go-openapi/runtime v0.0.0-20180920151709-4f900dc2ade9/go.mod h1:6v9a6LTXWQCdL8k1AO3cvqx5OtZY/Y9wKTgaoP6YRfA=
 github.com/go-openapi/runtime v0.19.0/go.mod h1:OwNfisksmmaZse4+gpV3Ne9AyMOlP1lt4sK4FXt0O64=
 github.com/go-openapi/runtime v0.19.4/go.mod h1:X277bwSUBxVlCYR3r7xgZZGKVvBd/29gLDlFGtJ8NL4=
@@ -168,6 +170,8 @@ github.com/go-openapi/spec v0.19.6/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHK
 github.com/go-openapi/spec v0.19.8/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/spec v0.19.15 h1:uxh8miNJEfMm8l8ekpY7i39LcORm1xSRtoipEGl1JPk=
 github.com/go-openapi/spec v0.19.15/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
+github.com/go-openapi/spec v0.20.0 h1:HGLc8AJ7ynOxwv0Lq4TsnwLsWMawHAYiJIFzbcML86I=
+github.com/go-openapi/spec v0.20.0/go.mod h1:+81FIL1JwC5P3/Iuuozq3pPE9dXdIEGxFutcFKaVbmU=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+ZPMF/cC8nDY=
@@ -199,6 +203,8 @@ github.com/go-openapi/validate v0.19.12 h1:mPLM/bfbd00PGOCJlU0yJL7IulkZ+q9VjPv7U
 github.com/go-openapi/validate v0.19.12/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/go-openapi/validate v0.19.15 h1:oUHZO8jD7p5oRLANlXF0U8ic9ePBUkDQyRZdN0EhL6M=
 github.com/go-openapi/validate v0.19.15/go.mod h1:tbn/fdOwYHgrhPBzidZfJC2MIVvs9GA7monOmWBbeCI=
+github.com/go-openapi/validate v0.20.0 h1:pzutNCCBZGZlE+u8HD3JZyWdc/TVbtVwlWUp8/vgUKk=
+github.com/go-openapi/validate v0.20.0/go.mod h1:b60iJT+xNNLfaQJUqLI7946tYiFEOuE9E4k54HpKcJ0=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -478,6 +484,8 @@ go.mongodb.org/mongo-driver v1.3.4 h1:zs/dKNwX0gYUtzwrN9lLiR15hCO0nDwQj5xXx+vjCd
 go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.4.3 h1:moga+uhicpVshTyaqY9L23E6QqwcHRUv1sqyOsoyOO8=
 go.mongodb.org/mongo-driver v1.4.3/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
+go.mongodb.org/mongo-driver v1.4.4 h1:bsPHfODES+/yx2PCWzUYMH8xj6PVniPI8DQrsJuSXSs=
+go.mongodb.org/mongo-driver v1.4.4/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -572,6 +580,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
* updated go-openapi dependencies to fix race conditions on parallel spec processing
* adapted tests to process fixtures in parallel
* refactored tests for readability (e.g. require... instead of if assert...)
* fixed race condition on global templates when testing in parallel:
   * templates are now a shadow clone in GenOpts: now generation can proceed in parallel, even with contrib templates
     (custom templates from config remain loaded in the global templates)

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>