### PR TITLE
refactored, documented and tested tags in models

### DIFF
--- a/docs/use/model.md
+++ b/docs/use/model.md
@@ -38,3 +38,4 @@ See the full list of available options [here](../generate/model.md).
   * [Polymorphic types](./models/schemas.md#polymorphic-types)
   * [Serialization interfaces](./models/schemas.md#serialization-interfaces)
   * [External types](./models/schemas.md#external-types)
+  * [Customizing struct tags](./models/schemas.md#customizing-struct-tags)

--- a/generator/model.go
+++ b/generator/model.go
@@ -1654,7 +1654,11 @@ func (sg *schemaGenContext) buildAdditionalItems() error {
 }
 
 func (sg *schemaGenContext) buildXMLNameWithTags() error {
-	if sg.WithXML || sg.Schema.XML != nil {
+	// render some "xml" struct tag under one the following conditions:
+	// - consumes/produces in spec contains xml
+	// - struct tags CLI option contains xml
+	// - XML object present in spec for this schema
+	if sg.WithXML || swag.ContainsStrings(sg.StructTags, "xml") || sg.Schema.XML != nil {
 		sg.GenSchema.XMLName = sg.Name
 
 		if sg.Schema.XML != nil {
@@ -1664,10 +1668,6 @@ func (sg *schemaGenContext) buildXMLNameWithTags() error {
 			if sg.Schema.XML.Attribute {
 				sg.GenSchema.XMLName += ",attr"
 			}
-		}
-
-		if !sg.GenSchema.Required && sg.GenSchema.IsEmptyOmitted {
-			sg.GenSchema.XMLName += ",omitempty"
 		}
 	}
 	return nil

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -195,7 +195,7 @@ func TestGenerateModel_SchemaField(t *testing.T) {
 // Max Items: 30
 // Min Items: 30
 // Unique: true
-`+"SomeName string `json:\"some name\" example:\"some example\\\"\" db:\"some name\" mytag:\"foobar,foobaz\"`\n")
+`+"SomeName string `json:\"some name\" db:\"some name\" example:\"some example\\\"\" mytag:\"foobar,foobaz\"`\n")
 
 	gmp.Example = "some example``"
 	tt.assertRender(&gmp, `// The title of the property
@@ -212,7 +212,7 @@ func TestGenerateModel_SchemaField(t *testing.T) {
 // Max Items: 30
 // Min Items: 30
 // Unique: true
-`+"SomeName string \"json:\\\"some name\\\" example:\\\"some example``\\\" db:\\\"some name\\\" mytag:\\\"foobar,foobaz\\\"\"\n")
+`+"SomeName string \"json:\\\"some name\\\" db:\\\"some name\\\" example:\\\"some example``\\\" mytag:\\\"foobar,foobaz\\\"\"\n")
 }
 
 var schTypeGenDataSimple = []struct {

--- a/generator/structs_test.go
+++ b/generator/structs_test.go
@@ -1,0 +1,160 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintTags(t *testing.T) {
+	type tagFixture struct {
+		Title        string
+		Schema       GenSchema
+		ExpectedTags string
+	}
+
+	mustJSON := func(in interface{}) string {
+		b, _ := asJSON(in)
+		return b
+	}
+
+	fixtures := []tagFixture{
+		{
+			Title: "no extra: default json",
+			Schema: GenSchema{
+				OriginalName: "field",
+			},
+			ExpectedTags: "`json:\"field\"`",
+		},
+		{
+			Title: "no extra: default json, omitempty",
+			Schema: GenSchema{
+				OriginalName: "field",
+				resolvedType: resolvedType{
+					IsEmptyOmitted: true,
+				},
+			},
+			ExpectedTags: "`json:\"field,omitempty\"`",
+		},
+		{
+			Title: "no extra: default json, required, omitempty",
+			Schema: GenSchema{
+				OriginalName: "field",
+				resolvedType: resolvedType{
+					IsEmptyOmitted: true,
+				},
+				sharedValidations: sharedValidations{
+					Required: true,
+				},
+			},
+			ExpectedTags: "`json:\"field\"`",
+		},
+		{
+			Title: "no extra: default json, omitempty, as JSON string",
+			Schema: GenSchema{
+				OriginalName: "field",
+				resolvedType: resolvedType{
+					IsEmptyOmitted: true,
+					IsJSONString:   true,
+				},
+			},
+			ExpectedTags: "`json:\"field,omitempty,string\"`",
+		},
+		{
+			Title: "with xml name",
+			Schema: GenSchema{
+				OriginalName: "field",
+				resolvedType: resolvedType{
+					IsEmptyOmitted: true,
+				},
+				sharedValidations: sharedValidations{
+					Required: true,
+				},
+				XMLName: "xmlfield",
+			},
+			ExpectedTags: "`json:\"field\" xml:\"xmlfield\"`",
+		},
+		{
+			Title: "with example (1/3)",
+			Schema: GenSchema{
+				OriginalName: "field",
+				resolvedType: resolvedType{
+					IsEmptyOmitted: true,
+				},
+				sharedValidations: sharedValidations{
+					Required: true,
+				},
+				Example:    mustJSON("xyz"),
+				StructTags: []string{"example"},
+			},
+			ExpectedTags: "`json:\"field\" example:\"\\\"xyz\\\"\"`",
+		},
+		{
+			Title: "with example (2/3)",
+			Schema: GenSchema{
+				OriginalName: "field",
+				resolvedType: resolvedType{
+					IsEmptyOmitted: true,
+				},
+				sharedValidations: sharedValidations{
+					Required: true,
+				},
+				Example:    mustJSON(15),
+				StructTags: []string{"example"},
+			},
+			ExpectedTags: "`json:\"field\" example:\"15\"`",
+		},
+		{
+			Title: "with example (3/3)",
+			Schema: GenSchema{
+				OriginalName: "field",
+				resolvedType: resolvedType{
+					IsEmptyOmitted: true,
+				},
+				sharedValidations: sharedValidations{
+					Required: true,
+				},
+				Example: mustJSON(struct {
+					A string `json:"a"`
+					B int64  `json:"b"`
+				}{A: "xyz", B: 12}),
+				StructTags: []string{"example"},
+			},
+			ExpectedTags: "`json:\"field\" example:\"{\\\"a\\\":\\\"xyz\\\",\\\"b\\\":12}\"`",
+		},
+		{
+			Title: "with example, xml, omitempty, custom tag",
+			Schema: GenSchema{
+				OriginalName: "field",
+				resolvedType: resolvedType{
+					IsEmptyOmitted: true,
+				},
+				Example:    mustJSON(15),
+				StructTags: []string{"example"},
+				XMLName:    "xmlfield,attr",
+				CustomTag:  `metric:"on"`,
+			},
+			ExpectedTags: "`json:\"field,omitempty\" xml:\"xmlfield,attr,omitempty\" example:\"15\" metric:\"on\"`",
+		},
+		{
+			Title: "with backticks",
+			Schema: GenSchema{
+				OriginalName: "field",
+				Example: mustJSON(struct {
+					A string `json:"a"`
+					B int64  `json:"b"`
+				}{A: "`xyz`", B: 12}),
+				StructTags: []string{"example"},
+				CustomTag:  "metric:\"`on`\"",
+			},
+			ExpectedTags: "\"json:\\\"field\\\" example:\\\"{\\\\\\\"a\\\\\\\":\\\\\\\"`xyz`\\\\\\\",\\\\\\\"b\\\\\\\":12}\\\" metric:\\\"`on`\\\"\"",
+		},
+	}
+
+	for _, toPin := range fixtures {
+		fixture := toPin
+		t.Run(fixture.Title, func(t *testing.T) {
+			require.Equal(t, fixture.ExpectedTags, fixture.Schema.PrintTags())
+		})
+	}
+}


### PR DESCRIPTION
* fixes #2423 - acknowledged fixed
* refactored tag rendering: use strings.Builder, cleaned up redundancies with xml tags,
  used stdlib strconv.CanBackQuote instead of Contains
* now always renders extra tags in order specified by the user (e.g. --struct-tags example,db)
* now renders xml tags if requested in the CLI opts, even when no consumes/produces is set with xml
* added unit tests for model tag generation
* added doc on how to play with struct tags

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>