### PR TITLE
CLI version: added versioning from module support for go get users

### DIFF
--- a/cmd/swagger/commands/version.go
+++ b/cmd/swagger/commands/version.go
@@ -1,6 +1,9 @@
 package commands
 
-import "fmt"
+import (
+	"fmt"
+	"runtime/debug"
+)
 
 var (
 	// Version for the swagger command
@@ -16,9 +19,17 @@ type PrintVersion struct {
 // Execute this command
 func (p *PrintVersion) Execute(args []string) error {
 	if Version == "" {
+		if info, available := debug.ReadBuildInfo(); available && info.Main.Version != "(devel)" {
+			// built from source, with module (e.g. go get)
+			fmt.Println("version:", info.Main.Version)
+			fmt.Println("commit:", fmt.Sprintf("(unknown, mod sum: %q)", info.Main.Sum))
+			return nil
+		}
+		// built from source, local repo
 		fmt.Println("dev")
 		return nil
 	}
+	// released version
 	fmt.Println("version:", Version)
 	fmt.Println("commit:", Commit)
 


### PR DESCRIPTION
CLI version: added versioning from module support for go get users

* go-swagger version is now properly displayed when building from source using go get:

go get -u github.com/go-swagger/go-swagger/cmd/swagger
swagger version
version: v0.25.0
...

* no change for released binary versions
* no change for versions build from source repo (e.g. "dev")

* fixes #1283
* fixes #2454

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>