### PR TITLE
Generator: Handle special characters *, /, and =

### DIFF
--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -635,7 +635,7 @@ func pascalize(arg string) string {
 		return "Empty"
 	case 1: // handle special case when we have a single rune that is not handled by swag.ToGoName
 		switch runes[0] {
-		case '+', '-', '#', '_': // those cases are handled differently than swag utility
+		case '+', '-', '#', '_', '*', '/', '=': // those cases are handled differently than swag utility
 			return prefixForName(arg)
 		}
 	}
@@ -654,6 +654,12 @@ func prefixForName(arg string) string {
 		return "Minus"
 	case '#':
 		return "HashTag"
+	case '*':
+		return "Asterisk"
+	case '/':
+		return "ForwardSlash"
+	case '=':
+		return "EqualSign"
 		// other cases ($,@ etc..) handled by swag.ToGoName
 	}
 	return "Nr"

--- a/generator/template_repo_test.go
+++ b/generator/template_repo_test.go
@@ -555,6 +555,9 @@ func TestFuncMap_Pascalize(t *testing.T) {
 	assert.Equal(t, "Minus1", pascalize("-1"))
 	assert.Equal(t, "Minus", pascalize("-"))
 	assert.Equal(t, "Nr8", pascalize("8"))
+	assert.Equal(t, "Asterisk", pascalize("*"))
+	assert.Equal(t, "ForwardSlash", pascalize("/"))
+	assert.Equal(t, "EqualSign", pascalize("="))
 
 	assert.Equal(t, "Hello", pascalize("+hello"))
 


### PR DESCRIPTION
Fixes #2501

I re-ran `swagger generate client` using this version and verified that it fixed the issue. The generator now correctly outputs:

```golang
const (

	// ModificationSourceOperationEqualSign captures enum value "="
	ModificationSourceOperationEqualSign string = "="

	// ModificationSourceOperationPlus captures enum value "+"
	ModificationSourceOperationPlus string = "+"

	// ModificationSourceOperationDash captures enum value "-"
	ModificationSourceOperationDash string = "-"

	// ModificationSourceOperationAsterisk captures enum value "*"
	ModificationSourceOperationAsterisk string = "*"

	// ModificationSourceOperationForwardSlash captures enum value "/"
	ModificationSourceOperationForwardSlash string = "/"
)
```