### PR TITLE
Update install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,7 @@ docker pull quay.io/goswagger/swagger
 #### For Mac And Linux users:
 
 ```bash
-alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=$HOME/go:/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
+alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=$(which go):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
 swagger version
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,7 @@ docker pull quay.io/goswagger/swagger
 #### For Mac And Linux users:
 
 ```bash
-alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=$(which go):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
+alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=$(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
 swagger version
 ```
 


### PR DESCRIPTION
For step:
```bash
alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=$HOME/go:/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
swagger version
```
It gets failed when GOPATH is not set to home folder. It gives below error:

```sh
2021/02/05 12:37:01 lstat /home/ashish/go: no such file or directory
```
Replacing `$HOME/go`  with `$(which go)` so that it can take GOPATH dynamically. 

Solving issue: https://github.com/go-swagger/go-swagger/issues/1176