### PR TITLE
add option to use opentracing

### DIFF
--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -21,11 +21,15 @@ import (
 )
 
 type clientOptions struct {
-	ClientPackage string `long:"client-package" short:"c" description:"the package to save the client specific code" default:"client"`
+	ClientPackage   string            `long:"client-package" short:"c" description:"the package to save the client specific code" default:"client"`
+	WithOpenTracing bool              `long:"with-opentracing" description:"includes opentracing support" default:"false"`
+	OpenTracingTags map[string]string `long:"opentracing-tags" description:"the opentracing tags to include in every client span"`
 }
 
 func (co clientOptions) apply(opts *generator.GenOpts) {
 	opts.ClientPackage = co.ClientPackage
+	opts.WithOpenTracing = co.WithOpenTracing
+	opts.OpenTracingTags = co.OpenTracingTags
 }
 
 // Client the command to generate a swagger client

--- a/generator/client.go
+++ b/generator/client.go
@@ -59,6 +59,8 @@ func GenerateClient(name string, modelNames, operationIDs []string, opts *GenOpt
 		ServerPackage:     opts.LanguageOpts.ManglePackagePath(opts.ServerPackage, defaultServerTarget),
 		ClientPackage:     opts.LanguageOpts.ManglePackagePath(opts.ClientPackage, defaultClientTarget),
 		OperationsPackage: opts.LanguageOpts.ManglePackagePath(opts.ClientPackage, defaultClientTarget),
+		WithOpenTracing:   opts.WithOpenTracing,
+		OpenTracingTags:   opts.OpenTracingTags,
 		Principal:         opts.PrincipalAlias(),
 		DefaultScheme:     opts.DefaultScheme,
 		DefaultProduces:   opts.DefaultProduces,

--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -47,6 +47,8 @@ func testClientGenOpts() *GenOpts {
 	g.TemplateDir = ""
 	g.DumpData = false
 	g.IsClient = true
+	g.WithOpenTracing = true
+	g.OpenTracingTags = map[string]string{"tag": "value"}
 	if err := g.EnsureDefaults(); err != nil {
 		panic(err)
 	}

--- a/generator/server_test.go
+++ b/generator/server_test.go
@@ -59,6 +59,8 @@ func testAppGenerator(t testing.TB, specPath, name string) (*appGenerator, error
 		DefaultScheme:   "http",
 		DefaultProduces: runtime.JSONMime,
 		DefaultConsumes: runtime.JSONMime,
+		WithOpenTracing: opts.WithOpenTracing,
+		OpenTracingTags: opts.OpenTracingTags,
 		GenOpts:         opts,
 	}, nil
 }

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -277,6 +277,8 @@ type GenOpts struct {
 	ServerPackage          string
 	ClientPackage          string
 	ImplementationPackage  string
+	WithOpenTracing        bool
+	OpenTracingTags        map[string]string
 	Principal              string
 	PrincipalCustomIface   bool // user-provided interface for Principal (non-nullable)
 	Target                 string

--- a/generator/support.go
+++ b/generator/support.go
@@ -119,6 +119,8 @@ func newAppGenerator(name string, modelNames, operationIDs []string, opts *GenOp
 		DefaultScheme:     opts.DefaultScheme,
 		DefaultProduces:   opts.DefaultProduces,
 		DefaultConsumes:   opts.DefaultConsumes,
+		WithOpenTracing:   opts.WithOpenTracing,
+		OpenTracingTags:   opts.OpenTracingTags,
 		GenOpts:           opts,
 	}, nil
 }
@@ -143,6 +145,8 @@ type appGenerator struct {
 	DefaultScheme     string
 	DefaultProduces   string
 	DefaultConsumes   string
+	WithOpenTracing   bool
+	OpenTracingTags   map[string]string
 	GenOpts           *GenOpts
 }
 

--- a/generator/templates/client/facade.gotmpl
+++ b/generator/templates/client/facade.gotmpl
@@ -53,7 +53,11 @@ func NewHTTPClientWithConfig(formats strfmt.Registry, cfg *TransportConfig) *{{ 
   }
 
   // create transport and client
-  transport := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)
+  transport := httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes){{ if .WithOpenTracing -}}.WithOpenTracing(opentracing.Tags{
+  {{ range $key, $value := .OpenTracingTags }}
+     "{{ $key }}": "{{ $value }}",
+  {{ end }}
+  }){{ end }}
   return New(transport, formats)
 }
 


### PR DESCRIPTION
https://github.com/go-openapi/runtime/releases/tag/v0.19.26
has added support for OpenTracing (I added it)

and now I'm trying to add the support for the generated client.

I got a bit stuck - not sure if I added the option in the right places.