### PR TITLE
generator: introduce support for "description" struct tag

### DIFF
--- a/docs/use/models/schemas.md
+++ b/docs/use/models/schemas.md
@@ -1305,6 +1305,26 @@ type ObjectWithExample struct {
 }
 ```
 
+#### The description tag
+
+If you add `description` to the list of generated tags from the CLI (`swagger generate ... --struct-tags description`),
+a special description tag is created with the description value taken from the specification.
+
+```yaml
+definitions:
+  objectWithDescription:
+   properties:
+     field:
+       type: string
+       description: "some description"
+```
+
+```go
+type ObjectWithDescription struct {
+    Field string `json:"field,omitempty" description:"\"some description\""`
+}
+```
+
 
 [swagger]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema-object
 [strfmt]: https://github.com/go-openapi/strfmt

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -146,6 +146,8 @@ func (g GenSchema) PrintTags() string {
 		if tag == "example" && len(g.Example) > 0 {
 			// only add example tag if it's contained in the struct tags
 			tags["example"] = g.Example // json representation of the example object
+		} else if tag == "description" && len(g.Description) > 0 {
+			tags["description"] = g.Description
 		} else {
 			tags[tag] = tags["json"]
 		}

--- a/generator/structs_test.go
+++ b/generator/structs_test.go
@@ -149,6 +149,15 @@ func TestPrintTags(t *testing.T) {
 			},
 			ExpectedTags: "\"json:\\\"field\\\" example:\\\"{\\\\\\\"a\\\\\\\":\\\\\\\"`xyz`\\\\\\\",\\\\\\\"b\\\\\\\":12}\\\" metric:\\\"`on`\\\"\"",
 		},
+		{
+			Title: "with description",
+			Schema: GenSchema{
+				OriginalName: "field",
+				Description: "some description",
+				StructTags: []string{"description"},
+			},
+			ExpectedTags: "`json:\"field\" description:\"some description\"`",
+		},
 	}
 
 	for _, toPin := range fixtures {

--- a/generator/structs_test.go
+++ b/generator/structs_test.go
@@ -158,6 +158,15 @@ func TestPrintTags(t *testing.T) {
 			},
 			ExpectedTags: "`json:\"field\" description:\"some description\"`",
 		},
+		{
+			Title: "with multiline description",
+			Schema: GenSchema{
+				OriginalName: "field",
+				Description: "a\ndescription\nspanning\nmultiple\nlines",
+				StructTags: []string{"description"},
+			},
+			ExpectedTags: "\"json:\\\"field\\\" description:\\\"a\\\\ndescription\\\\nspanning\\\\nmultiple\\\\nlines\\\"\"",
+		},
 	}
 
 	for _, toPin := range fixtures {


### PR DESCRIPTION
Addresses https://github.com/go-swagger/go-swagger/issues/2541 : introduces support for `--struct-tag description` to the code generator.

Signed-off-by: Arne Redlich <arne.redlich@gig.tech>