### PR TITLE
Fix a typo in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -94,7 +94,7 @@ To install a specific version from source an appropriate tag needs to be checked
 dir=$(mktemp -d)
 git clone https://github.com/go-swagger/go-swagger "$dir" 
 cd "$dir"
-go checkout v0.25.0
+git checkout v0.25.0
 go install -ldflags "-X github.com/go-swagger/go-swagger/cmd/swagger/commands.Version=$(git describe --tags) -X github.com/go-swagger/go-swagger/cmd/swagger/commands.Commit=$(git rev-parse HEAD)" ./cmd/swagger
 ```
 


### PR DESCRIPTION
I fixed a typo in docs/install.md. Please check my change.

source:
https://github.com/go-swagger/go-swagger/blob/3af79747ddab32ed5bd694514599f06e4299bca4/docs/install.md

Fixes https://github.com/go-swagger/go-swagger/issues/2550
Signed-off-by: masa08 <ushimasarug08@gmail.com>