### PR TITLE
Support nested body params for CompositeError

### DIFF
--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -72,6 +72,8 @@
       if err := {{.ValueExpression }}.ContextValidate(ctx, formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
           return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+        } else if ce, ok := err.(*errors.CompositeError); ok {
+          return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
         }
         return err
       }
@@ -137,6 +139,8 @@
       if err := {{.ValueExpression }}.Validate(formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
           return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+        } else if ce, ok := err.(*errors.CompositeError); ok {
+          return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
         }
         return err
       }
@@ -440,6 +444,8 @@
       if err := {{.ValueExpression }}.ContextValidate(ctx, formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
           return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+        } else if ce, ok := err.(*errors.CompositeError); ok {
+          return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
         }
         return err
       }
@@ -539,6 +545,8 @@
       if err := {{.ValueExpression }}.Validate(formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
           return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+        } else if ce, ok := err.(*errors.CompositeError); ok {
+          return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
         }
         return err
       }

--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -188,6 +188,8 @@ if err := validate.EnumCase(
   if err := {{ .ValueExpression }}.Validate(formats) ; err != nil {
     if ve, ok := err.(*errors.Validation); ok {
       return ve.ValidateName({{ .Path }})
+    } else if ce, ok := err.(*errors.CompositeError); ok {
+      return ce.ValidateName({{ .Path }})
     }
     return err
   }


### PR DESCRIPTION
Update templates that have nested body param logic to call ValidateName API on CompositeError.
See https://github.com/go-openapi/errors/pull/30 for addition of ValidateName API to CompositeError which needs to be committed prior to this.

Closes #2594 