### PR TITLE
Fix go sum error in CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,9 @@ commands:
         default: "./dist/swagger-musl"
     steps:
       - run:
+          name: Debug golang version
+          command: go version
+      - run:
           name: Build statically linked binary
           command: |
             rm -rf dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,6 @@ commands:
         default: "./dist/swagger-musl"
     steps:
       - run:
-          name: Debug golang version
-          command: go version
-      - run:
           name: Build statically linked binary
           command: |
             rm -rf dist

--- a/hack/build-docker.sh
+++ b/hack/build-docker.sh
@@ -6,6 +6,9 @@ set -e -o pipefail -x
 cd $(git rev-parse --show-toplevel)
 echo "Building swagger from $(pwd)..."
 
+# debug
+go version
+
 if [[ ${1} == "--circleci" ]] ; then
     # CI build mode (for releases)
     username="${CIRCLE_PROJECT_USERNAME-"$(basename `pwd`)"}"


### PR DESCRIPTION
CI build has been failing. Trying to reproduce.
WIP

go version used in CI is:
`go1.16.5 linux/amd64` 
There is a known bug in this version that results in error like this:
 `missing go.sum entry for module providing package golang.org/x/net/idna`
See golang bug here: https://github.com/golang/go/issues/44129
