### PR TITLE
codescan: use TypeSpec.Doc over GenDecl.Doc

### DIFF
--- a/codescan/application.go
+++ b/codescan/application.go
@@ -265,8 +265,14 @@ func (s *scanCtx) FindDecl(pkgPath, name string) (*entityDecl, bool) {
 							debugLog("%s is not a named type but a %T", ts.Name, def.Type())
 							continue
 						}
+
+						comments := ts.Doc // type ( /* doc */ Foo struct{} )
+						if comments == nil {
+							comments = gd.Doc // /* doc */  type ( Foo struct{} )
+						}
+
 						decl := &entityDecl{
-							Comments: gd.Doc,
+							Comments: comments,
 							Type:     nt,
 							Ident:    ts.Name,
 							Spec:     ts,
@@ -553,8 +559,14 @@ func (a *typeIndex) processDecl(pkg *packages.Package, file *ast.File, n node, g
 				debugLog("%s is not a named type but a %T", ts.Name, def.Type())
 				continue
 			}
+
+			comments := ts.Doc // type ( /* doc */ Foo struct{} )
+			if comments == nil {
+				comments = gd.Doc // /* doc */  type ( Foo struct{} )
+			}
+
 			decl := &entityDecl{
-				Comments: gd.Doc,
+				Comments: comments,
 				Type:     nt,
 				Ident:    ts.Name,
 				Spec:     ts,

--- a/fixtures/goparsing/classification/models/nomodel.go
+++ b/fixtures/goparsing/classification/models/nomodel.go
@@ -592,24 +592,27 @@ type ModelS struct {
 	Edition string `json:"edition"`
 }
 
-// The ModelX version of the tesla car
-//
-// swagger:model modelX
-type ModelX struct {
-	// swagger:allOf com.tesla.models.ModelX
-	TeslaCar
-	// The number of doors on this Model X
-	Doors int `json:"doors"`
-}
+// Test proper parsing of type declaration _blocks_:
+type (
+	// The ModelX version of the tesla car
+	//
+	// swagger:model modelX
+	ModelX struct {
+		// swagger:allOf com.tesla.models.ModelX
+		TeslaCar
+		// The number of doors on this Model X
+		Doors int `json:"doors"`
+	}
 
-// The ModelA version of the tesla car
-//
-// swagger:model modelA
-type ModelA struct {
-	Tesla TeslaCar
-	// The number of doors on this Model A
-	Doors int `json:"doors"`
-}
+	// The ModelA version of the tesla car
+	//
+	// swagger:model modelA
+	ModelA struct {
+		Tesla TeslaCar
+		// The number of doors on this Model A
+		Doors int `json:"doors"`
+	}
+)
 
 // Cars is a collection of cars
 //


### PR DESCRIPTION
This merge requests improves the command `generate spec` as follows:

```go
type (
   // Do not ignore this comment block
  Foo struct {
  }
)
```

```go
// Do not use this comment block for type Foo and Bar
type (
   // Use this comment block for type Foo instead
  Foo struct {
  }
  // Use this comment block for type Bar instead
  Bar struct {
  }
)
```
