### PR TITLE
genspec: use schema only for params in body

### DIFF
--- a/codescan/route_params.go
+++ b/codescan/route_params.go
@@ -153,6 +153,21 @@ func (s *setOpParams) finalizeParam(param *spec.Parameter, data map[string]strin
 	}
 
 	processSchema(data, param)
+
+	// schema is only allowed for parameters in "body"
+	// see https://swagger.io/specification/v2/#parameterObject
+	switch {
+	case param.In == "body":
+		param.Type = ""
+
+	case param.Schema != nil:
+		// convert schema into validations
+		param.SetValidations(param.Schema.Validations())
+		param.Default = param.Schema.Default
+		param.Format = param.Schema.Format
+		param.Schema = nil
+	}
+
 	s.parameters = append(s.parameters, param)
 }
 

--- a/codescan/routes_test.go
+++ b/codescan/routes_test.go
@@ -248,11 +248,11 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "path", p.In)
 	assert.Equal(t, true, p.Required)
 	assert.Equal(t, "number", p.Type)
-	assert.Equal(t, "number", p.Schema.Type[0])
 	min, max, def := float64(10), float64(20), float64(15)
-	assert.Equal(t, &max, p.Schema.Maximum)
-	assert.Equal(t, &min, p.Schema.Minimum)
-	assert.Equal(t, def, p.Schema.Default)
+	assert.Equal(t, &max, p.Maximum)
+	assert.Equal(t, &min, p.Minimum)
+	assert.Equal(t, def, p.Default)
+	assert.Nil(t, p.Schema)
 
 	// Testing array param provided as query string. Testing "minLength" and "maxLength" constraints for "array" types
 	p = po.Post.Parameters[1]
@@ -261,10 +261,10 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "query", p.In)
 	assert.Equal(t, false, p.Required)
 	assert.Equal(t, "array", p.Type)
-	assert.Equal(t, "array", p.Schema.Type[0])
 	minLen, maxLen := int64(5), int64(20)
-	assert.Equal(t, &maxLen, p.Schema.MaxLength)
-	assert.Equal(t, &minLen, p.Schema.MinLength)
+	assert.Equal(t, &maxLen, p.MaxLength)
+	assert.Equal(t, &minLen, p.MinLength)
+	assert.Nil(t, p.Schema)
 
 	// Testing boolean param with default value
 	p = po.Post.Parameters[2]
@@ -273,8 +273,8 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "path", p.In)
 	assert.Equal(t, false, p.Required)
 	assert.Equal(t, "boolean", p.Type)
-	assert.Equal(t, "boolean", p.Schema.Type[0])
-	assert.Equal(t, true, p.Schema.Default)
+	assert.Equal(t, true, p.Default)
+	assert.Nil(t, p.Schema)
 
 	// Testing that "min", "max", "minLength" and "maxLength" constraints will only be considered if the right type is provided
 	p = po.Post.Parameters[3]
@@ -282,13 +282,13 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "test constraints on invalid types", p.Description)
 	assert.Equal(t, "query", p.In)
 	assert.Equal(t, "boolean", p.Type)
-	assert.Equal(t, "boolean", p.Schema.Type[0])
-	assert.Nil(t, p.Schema.Maximum)
-	assert.Nil(t, p.Schema.Minimum)
-	assert.Nil(t, p.Schema.MaxLength)
-	assert.Nil(t, p.Schema.MinLength)
-	assert.Equal(t, "abcde", p.Schema.Format)
-	assert.Equal(t, false, p.Schema.Default)
+	assert.Nil(t, p.Maximum)
+	assert.Nil(t, p.Minimum)
+	assert.Nil(t, p.MaxLength)
+	assert.Nil(t, p.MinLength)
+	assert.Equal(t, "abcde", p.Format)
+	assert.Equal(t, false, p.Default)
+	assert.Nil(t, p.Schema)
 
 	// Testing that when "type" is not provided, a schema will not be created
 	p = po.Post.Parameters[4]
@@ -302,9 +302,10 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "request", p.Name)
 	assert.Equal(t, "The request model.", p.Description)
 	assert.Equal(t, "body", p.In)
-	assert.Equal(t, "string", p.Type)
+	assert.Equal(t, "string", p.Schema.Type[0])
 	assert.Equal(t, "orange", p.Schema.Default)
 	assert.Equal(t, []interface{}{"apple", "orange", "pineapple", "peach", "plum"}, p.Schema.Enum)
+	assert.Empty(t, "", p.Type)
 }
 
 func assertOperation(t *testing.T, op *spec.Operation, id, summary, description string, tags, scopes []string) {


### PR DESCRIPTION
Fixes command `generate spec` to only emit `schema` for parameters `in: body`.

As defined in https://swagger.io/specification/v2/#parameterObject.


