### PR TITLE
#2704 codescan fix for strfmt.ObjectId

### DIFF
--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -362,6 +362,11 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 					tgt.Typed("string", sfnm)
 					return nil
 				}
+				if sfnm == "bsonobjectid" {
+					tgt.Typed("string", sfnm)
+					return nil
+				}
+
 				tgt.Items().Typed("string", sfnm)
 				return nil
 			}


### PR DESCRIPTION
fixes https://github.com/go-swagger/go-swagger/issues/2704 : strfmt.ObjectId is scanned back as an array of strings

Signed-off-by: Nick Dimov <3619341+dimovnike@users.noreply.github.com>