### PR TITLE
add an interface to deal with client responses based on the status code

### DIFF
--- a/examples/authentication/client/customers/create_responses.go
+++ b/examples/authentication/client/customers/create_responses.go
@@ -54,9 +54,39 @@ type CreateCreated struct {
 	Payload *models.Customer
 }
 
+// IsSuccess returns true when this create created response returns a 2xx status code
+func (o *CreateCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this create created response returns a 3xx status code
+func (o *CreateCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this create created response returns a 4xx status code
+func (o *CreateCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this create created response returns a 5xx status code
+func (o *CreateCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this create created response returns a 4xx status code
+func (o *CreateCreated) IsCode(code int) bool {
+	return code == 201
+}
+
 func (o *CreateCreated) Error() string {
 	return fmt.Sprintf("[POST /customers][%d] createCreated  %+v", 201, o.Payload)
 }
+
+func (o *CreateCreated) String() string {
+	return fmt.Sprintf("[POST /customers][%d] createCreated  %+v", 201, o.Payload)
+}
+
 func (o *CreateCreated) GetPayload() *models.Customer {
 	return o.Payload
 }
@@ -95,9 +125,39 @@ func (o *CreateDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this create default response returns a 2xx status code
+func (o *CreateDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this create default response returns a 3xx status code
+func (o *CreateDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this create default response returns a 4xx status code
+func (o *CreateDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this create default response returns a 5xx status code
+func (o *CreateDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this create default response returns a 4xx status code
+func (o *CreateDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *CreateDefault) Error() string {
 	return fmt.Sprintf("[POST /customers][%d] create default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *CreateDefault) String() string {
+	return fmt.Sprintf("[POST /customers][%d] create default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *CreateDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/authentication/client/customers/get_id_responses.go
+++ b/examples/authentication/client/customers/get_id_responses.go
@@ -66,9 +66,39 @@ type GetIDOK struct {
 	Payload *models.Customer
 }
 
+// IsSuccess returns true when this get Id o k response returns a 2xx status code
+func (o *GetIDOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get Id o k response returns a 3xx status code
+func (o *GetIDOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get Id o k response returns a 4xx status code
+func (o *GetIDOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get Id o k response returns a 5xx status code
+func (o *GetIDOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get Id o k response returns a 4xx status code
+func (o *GetIDOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *GetIDOK) Error() string {
 	return fmt.Sprintf("[GET /customers][%d] getIdOK  %+v", 200, o.Payload)
 }
+
+func (o *GetIDOK) String() string {
+	return fmt.Sprintf("[GET /customers][%d] getIdOK  %+v", 200, o.Payload)
+}
+
 func (o *GetIDOK) GetPayload() *models.Customer {
 	return o.Payload
 }
@@ -98,9 +128,39 @@ type GetIDUnauthorized struct {
 	Payload *models.Error
 }
 
+// IsSuccess returns true when this get Id unauthorized response returns a 2xx status code
+func (o *GetIDUnauthorized) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get Id unauthorized response returns a 3xx status code
+func (o *GetIDUnauthorized) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get Id unauthorized response returns a 4xx status code
+func (o *GetIDUnauthorized) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get Id unauthorized response returns a 5xx status code
+func (o *GetIDUnauthorized) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get Id unauthorized response returns a 4xx status code
+func (o *GetIDUnauthorized) IsCode(code int) bool {
+	return code == 401
+}
+
 func (o *GetIDUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /customers][%d] getIdUnauthorized  %+v", 401, o.Payload)
 }
+
+func (o *GetIDUnauthorized) String() string {
+	return fmt.Sprintf("[GET /customers][%d] getIdUnauthorized  %+v", 401, o.Payload)
+}
+
 func (o *GetIDUnauthorized) GetPayload() *models.Error {
 	return o.Payload
 }
@@ -130,9 +190,39 @@ type GetIDNotFound struct {
 	Payload *models.Error
 }
 
+// IsSuccess returns true when this get Id not found response returns a 2xx status code
+func (o *GetIDNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get Id not found response returns a 3xx status code
+func (o *GetIDNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get Id not found response returns a 4xx status code
+func (o *GetIDNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get Id not found response returns a 5xx status code
+func (o *GetIDNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get Id not found response returns a 4xx status code
+func (o *GetIDNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
 func (o *GetIDNotFound) Error() string {
 	return fmt.Sprintf("[GET /customers][%d] getIdNotFound  %+v", 404, o.Payload)
 }
+
+func (o *GetIDNotFound) String() string {
+	return fmt.Sprintf("[GET /customers][%d] getIdNotFound  %+v", 404, o.Payload)
+}
+
 func (o *GetIDNotFound) GetPayload() *models.Error {
 	return o.Payload
 }
@@ -171,9 +261,39 @@ func (o *GetIDDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this get Id default response returns a 2xx status code
+func (o *GetIDDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this get Id default response returns a 3xx status code
+func (o *GetIDDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this get Id default response returns a 4xx status code
+func (o *GetIDDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this get Id default response returns a 5xx status code
+func (o *GetIDDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this get Id default response returns a 4xx status code
+func (o *GetIDDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *GetIDDefault) Error() string {
 	return fmt.Sprintf("[GET /customers][%d] getId default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *GetIDDefault) String() string {
+	return fmt.Sprintf("[GET /customers][%d] getId default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *GetIDDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/contributed-templates/stratoscale/client/pet/pet_create_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_create_responses.go
@@ -53,9 +53,39 @@ type PetCreateCreated struct {
 	Payload *models.Pet
 }
 
+// IsSuccess returns true when this pet create created response returns a 2xx status code
+func (o *PetCreateCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this pet create created response returns a 3xx status code
+func (o *PetCreateCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet create created response returns a 4xx status code
+func (o *PetCreateCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this pet create created response returns a 5xx status code
+func (o *PetCreateCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet create created response returns a 4xx status code
+func (o *PetCreateCreated) IsCode(code int) bool {
+	return code == 201
+}
+
 func (o *PetCreateCreated) Error() string {
 	return fmt.Sprintf("[POST /pet][%d] petCreateCreated  %+v", 201, o.Payload)
 }
+
+func (o *PetCreateCreated) String() string {
+	return fmt.Sprintf("[POST /pet][%d] petCreateCreated  %+v", 201, o.Payload)
+}
+
 func (o *PetCreateCreated) GetPayload() *models.Pet {
 	return o.Payload
 }
@@ -84,7 +114,36 @@ Invalid input
 type PetCreateMethodNotAllowed struct {
 }
 
+// IsSuccess returns true when this pet create method not allowed response returns a 2xx status code
+func (o *PetCreateMethodNotAllowed) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet create method not allowed response returns a 3xx status code
+func (o *PetCreateMethodNotAllowed) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet create method not allowed response returns a 4xx status code
+func (o *PetCreateMethodNotAllowed) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet create method not allowed response returns a 5xx status code
+func (o *PetCreateMethodNotAllowed) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet create method not allowed response returns a 4xx status code
+func (o *PetCreateMethodNotAllowed) IsCode(code int) bool {
+	return code == 405
+}
+
 func (o *PetCreateMethodNotAllowed) Error() string {
+	return fmt.Sprintf("[POST /pet][%d] petCreateMethodNotAllowed ", 405)
+}
+
+func (o *PetCreateMethodNotAllowed) String() string {
 	return fmt.Sprintf("[POST /pet][%d] petCreateMethodNotAllowed ", 405)
 }
 

--- a/examples/contributed-templates/stratoscale/client/pet/pet_delete_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_delete_responses.go
@@ -55,7 +55,36 @@ Deleted successfully
 type PetDeleteNoContent struct {
 }
 
+// IsSuccess returns true when this pet delete no content response returns a 2xx status code
+func (o *PetDeleteNoContent) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this pet delete no content response returns a 3xx status code
+func (o *PetDeleteNoContent) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet delete no content response returns a 4xx status code
+func (o *PetDeleteNoContent) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this pet delete no content response returns a 5xx status code
+func (o *PetDeleteNoContent) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet delete no content response returns a 4xx status code
+func (o *PetDeleteNoContent) IsCode(code int) bool {
+	return code == 204
+}
+
 func (o *PetDeleteNoContent) Error() string {
+	return fmt.Sprintf("[DELETE /pet/{petId}][%d] petDeleteNoContent ", 204)
+}
+
+func (o *PetDeleteNoContent) String() string {
 	return fmt.Sprintf("[DELETE /pet/{petId}][%d] petDeleteNoContent ", 204)
 }
 
@@ -76,7 +105,36 @@ Invalid ID supplied
 type PetDeleteBadRequest struct {
 }
 
+// IsSuccess returns true when this pet delete bad request response returns a 2xx status code
+func (o *PetDeleteBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet delete bad request response returns a 3xx status code
+func (o *PetDeleteBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet delete bad request response returns a 4xx status code
+func (o *PetDeleteBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet delete bad request response returns a 5xx status code
+func (o *PetDeleteBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet delete bad request response returns a 4xx status code
+func (o *PetDeleteBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
 func (o *PetDeleteBadRequest) Error() string {
+	return fmt.Sprintf("[DELETE /pet/{petId}][%d] petDeleteBadRequest ", 400)
+}
+
+func (o *PetDeleteBadRequest) String() string {
 	return fmt.Sprintf("[DELETE /pet/{petId}][%d] petDeleteBadRequest ", 400)
 }
 
@@ -97,7 +155,36 @@ Pet not found
 type PetDeleteNotFound struct {
 }
 
+// IsSuccess returns true when this pet delete not found response returns a 2xx status code
+func (o *PetDeleteNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet delete not found response returns a 3xx status code
+func (o *PetDeleteNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet delete not found response returns a 4xx status code
+func (o *PetDeleteNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet delete not found response returns a 5xx status code
+func (o *PetDeleteNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet delete not found response returns a 4xx status code
+func (o *PetDeleteNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
 func (o *PetDeleteNotFound) Error() string {
+	return fmt.Sprintf("[DELETE /pet/{petId}][%d] petDeleteNotFound ", 404)
+}
+
+func (o *PetDeleteNotFound) String() string {
 	return fmt.Sprintf("[DELETE /pet/{petId}][%d] petDeleteNotFound ", 404)
 }
 

--- a/examples/contributed-templates/stratoscale/client/pet/pet_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_get_responses.go
@@ -59,9 +59,39 @@ type PetGetOK struct {
 	Payload *models.Pet
 }
 
+// IsSuccess returns true when this pet get o k response returns a 2xx status code
+func (o *PetGetOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this pet get o k response returns a 3xx status code
+func (o *PetGetOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet get o k response returns a 4xx status code
+func (o *PetGetOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this pet get o k response returns a 5xx status code
+func (o *PetGetOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet get o k response returns a 4xx status code
+func (o *PetGetOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *PetGetOK) Error() string {
 	return fmt.Sprintf("[GET /pet/{petId}][%d] petGetOK  %+v", 200, o.Payload)
 }
+
+func (o *PetGetOK) String() string {
+	return fmt.Sprintf("[GET /pet/{petId}][%d] petGetOK  %+v", 200, o.Payload)
+}
+
 func (o *PetGetOK) GetPayload() *models.Pet {
 	return o.Payload
 }
@@ -90,7 +120,36 @@ Invalid ID supplied
 type PetGetBadRequest struct {
 }
 
+// IsSuccess returns true when this pet get bad request response returns a 2xx status code
+func (o *PetGetBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet get bad request response returns a 3xx status code
+func (o *PetGetBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet get bad request response returns a 4xx status code
+func (o *PetGetBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet get bad request response returns a 5xx status code
+func (o *PetGetBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet get bad request response returns a 4xx status code
+func (o *PetGetBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
 func (o *PetGetBadRequest) Error() string {
+	return fmt.Sprintf("[GET /pet/{petId}][%d] petGetBadRequest ", 400)
+}
+
+func (o *PetGetBadRequest) String() string {
 	return fmt.Sprintf("[GET /pet/{petId}][%d] petGetBadRequest ", 400)
 }
 
@@ -111,7 +170,36 @@ Pet not found
 type PetGetNotFound struct {
 }
 
+// IsSuccess returns true when this pet get not found response returns a 2xx status code
+func (o *PetGetNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet get not found response returns a 3xx status code
+func (o *PetGetNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet get not found response returns a 4xx status code
+func (o *PetGetNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet get not found response returns a 5xx status code
+func (o *PetGetNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet get not found response returns a 4xx status code
+func (o *PetGetNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
 func (o *PetGetNotFound) Error() string {
+	return fmt.Sprintf("[GET /pet/{petId}][%d] petGetNotFound ", 404)
+}
+
+func (o *PetGetNotFound) String() string {
 	return fmt.Sprintf("[GET /pet/{petId}][%d] petGetNotFound ", 404)
 }
 

--- a/examples/contributed-templates/stratoscale/client/pet/pet_list_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_list_responses.go
@@ -53,9 +53,39 @@ type PetListOK struct {
 	Payload []*models.Pet
 }
 
+// IsSuccess returns true when this pet list o k response returns a 2xx status code
+func (o *PetListOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this pet list o k response returns a 3xx status code
+func (o *PetListOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet list o k response returns a 4xx status code
+func (o *PetListOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this pet list o k response returns a 5xx status code
+func (o *PetListOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet list o k response returns a 4xx status code
+func (o *PetListOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *PetListOK) Error() string {
 	return fmt.Sprintf("[GET /pet][%d] petListOK  %+v", 200, o.Payload)
 }
+
+func (o *PetListOK) String() string {
+	return fmt.Sprintf("[GET /pet][%d] petListOK  %+v", 200, o.Payload)
+}
+
 func (o *PetListOK) GetPayload() []*models.Pet {
 	return o.Payload
 }
@@ -82,7 +112,36 @@ Invalid status value
 type PetListBadRequest struct {
 }
 
+// IsSuccess returns true when this pet list bad request response returns a 2xx status code
+func (o *PetListBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet list bad request response returns a 3xx status code
+func (o *PetListBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet list bad request response returns a 4xx status code
+func (o *PetListBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet list bad request response returns a 5xx status code
+func (o *PetListBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet list bad request response returns a 4xx status code
+func (o *PetListBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
 func (o *PetListBadRequest) Error() string {
+	return fmt.Sprintf("[GET /pet][%d] petListBadRequest ", 400)
+}
+
+func (o *PetListBadRequest) String() string {
 	return fmt.Sprintf("[GET /pet][%d] petListBadRequest ", 400)
 }
 

--- a/examples/contributed-templates/stratoscale/client/pet/pet_update_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_update_responses.go
@@ -65,9 +65,39 @@ type PetUpdateCreated struct {
 	Payload *models.Pet
 }
 
+// IsSuccess returns true when this pet update created response returns a 2xx status code
+func (o *PetUpdateCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this pet update created response returns a 3xx status code
+func (o *PetUpdateCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet update created response returns a 4xx status code
+func (o *PetUpdateCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this pet update created response returns a 5xx status code
+func (o *PetUpdateCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet update created response returns a 4xx status code
+func (o *PetUpdateCreated) IsCode(code int) bool {
+	return code == 201
+}
+
 func (o *PetUpdateCreated) Error() string {
 	return fmt.Sprintf("[PUT /pet][%d] petUpdateCreated  %+v", 201, o.Payload)
 }
+
+func (o *PetUpdateCreated) String() string {
+	return fmt.Sprintf("[PUT /pet][%d] petUpdateCreated  %+v", 201, o.Payload)
+}
+
 func (o *PetUpdateCreated) GetPayload() *models.Pet {
 	return o.Payload
 }
@@ -96,7 +126,36 @@ Invalid ID supplied
 type PetUpdateBadRequest struct {
 }
 
+// IsSuccess returns true when this pet update bad request response returns a 2xx status code
+func (o *PetUpdateBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet update bad request response returns a 3xx status code
+func (o *PetUpdateBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet update bad request response returns a 4xx status code
+func (o *PetUpdateBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet update bad request response returns a 5xx status code
+func (o *PetUpdateBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet update bad request response returns a 4xx status code
+func (o *PetUpdateBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
 func (o *PetUpdateBadRequest) Error() string {
+	return fmt.Sprintf("[PUT /pet][%d] petUpdateBadRequest ", 400)
+}
+
+func (o *PetUpdateBadRequest) String() string {
 	return fmt.Sprintf("[PUT /pet][%d] petUpdateBadRequest ", 400)
 }
 
@@ -117,7 +176,36 @@ Pet not found
 type PetUpdateNotFound struct {
 }
 
+// IsSuccess returns true when this pet update not found response returns a 2xx status code
+func (o *PetUpdateNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet update not found response returns a 3xx status code
+func (o *PetUpdateNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet update not found response returns a 4xx status code
+func (o *PetUpdateNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet update not found response returns a 5xx status code
+func (o *PetUpdateNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet update not found response returns a 4xx status code
+func (o *PetUpdateNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
 func (o *PetUpdateNotFound) Error() string {
+	return fmt.Sprintf("[PUT /pet][%d] petUpdateNotFound ", 404)
+}
+
+func (o *PetUpdateNotFound) String() string {
 	return fmt.Sprintf("[PUT /pet][%d] petUpdateNotFound ", 404)
 }
 
@@ -138,7 +226,36 @@ Validation exception
 type PetUpdateMethodNotAllowed struct {
 }
 
+// IsSuccess returns true when this pet update method not allowed response returns a 2xx status code
+func (o *PetUpdateMethodNotAllowed) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this pet update method not allowed response returns a 3xx status code
+func (o *PetUpdateMethodNotAllowed) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet update method not allowed response returns a 4xx status code
+func (o *PetUpdateMethodNotAllowed) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this pet update method not allowed response returns a 5xx status code
+func (o *PetUpdateMethodNotAllowed) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet update method not allowed response returns a 4xx status code
+func (o *PetUpdateMethodNotAllowed) IsCode(code int) bool {
+	return code == 405
+}
+
 func (o *PetUpdateMethodNotAllowed) Error() string {
+	return fmt.Sprintf("[PUT /pet][%d] petUpdateMethodNotAllowed ", 405)
+}
+
+func (o *PetUpdateMethodNotAllowed) String() string {
 	return fmt.Sprintf("[PUT /pet][%d] petUpdateMethodNotAllowed ", 405)
 }
 

--- a/examples/contributed-templates/stratoscale/client/pet/pet_upload_image_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_upload_image_responses.go
@@ -47,9 +47,39 @@ type PetUploadImageOK struct {
 	Payload *models.APIResponse
 }
 
+// IsSuccess returns true when this pet upload image o k response returns a 2xx status code
+func (o *PetUploadImageOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this pet upload image o k response returns a 3xx status code
+func (o *PetUploadImageOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this pet upload image o k response returns a 4xx status code
+func (o *PetUploadImageOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this pet upload image o k response returns a 5xx status code
+func (o *PetUploadImageOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this pet upload image o k response returns a 4xx status code
+func (o *PetUploadImageOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *PetUploadImageOK) Error() string {
 	return fmt.Sprintf("[POST /pet/{petId}/image][%d] petUploadImageOK  %+v", 200, o.Payload)
 }
+
+func (o *PetUploadImageOK) String() string {
+	return fmt.Sprintf("[POST /pet/{petId}/image][%d] petUploadImageOK  %+v", 200, o.Payload)
+}
+
 func (o *PetUploadImageOK) GetPayload() *models.APIResponse {
 	return o.Payload
 }

--- a/examples/contributed-templates/stratoscale/client/store/inventory_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/inventory_get_responses.go
@@ -45,9 +45,39 @@ type InventoryGetOK struct {
 	Payload map[string]int32
 }
 
+// IsSuccess returns true when this inventory get o k response returns a 2xx status code
+func (o *InventoryGetOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this inventory get o k response returns a 3xx status code
+func (o *InventoryGetOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this inventory get o k response returns a 4xx status code
+func (o *InventoryGetOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this inventory get o k response returns a 5xx status code
+func (o *InventoryGetOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this inventory get o k response returns a 4xx status code
+func (o *InventoryGetOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *InventoryGetOK) Error() string {
 	return fmt.Sprintf("[GET /store/inventory][%d] inventoryGetOK  %+v", 200, o.Payload)
 }
+
+func (o *InventoryGetOK) String() string {
+	return fmt.Sprintf("[GET /store/inventory][%d] inventoryGetOK  %+v", 200, o.Payload)
+}
+
 func (o *InventoryGetOK) GetPayload() map[string]int32 {
 	return o.Payload
 }

--- a/examples/contributed-templates/stratoscale/client/store/order_create_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_create_responses.go
@@ -53,9 +53,39 @@ type OrderCreateOK struct {
 	Payload *models.Order
 }
 
+// IsSuccess returns true when this order create o k response returns a 2xx status code
+func (o *OrderCreateOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this order create o k response returns a 3xx status code
+func (o *OrderCreateOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this order create o k response returns a 4xx status code
+func (o *OrderCreateOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this order create o k response returns a 5xx status code
+func (o *OrderCreateOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this order create o k response returns a 4xx status code
+func (o *OrderCreateOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *OrderCreateOK) Error() string {
 	return fmt.Sprintf("[POST /store/order][%d] orderCreateOK  %+v", 200, o.Payload)
 }
+
+func (o *OrderCreateOK) String() string {
+	return fmt.Sprintf("[POST /store/order][%d] orderCreateOK  %+v", 200, o.Payload)
+}
+
 func (o *OrderCreateOK) GetPayload() *models.Order {
 	return o.Payload
 }
@@ -84,7 +114,36 @@ Invalid Order
 type OrderCreateBadRequest struct {
 }
 
+// IsSuccess returns true when this order create bad request response returns a 2xx status code
+func (o *OrderCreateBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this order create bad request response returns a 3xx status code
+func (o *OrderCreateBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this order create bad request response returns a 4xx status code
+func (o *OrderCreateBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this order create bad request response returns a 5xx status code
+func (o *OrderCreateBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this order create bad request response returns a 4xx status code
+func (o *OrderCreateBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
 func (o *OrderCreateBadRequest) Error() string {
+	return fmt.Sprintf("[POST /store/order][%d] orderCreateBadRequest ", 400)
+}
+
+func (o *OrderCreateBadRequest) String() string {
 	return fmt.Sprintf("[POST /store/order][%d] orderCreateBadRequest ", 400)
 }
 

--- a/examples/contributed-templates/stratoscale/client/store/order_delete_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_delete_responses.go
@@ -55,7 +55,36 @@ Deleted successfully
 type OrderDeleteNoContent struct {
 }
 
+// IsSuccess returns true when this order delete no content response returns a 2xx status code
+func (o *OrderDeleteNoContent) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this order delete no content response returns a 3xx status code
+func (o *OrderDeleteNoContent) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this order delete no content response returns a 4xx status code
+func (o *OrderDeleteNoContent) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this order delete no content response returns a 5xx status code
+func (o *OrderDeleteNoContent) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this order delete no content response returns a 4xx status code
+func (o *OrderDeleteNoContent) IsCode(code int) bool {
+	return code == 204
+}
+
 func (o *OrderDeleteNoContent) Error() string {
+	return fmt.Sprintf("[DELETE /store/order/{orderId}][%d] orderDeleteNoContent ", 204)
+}
+
+func (o *OrderDeleteNoContent) String() string {
 	return fmt.Sprintf("[DELETE /store/order/{orderId}][%d] orderDeleteNoContent ", 204)
 }
 
@@ -76,7 +105,36 @@ Invalid ID supplied
 type OrderDeleteBadRequest struct {
 }
 
+// IsSuccess returns true when this order delete bad request response returns a 2xx status code
+func (o *OrderDeleteBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this order delete bad request response returns a 3xx status code
+func (o *OrderDeleteBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this order delete bad request response returns a 4xx status code
+func (o *OrderDeleteBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this order delete bad request response returns a 5xx status code
+func (o *OrderDeleteBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this order delete bad request response returns a 4xx status code
+func (o *OrderDeleteBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
 func (o *OrderDeleteBadRequest) Error() string {
+	return fmt.Sprintf("[DELETE /store/order/{orderId}][%d] orderDeleteBadRequest ", 400)
+}
+
+func (o *OrderDeleteBadRequest) String() string {
 	return fmt.Sprintf("[DELETE /store/order/{orderId}][%d] orderDeleteBadRequest ", 400)
 }
 
@@ -97,7 +155,36 @@ Order not found
 type OrderDeleteNotFound struct {
 }
 
+// IsSuccess returns true when this order delete not found response returns a 2xx status code
+func (o *OrderDeleteNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this order delete not found response returns a 3xx status code
+func (o *OrderDeleteNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this order delete not found response returns a 4xx status code
+func (o *OrderDeleteNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this order delete not found response returns a 5xx status code
+func (o *OrderDeleteNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this order delete not found response returns a 4xx status code
+func (o *OrderDeleteNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
 func (o *OrderDeleteNotFound) Error() string {
+	return fmt.Sprintf("[DELETE /store/order/{orderId}][%d] orderDeleteNotFound ", 404)
+}
+
+func (o *OrderDeleteNotFound) String() string {
 	return fmt.Sprintf("[DELETE /store/order/{orderId}][%d] orderDeleteNotFound ", 404)
 }
 

--- a/examples/contributed-templates/stratoscale/client/store/order_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_get_responses.go
@@ -59,9 +59,39 @@ type OrderGetOK struct {
 	Payload *models.Order
 }
 
+// IsSuccess returns true when this order get o k response returns a 2xx status code
+func (o *OrderGetOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this order get o k response returns a 3xx status code
+func (o *OrderGetOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this order get o k response returns a 4xx status code
+func (o *OrderGetOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this order get o k response returns a 5xx status code
+func (o *OrderGetOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this order get o k response returns a 4xx status code
+func (o *OrderGetOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *OrderGetOK) Error() string {
 	return fmt.Sprintf("[GET /store/order/{orderId}][%d] orderGetOK  %+v", 200, o.Payload)
 }
+
+func (o *OrderGetOK) String() string {
+	return fmt.Sprintf("[GET /store/order/{orderId}][%d] orderGetOK  %+v", 200, o.Payload)
+}
+
 func (o *OrderGetOK) GetPayload() *models.Order {
 	return o.Payload
 }
@@ -90,7 +120,36 @@ Invalid ID supplied
 type OrderGetBadRequest struct {
 }
 
+// IsSuccess returns true when this order get bad request response returns a 2xx status code
+func (o *OrderGetBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this order get bad request response returns a 3xx status code
+func (o *OrderGetBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this order get bad request response returns a 4xx status code
+func (o *OrderGetBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this order get bad request response returns a 5xx status code
+func (o *OrderGetBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this order get bad request response returns a 4xx status code
+func (o *OrderGetBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
 func (o *OrderGetBadRequest) Error() string {
+	return fmt.Sprintf("[GET /store/order/{orderId}][%d] orderGetBadRequest ", 400)
+}
+
+func (o *OrderGetBadRequest) String() string {
 	return fmt.Sprintf("[GET /store/order/{orderId}][%d] orderGetBadRequest ", 400)
 }
 
@@ -111,7 +170,36 @@ Order not found
 type OrderGetNotFound struct {
 }
 
+// IsSuccess returns true when this order get not found response returns a 2xx status code
+func (o *OrderGetNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this order get not found response returns a 3xx status code
+func (o *OrderGetNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this order get not found response returns a 4xx status code
+func (o *OrderGetNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this order get not found response returns a 5xx status code
+func (o *OrderGetNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this order get not found response returns a 4xx status code
+func (o *OrderGetNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
 func (o *OrderGetNotFound) Error() string {
+	return fmt.Sprintf("[GET /store/order/{orderId}][%d] orderGetNotFound ", 404)
+}
+
+func (o *OrderGetNotFound) String() string {
 	return fmt.Sprintf("[GET /store/order/{orderId}][%d] orderGetNotFound ", 404)
 }
 

--- a/examples/external-types/models/my_custom_map.go
+++ b/examples/external-types/models/my_custom_map.go
@@ -33,6 +33,11 @@ func (m MyCustomMap) Validate(formats strfmt.Registry) error {
 
 			if val, ok := m[k][kk]; ok {
 				if err := val.Validate(formats); err != nil {
+					if ve, ok := err.(*errors.Validation); ok {
+						return ve.ValidateName(k + "." + kk)
+					} else if ce, ok := err.(*errors.CompositeError); ok {
+						return ce.ValidateName(k + "." + kk)
+					}
 					return err
 				}
 			}

--- a/examples/external-types/models/my_custom_map_nullable.go
+++ b/examples/external-types/models/my_custom_map_nullable.go
@@ -36,6 +36,11 @@ func (m MyCustomMapNullable) Validate(formats strfmt.Registry) error {
 			}
 			if val, ok := m[k][kk]; ok {
 				if err := val.Validate(formats); err != nil {
+					if ve, ok := err.(*errors.Validation); ok {
+						return ve.ValidateName(k + "." + kk)
+					} else if ce, ok := err.(*errors.CompositeError); ok {
+						return ce.ValidateName(k + "." + kk)
+					}
 					return err
 				}
 			}

--- a/examples/external-types/models/my_tuple.go
+++ b/examples/external-types/models/my_tuple.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -185,6 +186,11 @@ func (m *MyTuple) validateMyTupleItems(formats strfmt.Registry) error {
 
 			if val, ok := m.MyTupleItems[i][k]; ok {
 				if err := val.Validate(formats); err != nil {
+					if ve, ok := err.(*errors.Validation); ok {
+						return ve.ValidateName(strconv.Itoa(i+2) + "." + k)
+					} else if ce, ok := err.(*errors.CompositeError); ok {
+						return ce.ValidateName(strconv.Itoa(i+2) + "." + k)
+					}
 					return err
 				}
 			}

--- a/examples/file-server/client/uploads/upload_file_responses.go
+++ b/examples/file-server/client/uploads/upload_file_responses.go
@@ -43,7 +43,36 @@ OK
 type UploadFileOK struct {
 }
 
+// IsSuccess returns true when this upload file o k response returns a 2xx status code
+func (o *UploadFileOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this upload file o k response returns a 3xx status code
+func (o *UploadFileOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this upload file o k response returns a 4xx status code
+func (o *UploadFileOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this upload file o k response returns a 5xx status code
+func (o *UploadFileOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this upload file o k response returns a 4xx status code
+func (o *UploadFileOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *UploadFileOK) Error() string {
+	return fmt.Sprintf("[POST /upload][%d] uploadFileOK ", 200)
+}
+
+func (o *UploadFileOK) String() string {
 	return fmt.Sprintf("[POST /upload][%d] uploadFileOK ", 200)
 }
 

--- a/examples/stream-client/client/operations/chunked_responses.go
+++ b/examples/stream-client/client/operations/chunked_responses.go
@@ -49,9 +49,39 @@ type ChunkedOK struct {
 	Payload io.Writer
 }
 
+// IsSuccess returns true when this chunked o k response returns a 2xx status code
+func (o *ChunkedOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this chunked o k response returns a 3xx status code
+func (o *ChunkedOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this chunked o k response returns a 4xx status code
+func (o *ChunkedOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this chunked o k response returns a 5xx status code
+func (o *ChunkedOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this chunked o k response returns a 4xx status code
+func (o *ChunkedOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *ChunkedOK) Error() string {
 	return fmt.Sprintf("[GET /HTTP/ChunkedScript][%d] chunkedOK  %+v", 200, o.Payload)
 }
+
+func (o *ChunkedOK) String() string {
+	return fmt.Sprintf("[GET /HTTP/ChunkedScript][%d] chunkedOK  %+v", 200, o.Payload)
+}
+
 func (o *ChunkedOK) GetPayload() io.Writer {
 	return o.Payload
 }

--- a/examples/stream-server/client/operations/elapse_responses.go
+++ b/examples/stream-server/client/operations/elapse_responses.go
@@ -55,9 +55,39 @@ type ElapseOK struct {
 	Payload io.Writer
 }
 
+// IsSuccess returns true when this elapse o k response returns a 2xx status code
+func (o *ElapseOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this elapse o k response returns a 3xx status code
+func (o *ElapseOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this elapse o k response returns a 4xx status code
+func (o *ElapseOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this elapse o k response returns a 5xx status code
+func (o *ElapseOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this elapse o k response returns a 4xx status code
+func (o *ElapseOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *ElapseOK) Error() string {
 	return fmt.Sprintf("[GET /elapse/{length}][%d] elapseOK  %+v", 200, o.Payload)
 }
+
+func (o *ElapseOK) String() string {
+	return fmt.Sprintf("[GET /elapse/{length}][%d] elapseOK  %+v", 200, o.Payload)
+}
+
 func (o *ElapseOK) GetPayload() io.Writer {
 	return o.Payload
 }
@@ -84,7 +114,36 @@ Contrived - thrown when length of 11 is chosen
 type ElapseForbidden struct {
 }
 
+// IsSuccess returns true when this elapse forbidden response returns a 2xx status code
+func (o *ElapseForbidden) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this elapse forbidden response returns a 3xx status code
+func (o *ElapseForbidden) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this elapse forbidden response returns a 4xx status code
+func (o *ElapseForbidden) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this elapse forbidden response returns a 5xx status code
+func (o *ElapseForbidden) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this elapse forbidden response returns a 4xx status code
+func (o *ElapseForbidden) IsCode(code int) bool {
+	return code == 403
+}
+
 func (o *ElapseForbidden) Error() string {
+	return fmt.Sprintf("[GET /elapse/{length}][%d] elapseForbidden ", 403)
+}
+
+func (o *ElapseForbidden) String() string {
 	return fmt.Sprintf("[GET /elapse/{length}][%d] elapseForbidden ", 403)
 }
 

--- a/examples/task-tracker/client/tasks/add_comment_to_task_responses.go
+++ b/examples/task-tracker/client/tasks/add_comment_to_task_responses.go
@@ -57,7 +57,36 @@ Comment added
 type AddCommentToTaskCreated struct {
 }
 
+// IsSuccess returns true when this add comment to task created response returns a 2xx status code
+func (o *AddCommentToTaskCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this add comment to task created response returns a 3xx status code
+func (o *AddCommentToTaskCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this add comment to task created response returns a 4xx status code
+func (o *AddCommentToTaskCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this add comment to task created response returns a 5xx status code
+func (o *AddCommentToTaskCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this add comment to task created response returns a 4xx status code
+func (o *AddCommentToTaskCreated) IsCode(code int) bool {
+	return code == 201
+}
+
 func (o *AddCommentToTaskCreated) Error() string {
+	return fmt.Sprintf("[POST /tasks/{id}/comments][%d] addCommentToTaskCreated ", 201)
+}
+
+func (o *AddCommentToTaskCreated) String() string {
 	return fmt.Sprintf("[POST /tasks/{id}/comments][%d] addCommentToTaskCreated ", 201)
 }
 
@@ -89,9 +118,39 @@ func (o *AddCommentToTaskDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this add comment to task default response returns a 2xx status code
+func (o *AddCommentToTaskDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this add comment to task default response returns a 3xx status code
+func (o *AddCommentToTaskDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this add comment to task default response returns a 4xx status code
+func (o *AddCommentToTaskDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this add comment to task default response returns a 5xx status code
+func (o *AddCommentToTaskDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this add comment to task default response returns a 4xx status code
+func (o *AddCommentToTaskDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *AddCommentToTaskDefault) Error() string {
 	return fmt.Sprintf("[POST /tasks/{id}/comments][%d] addCommentToTask default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *AddCommentToTaskDefault) String() string {
+	return fmt.Sprintf("[POST /tasks/{id}/comments][%d] addCommentToTask default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *AddCommentToTaskDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/task-tracker/client/tasks/create_task_responses.go
+++ b/examples/task-tracker/client/tasks/create_task_responses.go
@@ -60,7 +60,36 @@ type CreateTaskCreated struct {
 	Location strfmt.URI
 }
 
+// IsSuccess returns true when this create task created response returns a 2xx status code
+func (o *CreateTaskCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this create task created response returns a 3xx status code
+func (o *CreateTaskCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this create task created response returns a 4xx status code
+func (o *CreateTaskCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this create task created response returns a 5xx status code
+func (o *CreateTaskCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this create task created response returns a 4xx status code
+func (o *CreateTaskCreated) IsCode(code int) bool {
+	return code == 201
+}
+
 func (o *CreateTaskCreated) Error() string {
+	return fmt.Sprintf("[POST /tasks][%d] createTaskCreated ", 201)
+}
+
+func (o *CreateTaskCreated) String() string {
 	return fmt.Sprintf("[POST /tasks][%d] createTaskCreated ", 201)
 }
 
@@ -103,9 +132,39 @@ func (o *CreateTaskDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this create task default response returns a 2xx status code
+func (o *CreateTaskDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this create task default response returns a 3xx status code
+func (o *CreateTaskDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this create task default response returns a 4xx status code
+func (o *CreateTaskDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this create task default response returns a 5xx status code
+func (o *CreateTaskDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this create task default response returns a 4xx status code
+func (o *CreateTaskDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *CreateTaskDefault) Error() string {
 	return fmt.Sprintf("[POST /tasks][%d] createTask default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *CreateTaskDefault) String() string {
+	return fmt.Sprintf("[POST /tasks][%d] createTask default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *CreateTaskDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/task-tracker/client/tasks/delete_task_responses.go
+++ b/examples/task-tracker/client/tasks/delete_task_responses.go
@@ -53,7 +53,36 @@ Task deleted
 type DeleteTaskNoContent struct {
 }
 
+// IsSuccess returns true when this delete task no content response returns a 2xx status code
+func (o *DeleteTaskNoContent) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this delete task no content response returns a 3xx status code
+func (o *DeleteTaskNoContent) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this delete task no content response returns a 4xx status code
+func (o *DeleteTaskNoContent) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this delete task no content response returns a 5xx status code
+func (o *DeleteTaskNoContent) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this delete task no content response returns a 4xx status code
+func (o *DeleteTaskNoContent) IsCode(code int) bool {
+	return code == 204
+}
+
 func (o *DeleteTaskNoContent) Error() string {
+	return fmt.Sprintf("[DELETE /tasks/{id}][%d] deleteTaskNoContent ", 204)
+}
+
+func (o *DeleteTaskNoContent) String() string {
 	return fmt.Sprintf("[DELETE /tasks/{id}][%d] deleteTaskNoContent ", 204)
 }
 
@@ -85,9 +114,39 @@ func (o *DeleteTaskDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this delete task default response returns a 2xx status code
+func (o *DeleteTaskDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this delete task default response returns a 3xx status code
+func (o *DeleteTaskDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this delete task default response returns a 4xx status code
+func (o *DeleteTaskDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this delete task default response returns a 5xx status code
+func (o *DeleteTaskDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this delete task default response returns a 4xx status code
+func (o *DeleteTaskDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *DeleteTaskDefault) Error() string {
 	return fmt.Sprintf("[DELETE /tasks/{id}][%d] deleteTask default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *DeleteTaskDefault) String() string {
+	return fmt.Sprintf("[DELETE /tasks/{id}][%d] deleteTask default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *DeleteTaskDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/task-tracker/client/tasks/get_task_comments_responses.go
+++ b/examples/task-tracker/client/tasks/get_task_comments_responses.go
@@ -54,9 +54,39 @@ type GetTaskCommentsOK struct {
 	Payload []*models.Comment
 }
 
+// IsSuccess returns true when this get task comments o k response returns a 2xx status code
+func (o *GetTaskCommentsOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get task comments o k response returns a 3xx status code
+func (o *GetTaskCommentsOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get task comments o k response returns a 4xx status code
+func (o *GetTaskCommentsOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get task comments o k response returns a 5xx status code
+func (o *GetTaskCommentsOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get task comments o k response returns a 4xx status code
+func (o *GetTaskCommentsOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *GetTaskCommentsOK) Error() string {
 	return fmt.Sprintf("[GET /tasks/{id}/comments][%d] getTaskCommentsOK  %+v", 200, o.Payload)
 }
+
+func (o *GetTaskCommentsOK) String() string {
+	return fmt.Sprintf("[GET /tasks/{id}/comments][%d] getTaskCommentsOK  %+v", 200, o.Payload)
+}
+
 func (o *GetTaskCommentsOK) GetPayload() []*models.Comment {
 	return o.Payload
 }
@@ -94,9 +124,39 @@ func (o *GetTaskCommentsDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this get task comments default response returns a 2xx status code
+func (o *GetTaskCommentsDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this get task comments default response returns a 3xx status code
+func (o *GetTaskCommentsDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this get task comments default response returns a 4xx status code
+func (o *GetTaskCommentsDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this get task comments default response returns a 5xx status code
+func (o *GetTaskCommentsDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this get task comments default response returns a 4xx status code
+func (o *GetTaskCommentsDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *GetTaskCommentsDefault) Error() string {
 	return fmt.Sprintf("[GET /tasks/{id}/comments][%d] getTaskComments default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *GetTaskCommentsDefault) String() string {
+	return fmt.Sprintf("[GET /tasks/{id}/comments][%d] getTaskComments default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *GetTaskCommentsDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/task-tracker/client/tasks/get_task_details_responses.go
+++ b/examples/task-tracker/client/tasks/get_task_details_responses.go
@@ -60,9 +60,39 @@ type GetTaskDetailsOK struct {
 	Payload *models.Task
 }
 
+// IsSuccess returns true when this get task details o k response returns a 2xx status code
+func (o *GetTaskDetailsOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this get task details o k response returns a 3xx status code
+func (o *GetTaskDetailsOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get task details o k response returns a 4xx status code
+func (o *GetTaskDetailsOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get task details o k response returns a 5xx status code
+func (o *GetTaskDetailsOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get task details o k response returns a 4xx status code
+func (o *GetTaskDetailsOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *GetTaskDetailsOK) Error() string {
 	return fmt.Sprintf("[GET /tasks/{id}][%d] getTaskDetailsOK  %+v", 200, o.Payload)
 }
+
+func (o *GetTaskDetailsOK) String() string {
+	return fmt.Sprintf("[GET /tasks/{id}][%d] getTaskDetailsOK  %+v", 200, o.Payload)
+}
+
 func (o *GetTaskDetailsOK) GetPayload() *models.Task {
 	return o.Payload
 }
@@ -92,9 +122,39 @@ type GetTaskDetailsUnprocessableEntity struct {
 	Payload *models.ValidationError
 }
 
+// IsSuccess returns true when this get task details unprocessable entity response returns a 2xx status code
+func (o *GetTaskDetailsUnprocessableEntity) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get task details unprocessable entity response returns a 3xx status code
+func (o *GetTaskDetailsUnprocessableEntity) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get task details unprocessable entity response returns a 4xx status code
+func (o *GetTaskDetailsUnprocessableEntity) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get task details unprocessable entity response returns a 5xx status code
+func (o *GetTaskDetailsUnprocessableEntity) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get task details unprocessable entity response returns a 4xx status code
+func (o *GetTaskDetailsUnprocessableEntity) IsCode(code int) bool {
+	return code == 422
+}
+
 func (o *GetTaskDetailsUnprocessableEntity) Error() string {
 	return fmt.Sprintf("[GET /tasks/{id}][%d] getTaskDetailsUnprocessableEntity  %+v", 422, o.Payload)
 }
+
+func (o *GetTaskDetailsUnprocessableEntity) String() string {
+	return fmt.Sprintf("[GET /tasks/{id}][%d] getTaskDetailsUnprocessableEntity  %+v", 422, o.Payload)
+}
+
 func (o *GetTaskDetailsUnprocessableEntity) GetPayload() *models.ValidationError {
 	return o.Payload
 }
@@ -134,9 +194,39 @@ func (o *GetTaskDetailsDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this get task details default response returns a 2xx status code
+func (o *GetTaskDetailsDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this get task details default response returns a 3xx status code
+func (o *GetTaskDetailsDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this get task details default response returns a 4xx status code
+func (o *GetTaskDetailsDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this get task details default response returns a 5xx status code
+func (o *GetTaskDetailsDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this get task details default response returns a 4xx status code
+func (o *GetTaskDetailsDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *GetTaskDetailsDefault) Error() string {
 	return fmt.Sprintf("[GET /tasks/{id}][%d] getTaskDetails default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *GetTaskDetailsDefault) String() string {
+	return fmt.Sprintf("[GET /tasks/{id}][%d] getTaskDetails default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *GetTaskDetailsDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/task-tracker/client/tasks/list_tasks_responses.go
+++ b/examples/task-tracker/client/tasks/list_tasks_responses.go
@@ -69,9 +69,39 @@ type ListTasksOK struct {
 	Payload []*models.TaskCard
 }
 
+// IsSuccess returns true when this list tasks o k response returns a 2xx status code
+func (o *ListTasksOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this list tasks o k response returns a 3xx status code
+func (o *ListTasksOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this list tasks o k response returns a 4xx status code
+func (o *ListTasksOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this list tasks o k response returns a 5xx status code
+func (o *ListTasksOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this list tasks o k response returns a 4xx status code
+func (o *ListTasksOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *ListTasksOK) Error() string {
 	return fmt.Sprintf("[GET /tasks][%d] listTasksOK  %+v", 200, o.Payload)
 }
+
+func (o *ListTasksOK) String() string {
+	return fmt.Sprintf("[GET /tasks][%d] listTasksOK  %+v", 200, o.Payload)
+}
+
 func (o *ListTasksOK) GetPayload() []*models.TaskCard {
 	return o.Payload
 }
@@ -110,9 +140,39 @@ type ListTasksUnprocessableEntity struct {
 	Payload *models.ValidationError
 }
 
+// IsSuccess returns true when this list tasks unprocessable entity response returns a 2xx status code
+func (o *ListTasksUnprocessableEntity) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this list tasks unprocessable entity response returns a 3xx status code
+func (o *ListTasksUnprocessableEntity) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this list tasks unprocessable entity response returns a 4xx status code
+func (o *ListTasksUnprocessableEntity) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this list tasks unprocessable entity response returns a 5xx status code
+func (o *ListTasksUnprocessableEntity) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this list tasks unprocessable entity response returns a 4xx status code
+func (o *ListTasksUnprocessableEntity) IsCode(code int) bool {
+	return code == 422
+}
+
 func (o *ListTasksUnprocessableEntity) Error() string {
 	return fmt.Sprintf("[GET /tasks][%d] listTasksUnprocessableEntity  %+v", 422, o.Payload)
 }
+
+func (o *ListTasksUnprocessableEntity) String() string {
+	return fmt.Sprintf("[GET /tasks][%d] listTasksUnprocessableEntity  %+v", 422, o.Payload)
+}
+
 func (o *ListTasksUnprocessableEntity) GetPayload() *models.ValidationError {
 	return o.Payload
 }
@@ -152,9 +212,39 @@ func (o *ListTasksDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this list tasks default response returns a 2xx status code
+func (o *ListTasksDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this list tasks default response returns a 3xx status code
+func (o *ListTasksDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this list tasks default response returns a 4xx status code
+func (o *ListTasksDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this list tasks default response returns a 5xx status code
+func (o *ListTasksDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this list tasks default response returns a 4xx status code
+func (o *ListTasksDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *ListTasksDefault) Error() string {
 	return fmt.Sprintf("[GET /tasks][%d] listTasks default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *ListTasksDefault) String() string {
+	return fmt.Sprintf("[GET /tasks][%d] listTasks default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *ListTasksDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/task-tracker/client/tasks/update_task_responses.go
+++ b/examples/task-tracker/client/tasks/update_task_responses.go
@@ -60,9 +60,39 @@ type UpdateTaskOK struct {
 	Payload *models.Task
 }
 
+// IsSuccess returns true when this update task o k response returns a 2xx status code
+func (o *UpdateTaskOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this update task o k response returns a 3xx status code
+func (o *UpdateTaskOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this update task o k response returns a 4xx status code
+func (o *UpdateTaskOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this update task o k response returns a 5xx status code
+func (o *UpdateTaskOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this update task o k response returns a 4xx status code
+func (o *UpdateTaskOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *UpdateTaskOK) Error() string {
 	return fmt.Sprintf("[PUT /tasks/{id}][%d] updateTaskOK  %+v", 200, o.Payload)
 }
+
+func (o *UpdateTaskOK) String() string {
+	return fmt.Sprintf("[PUT /tasks/{id}][%d] updateTaskOK  %+v", 200, o.Payload)
+}
+
 func (o *UpdateTaskOK) GetPayload() *models.Task {
 	return o.Payload
 }
@@ -92,9 +122,39 @@ type UpdateTaskUnprocessableEntity struct {
 	Payload *models.ValidationError
 }
 
+// IsSuccess returns true when this update task unprocessable entity response returns a 2xx status code
+func (o *UpdateTaskUnprocessableEntity) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this update task unprocessable entity response returns a 3xx status code
+func (o *UpdateTaskUnprocessableEntity) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this update task unprocessable entity response returns a 4xx status code
+func (o *UpdateTaskUnprocessableEntity) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this update task unprocessable entity response returns a 5xx status code
+func (o *UpdateTaskUnprocessableEntity) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this update task unprocessable entity response returns a 4xx status code
+func (o *UpdateTaskUnprocessableEntity) IsCode(code int) bool {
+	return code == 422
+}
+
 func (o *UpdateTaskUnprocessableEntity) Error() string {
 	return fmt.Sprintf("[PUT /tasks/{id}][%d] updateTaskUnprocessableEntity  %+v", 422, o.Payload)
 }
+
+func (o *UpdateTaskUnprocessableEntity) String() string {
+	return fmt.Sprintf("[PUT /tasks/{id}][%d] updateTaskUnprocessableEntity  %+v", 422, o.Payload)
+}
+
 func (o *UpdateTaskUnprocessableEntity) GetPayload() *models.ValidationError {
 	return o.Payload
 }
@@ -134,9 +194,39 @@ func (o *UpdateTaskDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this update task default response returns a 2xx status code
+func (o *UpdateTaskDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this update task default response returns a 3xx status code
+func (o *UpdateTaskDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this update task default response returns a 4xx status code
+func (o *UpdateTaskDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this update task default response returns a 5xx status code
+func (o *UpdateTaskDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this update task default response returns a 4xx status code
+func (o *UpdateTaskDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *UpdateTaskDefault) Error() string {
 	return fmt.Sprintf("[PUT /tasks/{id}][%d] updateTask default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *UpdateTaskDefault) String() string {
+	return fmt.Sprintf("[PUT /tasks/{id}][%d] updateTask default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *UpdateTaskDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/task-tracker/client/tasks/upload_task_file_responses.go
+++ b/examples/task-tracker/client/tasks/upload_task_file_responses.go
@@ -53,7 +53,36 @@ File added
 type UploadTaskFileCreated struct {
 }
 
+// IsSuccess returns true when this upload task file created response returns a 2xx status code
+func (o *UploadTaskFileCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this upload task file created response returns a 3xx status code
+func (o *UploadTaskFileCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this upload task file created response returns a 4xx status code
+func (o *UploadTaskFileCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this upload task file created response returns a 5xx status code
+func (o *UploadTaskFileCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this upload task file created response returns a 4xx status code
+func (o *UploadTaskFileCreated) IsCode(code int) bool {
+	return code == 201
+}
+
 func (o *UploadTaskFileCreated) Error() string {
+	return fmt.Sprintf("[POST /tasks/{id}/files][%d] uploadTaskFileCreated ", 201)
+}
+
+func (o *UploadTaskFileCreated) String() string {
 	return fmt.Sprintf("[POST /tasks/{id}/files][%d] uploadTaskFileCreated ", 201)
 }
 
@@ -85,9 +114,39 @@ func (o *UploadTaskFileDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this upload task file default response returns a 2xx status code
+func (o *UploadTaskFileDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this upload task file default response returns a 3xx status code
+func (o *UploadTaskFileDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this upload task file default response returns a 4xx status code
+func (o *UploadTaskFileDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this upload task file default response returns a 5xx status code
+func (o *UploadTaskFileDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this upload task file default response returns a 4xx status code
+func (o *UploadTaskFileDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *UploadTaskFileDefault) Error() string {
 	return fmt.Sprintf("[POST /tasks/{id}/files][%d] uploadTaskFile default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *UploadTaskFileDefault) String() string {
+	return fmt.Sprintf("[POST /tasks/{id}/files][%d] uploadTaskFile default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *UploadTaskFileDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/task-tracker/models/task.go
+++ b/examples/task-tracker/models/task.go
@@ -178,6 +178,11 @@ func (m *Task) validateAttachments(formats strfmt.Registry) error {
 		}
 		if val, ok := m.Attachments[k]; ok {
 			if err := val.Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("attachments" + "." + k)
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("attachments" + "." + k)
+				}
 				return err
 			}
 		}

--- a/examples/todo-list/client/todos/add_one_responses.go
+++ b/examples/todo-list/client/todos/add_one_responses.go
@@ -54,9 +54,39 @@ type AddOneCreated struct {
 	Payload *models.Item
 }
 
+// IsSuccess returns true when this add one created response returns a 2xx status code
+func (o *AddOneCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this add one created response returns a 3xx status code
+func (o *AddOneCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this add one created response returns a 4xx status code
+func (o *AddOneCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this add one created response returns a 5xx status code
+func (o *AddOneCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this add one created response returns a 4xx status code
+func (o *AddOneCreated) IsCode(code int) bool {
+	return code == 201
+}
+
 func (o *AddOneCreated) Error() string {
 	return fmt.Sprintf("[POST /][%d] addOneCreated  %+v", 201, o.Payload)
 }
+
+func (o *AddOneCreated) String() string {
+	return fmt.Sprintf("[POST /][%d] addOneCreated  %+v", 201, o.Payload)
+}
+
 func (o *AddOneCreated) GetPayload() *models.Item {
 	return o.Payload
 }
@@ -95,9 +125,39 @@ func (o *AddOneDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this add one default response returns a 2xx status code
+func (o *AddOneDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this add one default response returns a 3xx status code
+func (o *AddOneDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this add one default response returns a 4xx status code
+func (o *AddOneDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this add one default response returns a 5xx status code
+func (o *AddOneDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this add one default response returns a 4xx status code
+func (o *AddOneDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *AddOneDefault) Error() string {
 	return fmt.Sprintf("[POST /][%d] addOne default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *AddOneDefault) String() string {
+	return fmt.Sprintf("[POST /][%d] addOne default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *AddOneDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/todo-list/client/todos/destroy_one_responses.go
+++ b/examples/todo-list/client/todos/destroy_one_responses.go
@@ -53,7 +53,36 @@ Deleted
 type DestroyOneNoContent struct {
 }
 
+// IsSuccess returns true when this destroy one no content response returns a 2xx status code
+func (o *DestroyOneNoContent) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this destroy one no content response returns a 3xx status code
+func (o *DestroyOneNoContent) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this destroy one no content response returns a 4xx status code
+func (o *DestroyOneNoContent) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this destroy one no content response returns a 5xx status code
+func (o *DestroyOneNoContent) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this destroy one no content response returns a 4xx status code
+func (o *DestroyOneNoContent) IsCode(code int) bool {
+	return code == 204
+}
+
 func (o *DestroyOneNoContent) Error() string {
+	return fmt.Sprintf("[DELETE /{id}][%d] destroyOneNoContent ", 204)
+}
+
+func (o *DestroyOneNoContent) String() string {
 	return fmt.Sprintf("[DELETE /{id}][%d] destroyOneNoContent ", 204)
 }
 
@@ -84,9 +113,39 @@ func (o *DestroyOneDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this destroy one default response returns a 2xx status code
+func (o *DestroyOneDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this destroy one default response returns a 3xx status code
+func (o *DestroyOneDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this destroy one default response returns a 4xx status code
+func (o *DestroyOneDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this destroy one default response returns a 5xx status code
+func (o *DestroyOneDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this destroy one default response returns a 4xx status code
+func (o *DestroyOneDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *DestroyOneDefault) Error() string {
 	return fmt.Sprintf("[DELETE /{id}][%d] destroyOne default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *DestroyOneDefault) String() string {
+	return fmt.Sprintf("[DELETE /{id}][%d] destroyOne default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *DestroyOneDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/todo-list/client/todos/find_responses.go
+++ b/examples/todo-list/client/todos/find_responses.go
@@ -54,9 +54,39 @@ type FindOK struct {
 	Payload []*models.Item
 }
 
+// IsSuccess returns true when this find o k response returns a 2xx status code
+func (o *FindOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this find o k response returns a 3xx status code
+func (o *FindOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this find o k response returns a 4xx status code
+func (o *FindOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this find o k response returns a 5xx status code
+func (o *FindOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this find o k response returns a 4xx status code
+func (o *FindOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *FindOK) Error() string {
 	return fmt.Sprintf("[GET /][%d] findOK  %+v", 200, o.Payload)
 }
+
+func (o *FindOK) String() string {
+	return fmt.Sprintf("[GET /][%d] findOK  %+v", 200, o.Payload)
+}
+
 func (o *FindOK) GetPayload() []*models.Item {
 	return o.Payload
 }
@@ -93,9 +123,39 @@ func (o *FindDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this find default response returns a 2xx status code
+func (o *FindDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this find default response returns a 3xx status code
+func (o *FindDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this find default response returns a 4xx status code
+func (o *FindDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this find default response returns a 5xx status code
+func (o *FindDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this find default response returns a 4xx status code
+func (o *FindDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *FindDefault) Error() string {
 	return fmt.Sprintf("[GET /][%d] find default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *FindDefault) String() string {
+	return fmt.Sprintf("[GET /][%d] find default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *FindDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/examples/todo-list/client/todos/update_one_responses.go
+++ b/examples/todo-list/client/todos/update_one_responses.go
@@ -54,9 +54,39 @@ type UpdateOneOK struct {
 	Payload *models.Item
 }
 
+// IsSuccess returns true when this update one o k response returns a 2xx status code
+func (o *UpdateOneOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this update one o k response returns a 3xx status code
+func (o *UpdateOneOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this update one o k response returns a 4xx status code
+func (o *UpdateOneOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this update one o k response returns a 5xx status code
+func (o *UpdateOneOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this update one o k response returns a 4xx status code
+func (o *UpdateOneOK) IsCode(code int) bool {
+	return code == 200
+}
+
 func (o *UpdateOneOK) Error() string {
 	return fmt.Sprintf("[PUT /{id}][%d] updateOneOK  %+v", 200, o.Payload)
 }
+
+func (o *UpdateOneOK) String() string {
+	return fmt.Sprintf("[PUT /{id}][%d] updateOneOK  %+v", 200, o.Payload)
+}
+
 func (o *UpdateOneOK) GetPayload() *models.Item {
 	return o.Payload
 }
@@ -95,9 +125,39 @@ func (o *UpdateOneDefault) Code() int {
 	return o._statusCode
 }
 
+// IsSuccess returns true when this update one default response returns a 2xx status code
+func (o *UpdateOneDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this update one default response returns a 3xx status code
+func (o *UpdateOneDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this update one default response returns a 4xx status code
+func (o *UpdateOneDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this update one default response returns a 5xx status code
+func (o *UpdateOneDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this update one default response returns a 4xx status code
+func (o *UpdateOneDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
 func (o *UpdateOneDefault) Error() string {
 	return fmt.Sprintf("[PUT /{id}][%d] updateOne default  %+v", o._statusCode, o.Payload)
 }
+
+func (o *UpdateOneDefault) String() string {
+	return fmt.Sprintf("[PUT /{id}][%d] updateOne default  %+v", o._statusCode, o.Payload)
+}
+
 func (o *UpdateOneDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/generator/templates/client/response.gotmpl
+++ b/generator/templates/client/response.gotmpl
@@ -71,16 +71,64 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) Code() int {
 }
   {{- end }}
 
+// IsSuccess returns true when this {{ humanize .Name }} response returns a 2xx status code
+func ({{ .ReceiverName }} *{{ pascalize .Name }}) IsSuccess() bool {
+  {{- if eq .Code -1 }}
+  return {{ .ReceiverName }}._statusCode/100 == 2
+  {{- else }}
+  return {{ and (ge .Code 200) (lt .Code 300) }}
+  {{- end }}
+}
+
+// IsRedirect returns true when this {{ humanize .Name }} response returns a 3xx status code
+func ({{ .ReceiverName }} *{{ pascalize .Name }}) IsRedirect() bool {
+  {{- if eq .Code -1 }}
+  return {{ .ReceiverName }}._statusCode/100 == 3
+  {{- else }}
+  return {{ and (ge .Code 300) (lt .Code 400) }}
+  {{- end }}
+}
+
+// IsClientError returns true when this {{ humanize .Name }} response returns a 4xx status code
+func ({{ .ReceiverName }} *{{ pascalize .Name }}) IsClientError() bool {
+  {{- if eq .Code -1 }}
+  return {{ .ReceiverName }}._statusCode/100 == 4
+  {{- else }}
+  return {{ and (ge .Code 400) (lt .Code 500) }}
+  {{- end }}
+}
+
+// IsServerError returns true when this {{ humanize .Name }} response returns a 5xx status code
+func ({{ .ReceiverName }} *{{ pascalize .Name }}) IsServerError() bool {
+  {{- if eq .Code -1 }}
+  return {{ .ReceiverName }}._statusCode/100 == 5
+  {{- else }}
+  return {{ and (ge .Code 500) (lt .Code 600) }}
+  {{- end }}
+}
+
+// IsCode returns true when this {{ humanize .Name }} response returns a 4xx status code
+func ({{ .ReceiverName }} *{{ pascalize .Name }}) IsCode(code int) bool {
+  {{- if eq .Code -1 }}
+  return {{ .ReceiverName }}._statusCode == code
+  {{- else }}
+  return code == {{ .Code }}
+  {{- end }}
+}
 
 func ({{ .ReceiverName }} *{{ pascalize .Name }}) Error() string {
 	return fmt.Sprintf("[{{ upper .Method }} {{ .Path }}][%d] {{ if .Name }}{{ .Name }} {{ else }}unknown error {{ end }}{{ if .Schema }} %+v{{ end }}", {{ if eq .Code -1 }}{{ .ReceiverName }}._statusCode{{ else }}{{ .Code }}{{ end }}{{ if .Schema }}, o.Payload{{ end }})
 }
 
-  {{- if .Schema }}
+func ({{ .ReceiverName }} *{{ pascalize .Name }}) String() string {
+	return fmt.Sprintf("[{{ upper .Method }} {{ .Path }}][%d] {{ if .Name }}{{ .Name }} {{ else }}unknown response {{ end }}{{ if .Schema }} %+v{{ end }}", {{ if eq .Code -1 }}{{ .ReceiverName }}._statusCode{{ else }}{{ .Code }}{{ end }}{{ if .Schema }}, o.Payload{{ end }})
+}
+
+{{ if .Schema }}
 func ({{ .ReceiverName }} *{{ pascalize .Name }}) GetPayload() {{ if and (not .Schema.IsBaseType) (not .Schema.IsInterface) .Schema.IsComplexObject (not .Schema.IsStream) }}*{{ end }}{{ if (not .Schema.IsStream) }}{{ .Schema.GoType }}{{ else }}io.Writer{{end}} {
 	return o.Payload
 }
-  {{- end }}
+{{- end }}
 
 func ({{ .ReceiverName }} *{{ pascalize .Name }}) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
   {{- range .Headers }}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-openapi/inflect v0.19.0
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/loads v0.21.0
-	github.com/go-openapi/runtime v0.21.1
+	github.com/go-openapi/runtime v0.23.0
 	github.com/go-openapi/spec v0.20.4
 	github.com/go-openapi/strfmt v0.21.1
 	github.com/go-openapi/swag v0.19.15

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/go-openapi/runtime v0.19.16/go.mod h1:5P9104EJgYcizotuXhEuUrzVc+j1RiS
 github.com/go-openapi/runtime v0.19.24/go.mod h1:Lm9YGCeecBnUUkFTxPC4s1+lwrkJ0pthx8YvyjCfkgk=
 github.com/go-openapi/runtime v0.21.1 h1:/KIG00BzA2x2HRStX2tnhbqbQdPcFlkgsYCiNY20FZs=
 github.com/go-openapi/runtime v0.21.1/go.mod h1:aQg+kaIQEn+A2CRSY1TxbM8+sT9g2V3aLc1FbIAnbbs=
+github.com/go-openapi/runtime v0.23.0 h1:HX6ET2sHCIvaKeDDQoU01CtO1ekg5EkekHSkLTtWXH0=
+github.com/go-openapi/runtime v0.23.0/go.mod h1:aQg+kaIQEn+A2CRSY1TxbM8+sT9g2V3aLc1FbIAnbbs=
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=

--- a/hack/download-stats.go
+++ b/hack/download-stats.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -9,9 +10,18 @@ import (
 	"os"
 )
 
+var (
+	allVersions bool
+)
+
+func init() {
+	flag.BoolVar(&allVersions, "all", allVersions, "when specified it will download stats for all versions")
+}
+
 func main() {
+	flag.Parse()
+
 	req, err := http.NewRequest("GET", "https://api.github.com/repos/go-swagger/go-swagger/releases", nil)
-	// req, err := http.NewRequest("GET", "https://api.github.com/repos/go-swagger/go-swagger/releases/latest", nil)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -46,6 +56,11 @@ func main() {
 	}
 
 	for i, result := range results {
+		if !allVersions {
+			if i > 0 {
+				break
+			}
+		}
 		if i > 0 {
 			fmt.Println()
 		}


### PR DESCRIPTION
Adds the same method sets to runtime.APIError and the generated client responses. There is also a convenience interface `runtime.ClientResponseStatus` to runtime 

```go

// IsSuccess returns true when this elapse o k response returns a 2xx status code
func (o *APIError) IsSuccess() bool {
	return o.Code/100 == 2
}

// IsRedirect returns true when this elapse o k response returns a 3xx status code
func (o *APIError) IsRedirect() bool {
	return o.Code/100 == 3
}

// IsClientError returns true when this elapse o k response returns a 4xx status code
func (o *APIError) IsClientError() bool {
	return o.Code/100 == 4
}

// IsServerError returns true when this elapse o k response returns a 5xx status code
func (o *APIError) IsServerError() bool {
	return o.Code/100 == 5
}

// IsCode returns true when this elapse o k response returns a 4xx status code
func (o *APIError) IsCode(code int) bool {
	return o.Code == code
}

```

So you should be able to use it as:

```go
func IsClientError(err error) bool {
	if rerr, ok := err.(runtime.ClientResponseStatus); ok {
            return rerr.IsClientError() 
        }
	return false
}
```

closes #2706 