### PR TITLE
support for passing basepath as an argument

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -56,12 +56,13 @@ $ ./examples/cli/cmd/todoctl/todoctl --help
 $ ./examples/cli/cmd/todoctl/todoctl todos updateOne --help
 ```
 ### Use config file to store common flag values
-`hostname`, `scheme`, and auth tokens can be read from a config file, so that you do not need to enter it every time via command line.
+`hostname`, `scheme`, `base_path` (default: `/`), and auth tokens can be read from a config file, so that you do not need to enter it every time via command line.
 For example, todo-cli config file looks like this:
 ```json
 {
     "hostname":"localhost:12345",
     "scheme":"http",
+    "base_path":"/base-path/",
     "x-todolist-token":"example token"
 }
 ```

--- a/examples/cli/cli/cli.go
+++ b/examples/cli/cli/cli.go
@@ -48,9 +48,11 @@ var maxDepth int = 5
 // makeClient constructs a client object
 func makeClient(cmd *cobra.Command, args []string) (*client.AToDoListApplication, error) {
 	hostname := viper.GetString("hostname")
+	viper.SetDefault("base_path", client.DefaultBasePath)
+	basePath := viper.GetString("base_path")
 	scheme := viper.GetString("scheme")
 
-	r := httptransport.New(hostname, client.DefaultBasePath, []string{scheme})
+	r := httptransport.New(hostname, basePath, []string{scheme})
 	r.SetDebug(debug)
 	// set custom producer and consumer to use the default ones
 

--- a/generator/templates/cli/cli.gotmpl
+++ b/generator/templates/cli/cli.gotmpl
@@ -46,9 +46,11 @@ var maxDepth int = 5
 // makeClient constructs a client object
 func makeClient(cmd *cobra.Command, args []string) (*client.{{ pascalize .Name }}, error) {
 	hostname := viper.GetString("hostname")
+	viper.SetDefault("base_path", client.DefaultBasePath)
+	basePath := viper.GetString("base_path")
 	scheme := viper.GetString("scheme")
 
-	r := httptransport.New(hostname, client.DefaultBasePath, []string{scheme})
+	r := httptransport.New(hostname, basePath, []string{scheme})
 	r.SetDebug(debug)
 
 	{{- /* user might define custom mediatype xxx/json and there is no registered ones to handle. */}}
@@ -98,6 +100,8 @@ func MakeRootCmd() (*cobra.Command, error) {
 	viper.BindPFlag("hostname", rootCmd.PersistentFlags().Lookup("hostname"))
 	rootCmd.PersistentFlags().String("scheme", client.DefaultSchemes[0], fmt.Sprintf("Choose from: %v", client.DefaultSchemes))
 	viper.BindPFlag("scheme", rootCmd.PersistentFlags().Lookup("scheme"))
+	rootCmd.PersistentFlags().String("base-path", client.DefaultBasePath, fmt.Sprintf("For example: %v", client.DefaultBasePath))
+	viper.BindPFlag("base_path", rootCmd.PersistentFlags().Lookup("base-path"))
 
 	// configure debug flag
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "output debug logs")


### PR DESCRIPTION
Not all projects use as a base path `/`, and this limitations makes generation of projects with go-swagger difficult to maintain.
Please consider this proposal as a solution to the issue described above.

- [x] This is an extension and it is backwards compatible, does not break old way of work, extends it.

Possibly related to https://github.com/go-swagger/go-swagger/issues/1083