### PR TITLE
allow trimPrefix and trimSuffix in templates

### DIFF
--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -135,6 +135,8 @@ func DefaultFuncMap(lang *LanguageOpts) template.FuncMap {
 		},
 		"docCollectionFormat": resolvedDocCollectionFormat,
 		"trimSpace":           strings.TrimSpace,
+		"trimPrefix":          strings.TrimPrefix,
+		"trimSuffix":          strings.TrimSuffix,
 		"httpStatus":          httpStatus,
 		"cleanupEnumVariant":  cleanupEnumVariant,
 		"gt0":                 gt0,


### PR DESCRIPTION
In order to better manipulate strings in custom templates.

fixes #2737 

Signed-off-by: Kevin Barbour <kevinbarbourd@gmail.com>