### PR TITLE
Update jwt library

### DIFF
--- a/docs/tutorial/composed-auth/README.md
+++ b/docs/tutorial/composed-auth/README.md
@@ -47,10 +47,10 @@ security requirements may be composed out of several schemes, and use API author
 
 ### Prerequisites
 
-`jwt-go` ships with a nice JWT CLI utility. Although not required, you might want to install it and 
+`golang-jwt/jwt` ships with a nice JWT CLI utility. Although not required, you might want to install it and 
 play with your own tokens:
 
-- `go install github.com/dgrijalva/jwt-go/cmd/jwt`
+- `go install github.com/golang-jwt/jwt/cmd/jwt`
 
 ### Swagger specification
 

--- a/examples/composed-auth/README.md
+++ b/examples/composed-auth/README.md
@@ -47,10 +47,10 @@ security requirements may be composed out of several schemes, and use API author
 
 ### Prerequisites
 
-`jwt-go` ships with a nice JWT CLI utility. Although not required, you might want to install it and 
+`golang-jwt/jwt` ships with a nice JWT CLI utility. Although not required, you might want to install it and 
 play with your own tokens:
 
-- `go install github.com/dgrijalva/jwt-go/cmd/jwt`
+- `go install github.com/golang-jwt/jwt/cmd/jwt`
 
 ### Swagger specification
 

--- a/examples/composed-auth/auth/authorizers.go
+++ b/examples/composed-auth/auth/authorizers.go
@@ -4,9 +4,9 @@ import (
 	"crypto/rsa"
 	"io/ioutil"
 
-	jwt "github.com/dgrijalva/jwt-go"
 	errors "github.com/go-openapi/errors"
 	models "github.com/go-swagger/go-swagger/examples/composed-auth/models"
+	jwt "github.com/golang-jwt/jwt"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/davecgh/go-spew v1.1.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-openapi/analysis v0.21.2
@@ -22,6 +21,7 @@ require (
 	github.com/go-openapi/validate v0.20.3
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gorilla/handlers v1.5.1
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/kr/pretty v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -290,6 +288,8 @@ github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY9
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
The original repository dgrijalva/jwt-go is no longer maintained and has
a high severity vulnerability (CVE-2020-26160)[1]. There is no patch
available and users of jwt-go are advised to migrate to golang-jwt[2].
This commit updates the library to its latest version.

1. https://nvd.nist.gov/vuln/detail/CVE-2020-26160
2. https://github.com/golang-jwt/jwt

Signed-off-by: Katyanna Moura <amelie.kn@gmail.com>