### PR TITLE
1957: Support for extensions within swagger:route

### DIFF
--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -1683,7 +1683,7 @@ func (ss *setOpExtensions) Parse(lines []string) error {
 		if _, ok := ext.Root.(map[string]string); ok {
 			exts.AddExtension(ext.Extension, ext.Root.(map[string]string)[ext.Extension])
 		} else if _, ok := ext.Root.(map[string]*[]string); ok {
-			exts.AddExtension(ext.Extension, ext.Root.(map[string]*[]string)[ext.Extension])
+			exts.AddExtension(ext.Extension, *(ext.Root.(map[string]*[]string)[ext.Extension]))
 		} else if _, ok := ext.Root.(map[string]interface{}); ok {
 			exts.AddExtension(ext.Extension, ext.Root.(map[string]interface{})[ext.Extension])
 		} else {

--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/ast"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1507,4 +1508,189 @@ func parseEnum(val string, s *spec.SimpleSchema) []interface{} {
 		interfaceSlice[i] = v
 	}
 	return interfaceSlice
+}
+
+// AlphaChars used when parsing for Vendor Extensions
+const AlphaChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func newSetExtensions(setter func(*spec.Extensions)) *setOpExtensions {
+	return &setOpExtensions{
+		set: setter,
+		rx:  rxExtensions,
+	}
+}
+
+type setOpExtensions struct {
+	set func(*spec.Extensions)
+	rx  *regexp.Regexp
+}
+
+type extensionObject struct {
+	Extension string
+	Root      interface{}
+}
+
+type extensionParsingStack []interface{}
+
+// Helper function to walk back through extensions until the proper nest level is reached
+func (stack *extensionParsingStack) walkBack(rawLines []string, lineIndex int) {
+	indent := strings.IndexAny(rawLines[lineIndex], AlphaChars)
+	nextIndent := strings.IndexAny(rawLines[lineIndex+1], AlphaChars)
+	if nextIndent < indent {
+		// Pop elements off the stack until we're back where we need to be
+		runbackIndex := 0
+		poppedIndent := 1000
+		for {
+			checkIndent := strings.IndexAny(rawLines[lineIndex-runbackIndex], AlphaChars)
+			if nextIndent == checkIndent {
+				break
+			}
+			if checkIndent < poppedIndent {
+				*stack = (*stack)[:len(*stack)-1]
+				poppedIndent = checkIndent
+			}
+			runbackIndex++
+		}
+	}
+}
+
+// Recursively parses through the given extension lines, building and adding extension objects as it goes.
+// Extensions may be key:value pairs, arrays, or objects.
+func buildExtensionObjects(rawLines []string, cleanLines []string, lineIndex int, extObjs *[]extensionObject, stack *extensionParsingStack) {
+	if lineIndex >= len(rawLines) {
+		if stack != nil {
+			if ext, ok := (*stack)[0].(extensionObject); ok {
+				*extObjs = append(*extObjs, ext)
+			}
+		}
+		return
+	}
+	kv := strings.SplitN(cleanLines[lineIndex], ":", 2)
+	key := strings.TrimSpace(kv[0])
+	if key == "" {
+		// Some odd empty line
+		return
+	}
+
+	nextIsList := false
+	if lineIndex < len(rawLines)-1 {
+		next := strings.SplitAfterN(cleanLines[lineIndex+1], ":", 2)
+		nextIsList = len(next) == 1
+	}
+
+	if len(kv) > 1 {
+		// Should be the start of a map or a key:value pair
+		value := strings.TrimSpace(kv[1])
+
+		if rxAllowedExtensions.MatchString(key) {
+			// New extension started
+			if stack != nil {
+				if ext, ok := (*stack)[0].(extensionObject); ok {
+					*extObjs = append(*extObjs, ext)
+				}
+			}
+
+			if value != "" {
+				ext := extensionObject{
+					Extension: key,
+				}
+				// Extension is simple key:value pair, no stack
+				ext.Root = make(map[string]string)
+				ext.Root.(map[string]string)[key] = value
+				*extObjs = append(*extObjs, ext)
+				buildExtensionObjects(rawLines, cleanLines, lineIndex+1, extObjs, nil)
+			} else {
+				ext := extensionObject{
+					Extension: key,
+				}
+				if nextIsList {
+					// Extension is an array
+					ext.Root = make(map[string]*[]string)
+					rootList := make([]string, 0)
+					ext.Root.(map[string]*[]string)[key] = &rootList
+					stack = &extensionParsingStack{}
+					*stack = append(*stack, ext)
+					*stack = append(*stack, ext.Root.(map[string]*[]string)[key])
+				} else {
+					// Extension is an object
+					ext.Root = make(map[string]interface{})
+					rootMap := make(map[string]interface{})
+					ext.Root.(map[string]interface{})[key] = rootMap
+					stack = &extensionParsingStack{}
+					*stack = append(*stack, ext)
+					*stack = append(*stack, rootMap)
+				}
+				buildExtensionObjects(rawLines, cleanLines, lineIndex+1, extObjs, stack)
+			}
+		} else if stack != nil && len(*stack) != 0 {
+			stackIndex := len(*stack) - 1
+			if value == "" {
+				if nextIsList {
+					// start of new list
+					newList := make([]string, 0)
+					(*stack)[stackIndex].(map[string]interface{})[key] = &newList
+					*stack = append(*stack, &newList)
+				} else {
+					// start of new map
+					newMap := make(map[string]interface{})
+					(*stack)[stackIndex].(map[string]interface{})[key] = newMap
+					*stack = append(*stack, newMap)
+				}
+			} else {
+				// key:value
+				if reflect.TypeOf((*stack)[stackIndex]).Kind() == reflect.Map {
+					(*stack)[stackIndex].(map[string]interface{})[key] = value
+				}
+				if lineIndex < len(rawLines)-1 && !rxAllowedExtensions.MatchString(cleanLines[lineIndex+1]) {
+					stack.walkBack(rawLines, lineIndex)
+				}
+			}
+			buildExtensionObjects(rawLines, cleanLines, lineIndex+1, extObjs, stack)
+		}
+	} else if stack != nil && len(*stack) != 0 {
+		// Should be a list item
+		stackIndex := len(*stack) - 1
+		list := (*stack)[stackIndex].(*[]string)
+		*list = append(*list, key)
+		(*stack)[stackIndex] = list
+		if lineIndex < len(rawLines)-1 && !rxAllowedExtensions.MatchString(cleanLines[lineIndex+1]) {
+			stack.walkBack(rawLines, lineIndex)
+		}
+		buildExtensionObjects(rawLines, cleanLines, lineIndex+1, extObjs, stack)
+	}
+}
+
+func (ss *setOpExtensions) Matches(line string) bool {
+	return ss.rx.MatchString(line)
+}
+
+func (ss *setOpExtensions) Parse(lines []string) error {
+	if len(lines) == 0 || (len(lines) == 1 && len(lines[0]) == 0) {
+		return nil
+	}
+
+	cleanLines := cleanupScannerLines(lines, rxUncommentHeaders, nil)
+
+	exts := new(spec.VendorExtensible)
+	extList := make([]extensionObject, 0)
+	buildExtensionObjects(lines, cleanLines, 0, &extList, nil)
+
+	// Extensions can be one of the following:
+	// key:value pair
+	// list/array
+	// object
+	for _, ext := range extList {
+		if _, ok := ext.Root.(map[string]string); ok {
+			exts.AddExtension(ext.Extension, ext.Root.(map[string]string)[ext.Extension])
+		} else if _, ok := ext.Root.(map[string]*[]string); ok {
+			exts.AddExtension(ext.Extension, ext.Root.(map[string]*[]string)[ext.Extension])
+		} else if _, ok := ext.Root.(map[string]interface{}); ok {
+			exts.AddExtension(ext.Extension, ext.Root.(map[string]interface{})[ext.Extension])
+		} else {
+			debugLog("Unknown Extension type: %s", fmt.Sprint(reflect.TypeOf(ext.Root)))
+		}
+	}
+
+	ss.set(&exts.Extensions)
+	return nil
 }

--- a/codescan/routes.go
+++ b/codescan/routes.go
@@ -40,6 +40,14 @@ func opParamSetter(op *spec.Operation) func([]*spec.Parameter) {
 	}
 }
 
+func opExtensionsSetter(op *spec.Operation) func(*spec.Extensions) {
+	return func(exts *spec.Extensions) {
+		for name, value := range *exts {
+			op.AddExtension(name, value)
+		}
+	}
+}
+
 type routesBuilder struct {
 	ctx         *scanCtx
 	route       parsedPathContent
@@ -71,6 +79,7 @@ func (r *routesBuilder) Build(tgt *spec.Paths) error {
 		newMultiLineTagParser("Parameters", spa, false),
 		newMultiLineTagParser("Responses", sr, false),
 		newSingleLineTagParser("Deprecated", &setDeprecatedOp{op}),
+		newMultiLineTagParser("Extensions", newSetExtensions(opExtensionsSetter(op)), true),
 	}
 	if err := sp.Parse(r.route.Remaining); err != nil {
 		return fmt.Errorf("operation (%s): %v", op.ID, err)

--- a/docs/use/spec/route.md
+++ b/docs/use/spec/route.md
@@ -26,6 +26,7 @@ Annotation | Format
 **Deprecated** | Route marked as deprecated if this value is true
 **Security** | a dictionary of key: []string{scopes}
 **Responses** | a dictionary of status code to named response
+**Extensions** | a dictionary of custom [vendor extensions](https://swagger.io/docs/specification/2-0/swagger-extensions/); each key must start with `x-`
 
 ##### Example:
 
@@ -60,6 +61,12 @@ func ServeAPI(host, basePath string, schemes []string) error {
 	//       default: genericError
 	//       200: someResponse
 	//       422: validationError
+  //     Extensions:
+  //       x-example-flag: true
+  //       x-some-list:
+  //         - dog
+  //         - cat
+  //         - bird
 	mountItem("GET", basePath+"/pets", nil)
 }
 ```
@@ -101,4 +108,10 @@ paths:
           $ref: "#/responses/someResponse"
         422:
           $ref: "#/responses/validationError"
+      extensions:
+        x-example-flag: true
+        x-some-list:
+        - dog
+        - cat
+        - bird
 ```

--- a/fixtures/goparsing/classification/operations/todo_operation.go
+++ b/fixtures/goparsing/classification/operations/todo_operation.go
@@ -48,6 +48,9 @@ func ServeAPI(host, basePath string, schemes []string) error {
 	// default: genericError
 	// 200: someResponse
 	// 422: validationError
+	//
+	// Extensions:
+	// x-some-flag: true
 	mountItem("GET", basePath+"/pets", nil)
 
 	/* swagger:route POST /pets pets users createPet
@@ -96,6 +99,20 @@ func ServeAPI(host, basePath string, schemes []string) error {
 	// default: genericError
 	// 200: someResponse
 	// 422: validationError
+	//
+	// Extensions:
+	// x-some-flag: false
+	// x-some-list:
+	//	- item1
+	//	- item2
+	//	- item3
+	// x-some-object:
+	//	key1: value1
+	//	key2: value2
+	//	subobject:
+	//		subkey1: subvalue1
+	//		subkey2: subvalue2
+	//	key3: value3
 	mountItem("GET", basePath+"/orders", nil)
 
 	// swagger:route POST /orders orders createOrder

--- a/fixtures/goparsing/classification/operations_body/todo_operation_body.go
+++ b/fixtures/goparsing/classification/operations_body/todo_operation_body.go
@@ -48,6 +48,9 @@ func ServeAPI(host, basePath string, schemes []string) error {
 	// default: body:genericError
 	// 200: body:someResponse
 	// 422: body:validationError
+	//
+	// Extensions:
+	// x-some-flag: true
 	mountItem("GET", basePath+"/pets", nil)
 
 	/* swagger:route POST /pets pets users createPet
@@ -110,6 +113,20 @@ func ServeAPI(host, basePath string, schemes []string) error {
 	// default: body:genericError
 	// 200: body:someResponse
 	// 422: body:validationError
+	//
+	// Extensions:
+	// x-some-flag: false
+	// x-some-list:
+	//	- item1
+	//	- item2
+	//	- item3
+	// x-some-object:
+	//	key1: value1
+	//	key2: value2
+	//	subobject:
+	//		subkey1: subvalue1
+	//		subkey2: subvalue2
+	//	key3: value3
 	mountItem("GET", basePath+"/orders", nil)
 
 	// swagger:route POST /orders orders createOrder


### PR DESCRIPTION
## Summary ##
Adding basic functionality to support the definition of vendor extensions on a per-path basis as requested in issue #1957. This would be defined by a developer within a `swagger:route` block of their codebase, and the corresponding swagger definition would be created when running `swagger generate spec`. These changes currently only support go1.11+.

These changes are making the following assumptions:
- the value of a vendor extension can be a single string, a list/array of strings, or objects
- a list cannot contain a mix of strings and objects
- annotations defining extensions should be indented properly
- each extension key must start with `x-`, e.g. `x-some-extension`
- objects defined in an extension may contain multiple other nested objects

The new extension parser reads through the `Extension` annotation block within a `swagger:route` annotation, checking for what kind of data each line may be and builds out as many `map[string]interface{}`s as necessary until reaching the end of the block. 
- Simple key:value extensions will be `map[string]string`
- Lists/Arrays will be `map[string]*[]string`
- Objects will be `map[string]interface{}` that can contain any of the above types, including more objects

### Example ###
#### Input: ####
```go
// swagger:route GET /pets pets users listPets
//
// Lists pets filtered by some parameters.
//
//     Extensions:
//       x-example-flag: true
//       x-some-expected-list:
//         - dog
//         - cat
//         - bird
//       x-env-data:
//         userId:
//           prod: some-user-id
//           dev: some-test-id
```
#### Output: ####
```yaml
paths:
  "/pets":
    get:
      operationId: listPets
      summary: Lists pets filtered by some parameters.
      tags:
      - pets
      - users
      extensions:
        x-example-flag: true
        x-some-list:
        - dog
        - cat
        - bird
        x-env-data:
          userId:
            prod: some-user-id
            dev: some-test-id
```

Fixes #1957