### PR TITLE
Fix docker command in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,7 @@ docker pull quay.io/goswagger/swagger
 #### For Mac And Linux users:
 
 ```bash
-alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=$(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
+alias swagger='docker run --rm -it  --user $(id -u):$(id -g) -e GOPATH=/go -v $(go env GOPATH):/go -v $HOME:$HOME -w $(pwd) quay.io/goswagger/swagger'
 swagger version
 ```
 


### PR DESCRIPTION
`-e GOPATH=$(go env GOPATH):/go` is wrong and should most likely be 
`-e GOPATH=/go -v $(go env GOPATH):/go`