### PR TITLE
Add details on how to install using go install

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -46,6 +46,7 @@ brew install go-swagger
 
 ## Install to GOPATH using go install
 
+If you have `go` version `1.16` or greater installed the binary  can be installed by running:
 ```
 go install github.com/go-swagger/go-swagger/cmd/swagger@latest
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,6 +44,12 @@ brew tap go-swagger/go-swagger
 brew install go-swagger
 ```
 
+## Install to GOPATH using go install
+
+```
+go install github.com/go-swagger/go-swagger/cmd/swagger@latest
+```
+
 ### Static binary
 
 You can download a binary for your platform from github:


### PR DESCRIPTION
I was adding instructions on how to install the command line tool to a new project and I 

Was unsure if the cli tool could be installed using `go install`

I worked it out, so adding details here