### PR TITLE
fixbug: `interface{}` in a `map` as value should be generated/typed to `any`

### DIFF
--- a/codescan/application_test.go
+++ b/codescan/application_test.go
@@ -47,7 +47,7 @@ func loadClassificationPkgsCtx(t testing.TB, extra ...string) *scanCtx {
 func TestApplication_LoadCode(t *testing.T) {
 	sctx := loadClassificationPkgsCtx(t)
 	require.NotNil(t, sctx)
-	require.Len(t, sctx.app.Models, 31)
+	require.Len(t, sctx.app.Models, 32)
 	require.Len(t, sctx.app.Meta, 1)
 	require.Len(t, sctx.app.Routes, 7)
 	require.Empty(t, sctx.app.Operations)

--- a/codescan/parameters_test.go
+++ b/codescan/parameters_test.go
@@ -393,6 +393,4 @@ func TestParameterParser_Issue2011(t *testing.T) {
 	require.Len(t, op.Parameters, 1)
 	sch := op.Parameters[0].Schema
 	require.NotNil(t, sch)
-
-	require.True(t, sch.Type.Contains("object"))
 }

--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -250,6 +250,8 @@ func swaggerSchemaForType(typeName string, prop swaggerTypable) error {
 		prop.Typed("integer", "uint8")
 	case "uintptr":
 		prop.Typed("integer", "uint64")
+	case "object":
+		prop.Typed("object", "")
 	default:
 		return fmt.Errorf("unsupported type %q", typeName)
 	}

--- a/codescan/responses_test.go
+++ b/codescan/responses_test.go
@@ -259,8 +259,6 @@ func TestParseResponses_Issue2011(t *testing.T) {
 	resp := responses["NumPlatesResp"]
 	require.Len(t, resp.Headers, 0)
 	require.NotNil(t, resp.Schema)
-
-	require.True(t, resp.Schema.Type.Contains("object"))
 }
 
 func TestParseResponses_Issue2145(t *testing.T) {

--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -488,7 +488,6 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 
 func (s *schemaBuilder) buildFromInterface(decl *entityDecl, it *types.Interface, schema *spec.Schema, seen map[string]string) error {
 	if it.Empty() {
-		schema.Typed("object", "")
 		return nil
 	}
 

--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -356,6 +356,11 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 			cmt = new(ast.CommentGroup)
 		}
 
+		if typeName, ok := typeName(cmt); ok {
+			_ = swaggerSchemaForType(typeName, tgt)
+			return nil
+		}
+
 		switch utitpe := tpe.Underlying().(type) {
 		case *types.Struct:
 

--- a/codescan/schema_test.go
+++ b/codescan/schema_test.go
@@ -669,7 +669,7 @@ func TestInterfaceField(t *testing.T) {
 	require.NoError(t, prs.Build(models))
 
 	schema := models["Interfaced"]
-	assertProperty(t, &schema, "object", "custom_data", "", "CustomData")
+	assertProperty(t, &schema, "", "custom_data", "", "CustomData")
 }
 
 func TestAliasedTypes(t *testing.T) {
@@ -1047,7 +1047,9 @@ func assertMapDefinition(t testing.TB, defs map[string]spec.Schema, defName, typ
 			assert.Equal(t, "object", schema.Type[0])
 			adl := schema.AdditionalProperties
 			if assert.NotNil(t, adl) && assert.NotNil(t, adl.Schema) {
-				assert.Equal(t, typeName, adl.Schema.Type[0])
+				if len(adl.Schema.Type) > 0 {
+					assert.Equal(t, typeName, adl.Schema.Type[0])
+				}
 				assert.Equal(t, formatName, adl.Schema.Format)
 			}
 			if goName != "" {

--- a/codescan/schema_test.go
+++ b/codescan/schema_test.go
@@ -832,6 +832,21 @@ func TestEmbeddedAllOf(t *testing.T) {
 	assertProperty(t, &asch, "string", "cat", "", "Cat")
 }
 
+func TestSwaggerTypeNamed(t *testing.T) {
+	sctx := loadClassificationPkgsCtx(t)
+	decl := getClassificationModel(sctx, "NamedWithType")
+	require.NotNil(t, decl)
+	prs := &schemaBuilder{
+		ctx:  sctx,
+		decl: decl,
+	}
+	models := make(map[string]spec.Schema)
+	require.NoError(t, prs.Build(models))
+	schema := models["namedWithType"]
+
+	assertProperty(t, &schema, "object", "some_map", "", "SomeMap")
+}
+
 func TestSwaggerTypeStruct(t *testing.T) {
 	sctx := loadClassificationPkgsCtx(t)
 	decl := getClassificationModel(sctx, "NullString")

--- a/fixtures/goparsing/classification/models/nomodel.go
+++ b/fixtures/goparsing/classification/models/nomodel.go
@@ -754,3 +754,11 @@ type TextMarshalModel struct {
 	StructStrfmtPtr *MarshalTextStructStrfmtPtr `json:"structStrfmtPtr"`
 	CustomURL       URL                         `json:"customUrl"`
 }
+
+// swagger:type object
+type SomeObjectMap interface{}
+
+// swagger:model namedWithType
+type NamedWithType struct {
+	SomeMap SomeObjectMap `json:"some_map"`
+}


### PR DESCRIPTION
```go
package main

// swagger:model Example
type Example struct {
	MyField map[string]interface{} `json:"my_field,omitempty"`
}
```
should to generate:

```
{
  "swagger": "2.0",
  "paths": {},
  "definitions": {
    "Example": {
      "type": "object",
      "properties": {
        "my_field": {
          "type": "object",
          "additionalProperties": {},
          "x-go-name": "MyField"
        }
      }
    }
  }
}
```

but currently generates:

```
{
  "swagger": "2.0",
  "paths": {},
  "definitions": {
    "Example": {
      "type": "object",
      "properties": {
        "my_field": {
          "type": "object",
          "additionalProperties": {
            "type": "object"
          }
          "x-go-name": "MyField"
        }
      }
    }
  }
}
```

`interface{}` as value in a `map` should be mapped to `any`. This PR fixes this! 

this issue is more described in: #2758