### PR TITLE
Fixes #2740 - Minimum misspelled

### DIFF
--- a/fixtures/goparsing/petstore/models/order.go
+++ b/fixtures/goparsing/petstore/models/order.go
@@ -35,7 +35,7 @@ type Order struct {
 	OrderedAt strfmt.DateTime `json:"orderedAt"`
 
 	// the items for this order
-	// mininum items: 1
+	// minimum items: 1
 	Items []struct {
 
 		// the id of the pet to order


### PR DESCRIPTION
Fixes a little typo in a comment in file fixtures/goparsing/petstore/models/order.go