### PR TITLE
fix WithEnum pass []any as any in variadic function, by asasalint

### DIFF
--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -6,11 +6,9 @@ import (
 	"go/types"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	"golang.org/x/tools/go/ast/astutil"
-
 	"github.com/go-openapi/spec"
+	"github.com/pkg/errors"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 type responseTypable struct {
@@ -82,7 +80,7 @@ func (ht responseTypable) AddExtension(key string, value interface{}) {
 }
 
 func (ht responseTypable) WithEnum(values ...interface{}) {
-	ht.header.WithEnum(values)
+	ht.header.WithEnum(values...)
 }
 
 func (ht responseTypable) WithEnumDescription(desc string) {

--- a/scan/responses.go
+++ b/scan/responses.go
@@ -1,3 +1,4 @@
+//go:build !go1.11
 // +build !go1.11
 
 // Copyright 2015 go-swagger maintainers
@@ -39,7 +40,7 @@ func (ht responseTypable) Typed(tpe, format string) {
 }
 
 func (ht responseTypable) WithEnum(values ...interface{}) {
-	ht.header.WithEnum(values)
+	ht.header.WithEnum(values...)
 }
 
 func bodyTypable(in string, schema *spec.Schema) (swaggerTypable, *spec.Schema) {


### PR DESCRIPTION
see https://github.com/alingse/asasalint for detail
```
asasalint ./...
```
got 
```
go-swagger/codescan/responses.go:85:21: pass []any as any to func(values ...interface{}) *github.com/go-openapi/spec.Header
go-swagger/codescan/application_test.go:159:65: pass []any as any to func(t github.com/stretchr/testify/assert.TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool
...
```
ignore the _test.go file, found one place `WithEnum(values)`


but I don't know it was a mistake or by design ?