### PR TITLE
add option to select custom struct tag for spec-generation

### DIFF
--- a/cmd/swagger/commands/generate/spec_go111.go
+++ b/cmd/swagger/commands/generate/spec_go111.go
@@ -30,6 +30,7 @@ type SpecFile struct {
 	IncludeTags []string       `long:"include-tag" short:"" description:"include routes having specified tags (can be specified many times)"`
 	ExcludeTags []string       `long:"exclude-tag" short:"" description:"exclude routes having specified tags (can be specified many times)"`
 	ExcludeDeps bool           `long:"exclude-deps" short:"" description:"exclude all dependencies of project"`
+	StructTag   string         `long:"struct-tag" short:"" description:"specify which struct tag will be used" default:"json"`
 }
 
 // Execute runs this command
@@ -54,6 +55,8 @@ func (s *SpecFile) Execute(args []string) error {
 	opts.IncludeTags = s.IncludeTags
 	opts.ExcludeTags = s.ExcludeTags
 	opts.ExcludeDeps = s.ExcludeDeps
+	opts.StructTag = s.StructTag
+
 	swspec, err := codescan.Run(&opts)
 	if err != nil {
 		return err

--- a/cmd/swagger/commands/generate/spec_go111_test.go
+++ b/cmd/swagger/commands/generate/spec_go111_test.go
@@ -19,6 +19,10 @@ const (
 	basePath       = "../../../../fixtures/goparsing/spec"
 	jsonResultFile = basePath + "/api_spec_go111.json"
 	yamlResultFile = basePath + "/api_spec_go111.yml"
+
+	customStructTagBasePath       = "../../../../fixtures/goparsing/spec_custom_tag"
+	customStructTagJsonResultFile = customStructTagBasePath + "/api_spec_go111.json"
+	customStructTagYamlResultFile = customStructTagBasePath + "/api_spec_go111.yml"
 )
 
 func TestSpecFileExecute(t *testing.T) {
@@ -27,6 +31,23 @@ func TestSpecFileExecute(t *testing.T) {
 		spec := &SpecFile{
 			WorkDir: basePath,
 			Output:  flags.Filename(outputFile),
+		}
+
+		err := spec.Execute(nil)
+		assert.NoError(t, err)
+		if outputFile != "" {
+			_ = os.Remove(outputFile)
+		}
+	}
+}
+
+func TestSpecFileExecuteWithCustomStructTag(t *testing.T) {
+	files := []string{"", "spec.json", "spec.yml", "spec.yaml"}
+	for _, outputFile := range files {
+		spec := &SpecFile{
+			StructTag: "swagger",
+			WorkDir:   customStructTagBasePath,
+			Output:    flags.Filename(outputFile),
 		}
 
 		err := spec.Execute(nil)
@@ -55,6 +76,25 @@ func TestGenerateJSONSpec(t *testing.T) {
 	verifyJSONData(t, data, expected)
 }
 
+func TestGenerateJSONSpecWithCustomTag(t *testing.T) {
+	opts := codescan.Options{
+		WorkDir:   customStructTagBasePath,
+		Packages:  []string{"./..."},
+		StructTag: "swagger",
+	}
+
+	swspec, err := codescan.Run(&opts)
+	assert.NoError(t, err)
+
+	data, err := marshalToJSONFormat(swspec, true)
+	assert.NoError(t, err)
+
+	expected, err := ioutil.ReadFile(customStructTagJsonResultFile)
+	assert.NoError(t, err)
+
+	verifyJSONData(t, data, expected)
+}
+
 func TestGenerateYAMLSpec(t *testing.T) {
 	opts := codescan.Options{
 		WorkDir:  basePath,
@@ -68,6 +108,25 @@ func TestGenerateYAMLSpec(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected, err := os.ReadFile(yamlResultFile)
+	assert.NoError(t, err)
+
+	verifyYAMLData(t, data, expected)
+}
+
+func TestGenerateYAMLSpecWithCustomStructTag(t *testing.T) {
+	opts := codescan.Options{
+		StructTag: "swagger",
+		WorkDir:   customStructTagBasePath,
+		Packages:  []string{"./..."},
+	}
+
+	swspec, err := codescan.Run(&opts)
+	assert.NoError(t, err)
+
+	data, err := marshalToYAMLFormat(swspec)
+	assert.NoError(t, err)
+
+	expected, err := ioutil.ReadFile(customStructTagYamlResultFile)
 	assert.NoError(t, err)
 
 	verifyYAMLData(t, data, expected)

--- a/codescan/application.go
+++ b/codescan/application.go
@@ -52,11 +52,13 @@ type Options struct {
 	Exclude     []string
 	IncludeTags []string
 	ExcludeTags []string
+	StructTag   string
 }
 
 type scanCtx struct {
-	pkgs []*packages.Package
-	app  *typeIndex
+	pkgs      []*packages.Package
+	app       *typeIndex
+	structTag string
 }
 
 func sliceToSet(names []string) map[string]bool {
@@ -87,6 +89,10 @@ func newScanCtx(opts *Options) (*scanCtx, error) {
 		cfg.BuildFlags = []string{"-tags", opts.BuildTags}
 	}
 
+	if opts.StructTag == "" {
+		opts.StructTag = jsonTag
+	}
+
 	pkgs, err := packages.Load(cfg, opts.Packages...)
 	if err != nil {
 		return nil, err
@@ -100,8 +106,9 @@ func newScanCtx(opts *Options) (*scanCtx, error) {
 	}
 
 	return &scanCtx{
-		pkgs: pkgs,
-		app:  app,
+		pkgs:      pkgs,
+		app:       app,
+		structTag: opts.StructTag,
 	}, nil
 }
 

--- a/codescan/application_test.go
+++ b/codescan/application_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	petstoreCtx       *scanCtx
-	classificationCtx *scanCtx
+	petstoreCtx          *scanCtx
+	petstroeCustomTagCtx *scanCtx
+	classificationCtx    *scanCtx
 )
 
 func loadPetstorePkgsCtx(t testing.TB) *scanCtx {
@@ -26,6 +27,19 @@ func loadPetstorePkgsCtx(t testing.TB) *scanCtx {
 	require.NoError(t, err)
 	petstoreCtx = sctx
 	return petstoreCtx
+}
+
+func loadPetstoreCustomTagPkgsCtx(t testing.TB) *scanCtx {
+	if petstroeCustomTagCtx != nil {
+		return petstroeCustomTagCtx
+	}
+	sctx, err := newScanCtx(&Options{
+		Packages:  []string{"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag/..."},
+		StructTag: "swagger",
+	})
+	require.NoError(t, err)
+	petstroeCustomTagCtx = sctx
+	return petstroeCustomTagCtx
 }
 
 func loadClassificationPkgsCtx(t testing.TB, extra ...string) *scanCtx {
@@ -58,6 +72,19 @@ func TestApplication_LoadCode(t *testing.T) {
 func TestAppScanner_NewSpec(t *testing.T) {
 	doc, err := Run(&Options{
 		Packages: []string{"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore/..."},
+	})
+	require.NoError(t, err)
+	if assert.NotNil(t, doc) {
+		// b, _ := json.MarshalIndent(doc.Responses, "", "  ")
+		// log.Println(string(b))
+		verifyParsedPetStore(t, doc)
+	}
+}
+
+func TestAppScanner_NewSpecWithCustomTag(t *testing.T) {
+	doc, err := Run(&Options{
+		Packages:  []string{"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag/..."},
+		StructTag: "swagger",
 	})
 	require.NoError(t, err)
 	if assert.NotNil(t, doc) {

--- a/codescan/parameters.go
+++ b/codescan/parameters.go
@@ -332,7 +332,7 @@ func (p *parameterBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, 
 			continue
 		}
 
-		name, ignore, _, err := parseJSONTag(afld)
+		name, ignore, _, err := parseCustomTag(afld, p.ctx.structTag)
 		if err != nil {
 			return err
 		}

--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -307,7 +307,7 @@ func (r *responseBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, r
 			continue
 		}
 
-		name, ignore, _, err := parseJSONTag(afld)
+		name, ignore, _, err := parseCustomTag(afld, r.ctx.structTag)
 		if err != nil {
 			return err
 		}

--- a/codescan/schema_test.go
+++ b/codescan/schema_test.go
@@ -29,11 +29,51 @@ func TestSchemaBuilder_Struct_Tag(t *testing.T) {
 	require.NoError(t, prs.Build(result))
 }
 
+func TestSchemaBuilder_Struct_Tag_WithCustomTag(t *testing.T) {
+	sctx := loadPetstoreCustomTagPkgsCtx(t)
+	var td *entityDecl
+	for k := range sctx.app.Models {
+		if k.Name != "Tag" {
+			continue
+		}
+		td = sctx.app.Models[k]
+		break
+	}
+	require.NotNil(t, td)
+
+	prs := &schemaBuilder{
+		ctx:  sctx,
+		decl: td,
+	}
+	result := make(map[string]spec.Schema)
+	require.NoError(t, prs.Build(result))
+}
+
 func TestSchemaBuilder_Struct_Pet(t *testing.T) {
 	// Debug = true
 	// defer func() { Debug = false }()
 
 	sctx := loadPetstorePkgsCtx(t)
+	var td *entityDecl
+	for k := range sctx.app.Models {
+		if k.Name != "Pet" {
+			continue
+		}
+		td = sctx.app.Models[k]
+		break
+	}
+	require.NotNil(t, td)
+
+	prs := &schemaBuilder{
+		ctx:  sctx,
+		decl: td,
+	}
+	result := make(map[string]spec.Schema)
+	require.NoError(t, prs.Build(result))
+}
+
+func TestSchemaBuilder_Struct_Pet_WithCustomTag(t *testing.T) {
+	sctx := loadPetstoreCustomTagPkgsCtx(t)
 	var td *entityDecl
 	for k := range sctx.app.Models {
 		if k.Name != "Pet" {

--- a/fixtures/goparsing/petstore_custom_tag/doc.go
+++ b/fixtures/goparsing/petstore_custom_tag/doc.go
@@ -1,0 +1,44 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package petstore_custom_tag Petstore API.
+//
+// the purpose of this application is to provide an application
+// that is using plain go code to define an API
+//
+// This should demonstrate all the possible comment annotations
+// that are available to turn go code into a fully compliant swagger 2.0 spec
+//
+// Terms Of Service:
+//
+// there are no TOS at this moment, use at your own risk we take no responsibility
+//
+//     Schemes: http, https
+//     Host: localhost
+//     BasePath: /v2
+//     Version: 0.0.1
+//     License: MIT http://opensource.org/licenses/MIT
+//     Contact: John Doe<john.doe@example.com> http://john.doe.com
+//
+//     Consumes:
+//     - application/json
+//
+//     Produces:
+//     - application/json
+//
+// swagger:meta
+package petstore_custom_tag
+
+// APIVersion shows this API's current version
+var APIVersion string

--- a/fixtures/goparsing/petstore_custom_tag/enums/status.go
+++ b/fixtures/goparsing/petstore_custom_tag/enums/status.go
@@ -1,0 +1,25 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enums
+
+// pet status in the store
+// swagger:enum Status
+type Status string
+
+const (
+	STATUS_AVAILABLE Status = "available"
+	STATUS_PENDING   Status = "pending"
+	STATUS_SOLD      Status = "sold"
+)

--- a/fixtures/goparsing/petstore_custom_tag/models/order.go
+++ b/fixtures/goparsing/petstore_custom_tag/models/order.go
@@ -1,0 +1,52 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import "github.com/go-openapi/strfmt"
+
+// An Order for one or more pets by a user.
+// swagger:model order
+type Order struct {
+	// the ID of the order
+	//
+	// required: true
+	ID int64 `swagger:"id"`
+
+	// the id of the user who placed the order.
+	//
+	// required: true
+	UserID int64 `swagger:"userId"`
+
+	// the time at which this order was made.
+	//
+	// required: true
+	OrderedAt strfmt.DateTime `swagger:"orderedAt"`
+
+	// the items for this order
+	// mininum items: 1
+	Items []struct {
+
+		// the id of the pet to order
+		//
+		// required: true
+		PetID int64 `swagger:"petId"`
+
+		// the quantity of this pet to order
+		//
+		// required: true
+		// minimum: 1
+		Quantity int32 `swagger:"qty"`
+	} `swagger:"items"`
+}

--- a/fixtures/goparsing/petstore_custom_tag/models/pet.go
+++ b/fixtures/goparsing/petstore_custom_tag/models/pet.go
@@ -1,0 +1,58 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"time"
+
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag/enums"
+)
+
+// A Pet is the main product in the store.
+// It is used to describe the animals available in the store.
+//
+// swagger:model pet
+type Pet struct {
+	// The id of the pet.
+	//
+	// required: true
+	ID int64 `swagger:"id"`
+
+	// The name of the pet.
+	//
+	// required: true
+	// pattern: \w[\w-]+
+	// minimum length: 3
+	// maximum length: 50
+	Name string `swagger:"name"`
+
+	// The photo urls for the pet.
+	// This only accepts jpeg or png images.
+	//
+	// items pattern: \.(jpe?g|png)$
+	PhotoURLs []string `swagger:"photoUrls,omitempty"`
+
+	// The current status of the pet in the store.
+	Status enums.Status `swagger:"status,omitempty"`
+
+	// Extra bits of information attached to this pet.
+	//
+	Tags []Tag `swagger:"tags,omitempty"`
+
+	// The pet's birthday
+	//
+	// swagger:strfmt date
+	Birthday time.Time `swagger:"birthday"`
+}

--- a/fixtures/goparsing/petstore_custom_tag/models/tag.go
+++ b/fixtures/goparsing/petstore_custom_tag/models/tag.go
@@ -1,0 +1,30 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// A Tag is an extra piece of data to provide more information about a pet.
+// It is used to describe the animals available in the store.
+// swagger:model tag
+type Tag struct {
+	// The id of the tag.
+	//
+	// required: true
+	ID int64 `swagger:"id"`
+
+	// The value of the tag.
+	//
+	// required: true
+	Value string `swagger:"value"`
+}

--- a/fixtures/goparsing/petstore_custom_tag/models/user.go
+++ b/fixtures/goparsing/petstore_custom_tag/models/user.go
@@ -1,0 +1,29 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// A User can purchase pets
+// swagger:model user
+type User struct {
+	// The id of the user.
+	//
+	// required: true
+	ID int64 `swagger:"id"`
+
+	// The name of the user.
+	//
+	// required: true
+	Name string `swagger:"name"`
+}

--- a/fixtures/goparsing/petstore_custom_tag/petstore-fixture/main.go
+++ b/fixtures/goparsing/petstore_custom_tag/petstore-fixture/main.go
@@ -1,0 +1,40 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+
+	petstore "github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag"
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag/rest"
+)
+
+var (
+	// Version is a compile time constant, injected at build time
+	Version string
+)
+
+// This is an application that doesn't actually do anything,
+// it's used for testing the scanner
+func main() {
+	// this has no real purpose besides making the import present in this main package.
+	// without this line the meta info for the swagger doc wouldn't be discovered
+	petstore.APIVersion = Version
+
+	// This servers na hypothetical API
+	if err := rest.ServeAPI(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/fixtures/goparsing/petstore_custom_tag/rest/app.go
+++ b/fixtures/goparsing/petstore_custom_tag/rest/app.go
@@ -1,0 +1,45 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime/middleware/denco"
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag/rest/handlers"
+)
+
+// ServeAPI serves this api
+func ServeAPI() error {
+	mux := denco.NewMux()
+
+	routes := []denco.Handler{
+		mux.GET("/pets", handlers.GetPets),
+		mux.POST("/pets", handlers.CreatePet),
+		mux.GET("/pets/:id", handlers.GetPetByID),
+		mux.PUT("/pets/:id", handlers.UpdatePet),
+		mux.Handler("DELETE", "/pets/:id", handlers.DeletePet),
+		mux.GET("/orders/:id", handlers.GetOrderDetails),
+		mux.POST("/orders", handlers.CreateOrder),
+		mux.PUT("/orders/:id", handlers.UpdateOrder),
+		mux.GET("/help", handlers.GetHelp),
+		mux.Handler("DELETE", "/orders/:id", handlers.CancelOrder),
+	}
+	handler, err := mux.Build(routes)
+	if err != nil {
+		return err
+	}
+	return http.ListenAndServe(":8000", handler)
+}

--- a/fixtures/goparsing/petstore_custom_tag/rest/handlers/orders.go
+++ b/fixtures/goparsing/petstore_custom_tag/rest/handlers/orders.go
@@ -1,0 +1,118 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime/middleware/denco"
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag/models"
+)
+
+// An OrderID parameter model.
+//
+// This is used for operations that want the ID of an order in the path
+// swagger:parameters getOrderDetails cancelOrder updateOrder
+type OrderID struct {
+	// The ID of the order
+	//
+	// in: path
+	// required: true
+	ID int64 `swagger:"id"`
+}
+
+// An OrderBodyParams model.
+//
+// This is used for operations that want an Order as body of the request
+// swagger:parameters updateOrder createOrder
+type OrderBodyParams struct {
+	// The order to submit
+	//
+	// required: true
+	// in: body
+	Order *models.Order `swagger:"order"`
+}
+
+// An OrderResponse response model
+//
+// This is used for returning a response with a single order as body
+//
+// swagger:response orderResponse
+type OrderResponse struct {
+	// in: body
+	Payload *models.Order `swagger:"order"`
+}
+
+// GetOrderDetails swagger:route GET /orders/{id} orders getOrderDetails
+//
+// Gets the details for an order.
+//
+// Responses:
+//    default: genericError
+//        200: orderResponse
+func GetOrderDetails(rw http.ResponseWriter, req *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// CancelOrder swagger:route DELETE /orders/{id} orders cancelOrder
+//
+// Deletes an order.
+//
+// Responses:
+//    default: genericError
+//        204:
+func CancelOrder(rw http.ResponseWriter, req *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// UpdateOrder swagger:route PUT /orders/{id} orders updateOrder
+//
+// Updates an order.
+//
+// Responses:
+//    default: genericError
+//        200: order
+//        422: validationError
+func UpdateOrder(rw http.ResponseWriter, req *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// CreateOrder swagger:route POST /orders orders createOrder
+//
+// Creates an order.
+//
+// Responses:
+//    default: genericError
+//        200: orderResponse
+//        422: validationError
+func CreateOrder(rw http.ResponseWriter, req *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// GetHelp swagger:route GET /help help
+//
+// Gets the help as markdown
+//
+// Responses:
+//    default: genericError
+//        200: MarkdownRender
+//        422: validationError
+func GetHelp(rw http.ResponseWriter, req *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// MarkdownRender is a rendered markdown document
+// swagger:response MarkdownRender
+type MarkdownRender string

--- a/fixtures/goparsing/petstore_custom_tag/rest/handlers/pets.go
+++ b/fixtures/goparsing/petstore_custom_tag/rest/handlers/pets.go
@@ -1,0 +1,146 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/runtime/middleware/denco"
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag/enums"
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/petstore_custom_tag/models"
+)
+
+// A GenericError is the default error message that is generated.
+// For certain status codes there are more appropriate error structures.
+//
+// swagger:response genericError
+type GenericError struct {
+	// in: body
+	Body struct {
+		Code    int32 `swagger:"code"`
+		Message error `swagger:"message"`
+	} `swagger:"body"`
+}
+
+// A ValidationError is an that is generated for validation failures.
+// It has the same fields as a generic error but adds a Field property.
+//
+// swagger:response validationError
+type ValidationError struct {
+	// in: body
+	Body struct {
+		Code    int32  `swagger:"code"`
+		Message string `swagger:"message"`
+		Field   string `swagger:"field"`
+	} `swagger:"body"`
+}
+
+// A PetQueryFlags contains the query flags for things that list pets.
+// swagger:parameters listPets
+type PetQueryFlags struct {
+	// Status
+	Status enums.Status `swagger:"status"`
+
+	// Birthday
+	//
+	// swagger:strfmt date
+	Birthday time.Time `swagger:"birthday"`
+}
+
+// A PetID parameter model.
+//
+// This is used for operations that want the ID of an pet in the path
+// swagger:parameters getPetById deletePet updatePet
+type PetID struct {
+	// The ID of the pet
+	//
+	// in: path
+	// required: true
+	ID int64 `swagger:"id"`
+}
+
+// A PetBodyParams model.
+//
+// This is used for operations that want an Order as body of the request
+// swagger:parameters updatePet createPet
+type PetBodyParams struct {
+	// The pet to submit.
+	//
+	// in: body
+	// required: true
+	Pet *models.Pet `swagger:"pet"`
+}
+
+// GetPets swagger:route GET /pets pets listPets
+//
+// Lists the pets known to the store.
+//
+// By default it will only lists pets that are available for sale.
+// This can be changed with the status flag.
+//
+// Deprecated: true
+// Responses:
+// 		default: genericError
+// 		    200: []pet
+func GetPets(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// GetPetByID swagger:route GET /pets/{id} pets getPetById
+//
+// Gets the details for a pet.
+//
+// Responses:
+//    default: genericError
+//        200: pet
+func GetPetByID(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// CreatePet swagger:route POST /pets pets createPet
+//
+// Creates a new pet in the store.
+//
+// Responses:
+//    default: genericError
+//        200: pet
+//        422: validationError
+func CreatePet(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// UpdatePet swagger:route PUT /pets/{id} pets updatePet
+//
+// Updates the details for a pet.
+//
+// Responses:
+//    default: genericError
+//        200: pet
+//        422: validationError
+func UpdatePet(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// DeletePet swagger:route DELETE /pets/{id} pets deletePet
+//
+// Deletes a pet from the store.
+//
+// Responses:
+//    default: genericError
+//        204:
+func DeletePet(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}

--- a/fixtures/goparsing/petstore_custom_tag/rest/handlers/users.go
+++ b/fixtures/goparsing/petstore_custom_tag/rest/handlers/users.go
@@ -1,0 +1,46 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime/middleware/denco"
+)
+
+// GetUsers handles the list users operation
+func GetUsers(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// GetUserByID gets a user by id
+func GetUserByID(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// CreateUser creates a user
+func CreateUser(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// UpdateUser updates a user
+func UpdateUser(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}
+
+// DeleteUser deletes a user from the store
+func DeleteUser(w http.ResponseWriter, r *http.Request, params denco.Params) {
+	// some actual stuff should happen in here
+}

--- a/fixtures/goparsing/spec_custom_tag/api.go
+++ b/fixtures/goparsing/spec_custom_tag/api.go
@@ -1,0 +1,83 @@
+// Package booking API.
+//
+// the purpose of this application is to provide an application
+// that is using plain go code to define an API
+//
+//
+//     Schemes: https
+//     Host: localhost
+//     Version: 0.0.1
+//
+//     Consumes:
+//     - application/json
+//
+//     Produces:
+//     - application/json
+//
+//
+// swagger:meta
+package spec_custom_tag
+
+import (
+	"github.com/go-swagger/go-swagger/fixtures/goparsing/spec_custom_tag/makeplans"
+	"net/http"
+)
+
+// Customer of the site.
+//
+// swagger:model Customer
+type Customer struct {
+	Name string `swagger:"name"`
+}
+
+// IgnoreMe should not be added to definitions since it is not annotated.
+type IgnoreMe struct {
+	Name string `swagger:"name"`
+}
+
+// DateRange represents a scheduled appointments time
+// DateRange should be in definitions since it's being used in a response
+type DateRange struct {
+	Start string `swagger:"start"`
+	End   string `swagger:"end"`
+}
+
+// BookingResponse represents a scheduled appointment
+//
+// swagger:response BookingResponse
+type BookingResponse struct {
+	// Booking struct
+	//
+	// in: body
+	// required: true
+	Body struct {
+		Booking  makeplans.Booking `swagger:"booking"`
+		Customer Customer          `swagger:"customer"`
+		Dates    DateRange         `swagger:"dates"`
+		// example: {"key": "value"}
+		Map map[string]string `swagger:"map"`
+		// example: [1, 2]
+		Slice []int `swagger:"slice"`
+	}
+}
+
+// Bookings swagger:route GET /admin/bookings/ booking Bookings
+//
+// Bookings lists all the appointments that have been made on the site.
+//
+//
+// Consumes:
+// application/json
+//
+// Deprecated: true
+//
+// Schemes: http, https
+//
+// Produces:
+// application/json
+//
+// Responses:
+// 200: BookingResponse
+func bookings(w http.ResponseWriter, r *http.Request) {
+
+}

--- a/fixtures/goparsing/spec_custom_tag/api_spec_go111.json
+++ b/fixtures/goparsing/spec_custom_tag/api_spec_go111.json
@@ -1,0 +1,134 @@
+{
+  "consumes":[
+    "application/json"
+  ],
+  "produces":[
+    "application/json"
+  ],
+  "schemes":[
+    "https"
+  ],
+  "swagger":"2.0",
+  "info":{
+    "description":"the purpose of this application is to provide an application\nthat is using plain go code to define an API",
+    "title":"API.",
+    "version":"0.0.1"
+  },
+  "host":"localhost",
+  "paths":{
+    "/admin/bookings/":{
+      "get":{
+        "consumes":[
+          "application/json"
+        ],
+        "produces":[
+          "application/json"
+        ],
+        "schemes":[
+          "http",
+          "https"
+        ],
+        "tags":[
+          "booking"
+        ],
+        "summary":"Bookings lists all the appointments that have been made on the site.",
+        "deprecated": true,
+        "operationId":"Bookings",
+        "responses":{
+          "200":{
+            "$ref":"#/responses/BookingResponse"
+          }
+        }
+      }
+    }
+  },
+  "definitions":{
+    "Booking":{
+      "description":"A Booking in the system",
+      "type":"object",
+      "required":[
+        "id",
+        "Subject"
+      ],
+      "properties":{
+        "Subject":{
+          "description":"Subject the subject of this booking",
+          "type":"string"
+        },
+        "id":{
+          "description":"ID the id of the booking",
+          "type":"integer",
+          "format":"int64",
+          "x-go-name":"ID",
+          "readOnly":true
+        }
+      },
+      "x-go-package":"github.com/go-swagger/go-swagger/fixtures/goparsing/spec_custom_tag/makeplans"
+    },
+    "Customer":{
+      "type":"object",
+      "title":"Customer of the site.",
+      "properties":{
+        "name":{
+          "type":"string",
+          "x-go-name":"Name"
+        }
+      },
+      "x-go-package":"github.com/go-swagger/go-swagger/fixtures/goparsing/spec_custom_tag"
+    },
+    "DateRange":{
+      "description":"DateRange represents a scheduled appointments time\nDateRange should be in definitions since it's being used in a response",
+      "type":"object",
+      "properties":{
+        "end":{
+          "type":"string",
+          "x-go-name":"End"
+        },
+        "start":{
+          "type":"string",
+          "x-go-name":"Start"
+        }
+      },
+      "x-go-package":"github.com/go-swagger/go-swagger/fixtures/goparsing/spec_custom_tag"
+    }
+  },
+  "responses":{
+    "BookingResponse":{
+      "description":"BookingResponse represents a scheduled appointment",
+      "schema":{
+        "type":"object",
+        "properties":{
+          "booking":{
+            "$ref":"#/definitions/Booking"
+          },
+          "customer":{
+            "$ref":"#/definitions/Customer"
+          },
+          "dates":{
+            "$ref":"#/definitions/DateRange"
+          },
+          "map": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "example": {"key": "value"},
+            "x-go-name": "Map"
+          },
+          "slice": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "x-go-name": "Slice",
+            "example": [
+              1,
+              2
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/fixtures/goparsing/spec_custom_tag/api_spec_go111.yml
+++ b/fixtures/goparsing/spec_custom_tag/api_spec_go111.yml
@@ -1,0 +1,99 @@
+consumes:
+  - application/json
+produces:
+  - application/json
+schemes:
+  - https
+swagger: '2.0'
+info:
+  description: |-
+    the purpose of this application is to provide an application
+    that is using plain go code to define an API
+  title: API.
+  version: 0.0.1
+host: localhost
+paths:
+  "/admin/bookings/":
+    get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      schemes:
+        - http
+        - https
+      tags:
+        - booking
+      summary: Bookings lists all the appointments that have been made on the site.
+      deprecated: true
+      operationId: Bookings
+      responses:
+        '200':
+          "$ref": "#/responses/BookingResponse"
+definitions:
+  Booking:
+    description: A Booking in the system
+    type: object
+    required:
+      - id
+      - Subject
+    properties:
+      Subject:
+        description: Subject the subject of this booking
+        type: string
+      id:
+        description: ID the id of the booking
+        type: integer
+        format: int64
+        x-go-name: ID
+        readOnly: true
+    x-go-package:  github.com/go-swagger/go-swagger/fixtures/goparsing/spec_custom_tag/makeplans
+  Customer:
+    type: object
+    title: Customer of the site.
+    properties:
+      name:
+        type: string
+        x-go-name: Name
+    x-go-package: github.com/go-swagger/go-swagger/fixtures/goparsing/spec_custom_tag
+  DateRange:
+    description: |-
+      DateRange represents a scheduled appointments time
+      DateRange should be in definitions since it's being used in a response
+    type: object
+    properties:
+      end:
+        type: string
+        x-go-name: End
+      start:
+        type: string
+        x-go-name: Start
+    x-go-package: github.com/go-swagger/go-swagger/fixtures/goparsing/spec_custom_tag
+responses:
+  BookingResponse:
+    description: BookingResponse represents a scheduled appointment
+    schema:
+      type: object
+      properties:
+        booking:
+          "$ref": "#/definitions/Booking"
+        customer:
+          "$ref": "#/definitions/Customer"
+        dates:
+          "$ref": "#/definitions/DateRange"
+        map:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            key: value
+          x-go-name: Map
+        slice:
+          type: array
+          items:
+            type: integer
+            format: int64
+          x-go-name: Slice
+          example:
+            - 1
+            - 2

--- a/fixtures/goparsing/spec_custom_tag/makeplans/booking.go
+++ b/fixtures/goparsing/spec_custom_tag/makeplans/booking.go
@@ -1,0 +1,14 @@
+package makeplans
+
+// A Booking in the system
+type Booking struct {
+	// ID the id of the booking
+	//
+	// required: true
+	// read only: true
+	ID int64 `swagger:"id,omitempty"`
+
+	// Subject the subject of this booking
+	// required: true
+	Subject string
+}


### PR DESCRIPTION
Hi All,

First, thanks for this library. It makes many things easier to implement.

I'm using go-swagger to generate swagger files from the code for almost 3 years. I've been searching for a way to provide custom names other than JSON tag and field name for a while. I thought that providing a custom struct tag while generating spec would be awesome.

Example:

Let's say I've struct like

```go

type CreateUserRequest struct {
       XForwardedFor []string `json:"X-Forwarded-For" header:"X-Forwarded-For"`
       FirstName string `json:"firstName"`
}
```
I'm decoding the request according to the `json, header, query` tags. But I have to add the JSON tag to `XForwardedFor` field to show it in the swagger with the correct name. In this scenario, the client can override the XForwardedFor header by sending `X-Forwarded-For` field in the body. I think `--struct-tag` option can be useful in anyways. 


Usage:
`swagger generate spec -o ./docs/swagger.yaml --scan-models -w ./examples/generated --struct-tag swg`

With `--struct-tag swg` struct will look like 

```go
type CreateUserRequest struct {
       XForwardedFor []string `header:"X-Forwarded-For" swg:"X-Forwarded-For"`
       FirstName string `json:"firstName" swg:"firstName"`
}
```


Signed-off-by: furkan <fufuceng@gmail.com>