### PR TITLE
made up for missing packages from template

### DIFF
--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -9,7 +9,10 @@ package {{ .APIPackage }}
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"


### PR DESCRIPTION
revised version of https://github.com/go-swagger/go-swagger/pull/2775

When execute `swagger generate support` on the environment without Go and its runtime source,
it will be failed with this messages.

```
2022/05/16 15:47:25 source formatting failed on template-generated source ("restapi\\server.go" for server). Check that your template produces valid code
2022/05/16 15:47:25 unformatted generated source "server.go" has been dumped for template debugging purposes. DO NOT build on this source!
source formatting on generated source "server" failed: err: go command required, not found: exec: "go": executable file not found in %PATH%: stderr:
```

This came from missing packages to imports in the template of server.go.
(the formatter would requrie Go's source code to complete those packages)

This PR make up for those missing packages.