### PR TITLE
Fix #2800 Update key import method for debian

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -91,8 +91,8 @@ without sudo:
 
 ```sh
 apt update
-apt install -y apt-transport-https gnupg curl
-curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | apt-key add -
+apt install -y apt-transport-https gnupg curl debian-keyring debian-archive-keyring
+curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | gpg --dearmor -o /usr/share/keyrings/go-swagger-go-swagger-archive-keyring.gpg
 curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/config.deb.txt?distro=debian&codename=any-version' > /etc/apt/sources.list.d/go-swagger-go-swagger.list
 apt update 
 apt install swagger
@@ -102,8 +102,8 @@ with sudo:
 
 ```sh
 sudo apt update
-sudo apt install -y apt-transport-https gnupg curl
-curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | sudo apt-key add -
+sudo apt install -y apt-transport-https gnupg curl debian-keyring debian-archive-keyring
+curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/gpg.2F8CB673971B5C9E.key' | sudo gpg --dearmor -o /usr/share/keyrings/go-swagger-go-swagger-archive-keyring.gpg
 curl -1sLf 'https://dl.cloudsmith.io/public/go-swagger/go-swagger/config.deb.txt?distro=debian&codename=any-version' | sudo tee /etc/apt/sources.list.d/go-swagger-go-swagger.list
 sudo apt update 
 sudo apt install swagger


### PR DESCRIPTION
Fix #2800 

This is similar to https://github.com/caddyserver/dist/issues/83, so I fixed it by adapting their solution. Tested on fresh Ubuntu 22.04 VPS.