### PR TITLE
Support for extensions within swagger:parameters

### DIFF
--- a/codescan/parameters.go
+++ b/codescan/parameters.go
@@ -285,6 +285,14 @@ func (p *parameterBuilder) buildFromField(fld *types.Var, tpe types.Type, typabl
 	}
 }
 
+func spExtensionsSetter(ps *spec.Parameter) func(*spec.Extensions) {
+	return func(exts *spec.Extensions) {
+		for name, value := range *exts {
+			addExtension(&ps.VendorExtensible, name, value)
+		}
+	}
+}
+
 func (p *parameterBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, op *spec.Operation, seen map[string]spec.Parameter) error {
 	if tpe.NumFields() == 0 {
 		return nil
@@ -396,7 +404,7 @@ func (p *parameterBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, 
 				newSingleLineTagParser("default", &setDefault{&ps.SimpleSchema, paramValidations{&ps}, rxf(rxDefaultFmt, "")}),
 				newSingleLineTagParser("example", &setExample{&ps.SimpleSchema, paramValidations{&ps}, rxf(rxExampleFmt, "")}),
 				newSingleLineTagParser("required", &setRequiredParam{&ps}),
-				newMultiLineTagParser("Extensions", newSetExtensions(opExtensionsSetter(op)), true),
+				newMultiLineTagParser("Extensions", newSetExtensions(spExtensionsSetter(&ps)), true),
 			}
 
 			itemsTaggers := func(items *spec.Items, level int) []tagParser {
@@ -472,10 +480,10 @@ func (p *parameterBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, 
 			}
 
 		} else {
-
 			sp.taggers = []tagParser{
 				newSingleLineTagParser("in", &matchOnlyParam{&ps, rxIn}),
 				newSingleLineTagParser("required", &matchOnlyParam{&ps, rxRequired}),
+				newMultiLineTagParser("Extensions", newSetExtensions(spExtensionsSetter(&ps)), true),
 			}
 		}
 		if err := sp.Parse(afld.Doc); err != nil {

--- a/codescan/parameters.go
+++ b/codescan/parameters.go
@@ -396,6 +396,7 @@ func (p *parameterBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, 
 				newSingleLineTagParser("default", &setDefault{&ps.SimpleSchema, paramValidations{&ps}, rxf(rxDefaultFmt, "")}),
 				newSingleLineTagParser("example", &setExample{&ps.SimpleSchema, paramValidations{&ps}, rxf(rxExampleFmt, "")}),
 				newSingleLineTagParser("required", &setRequiredParam{&ps}),
+				newMultiLineTagParser("Extensions", newSetExtensions(opExtensionsSetter(op)), true),
 			}
 
 			itemsTaggers := func(items *spec.Items, level int) []tagParser {

--- a/docs/use/spec/params.md
+++ b/docs/use/spec/params.md
@@ -40,6 +40,7 @@ Annotation | Format
 **Unique** | when set to true the slice can only contain unique items
 **Required** | when set to true this value needs to be present in the request
 **Example** | an example value, parsed as the field's type<br/>(objects and slices are parsed as JSON)
+**Extensions** | a dictionary of custom [vendor extensions](https://swagger.io/docs/specification/2-0/swagger-extensions/); each key must start with `x-`
 
 For slice properties there are also items to be defined. This might be a nested collection, for indicating nesting
 level the value is a 0-based index, so items.minLength is the same as items.0.minLength
@@ -76,6 +77,12 @@ type BarSliceParam struct {
 	// collection format: pipe
 	// in: query
 	// example: [[["bar_000"]]]
+  // Extensions:
+  //   x-example-flag: true
+  //   x-some-list:
+  //     - dog
+  //     - cat
+  //     - bird
 	BarSlice [][][]string `json:"bar_slice"`
 }
 ```
@@ -111,6 +118,12 @@ operations:
                 minLength: 3
                 maxLength: 10
                 pattern: "\\w+"
+          extensions:
+            x-example-flag: true
+            x-some-list:
+              - dog
+              - cat
+              - bird
     post:
       operationId: addBars
       parameters:
@@ -136,4 +149,10 @@ operations:
                 minLength: 3
                 maxLength: 10
                 pattern: "\\w+"
+          extensions:
+            x-example-flag: true
+            x-some-list:
+              - dog
+              - cat
+              - bird
 ```


### PR DESCRIPTION
## Summary
Related to https://github.com/go-swagger/go-swagger/pull/2751.  

For i18n document,  `route` almost can include more information, now I want the `parameter` has more information.

## Example
Example
Input:
```go
// swagger:parameters listPets
type FooParam struct {
	// Bar parameter in query
	// Required: true
	// Extensions:
	//   x-description-i18n:
	//     cn: 一个参数
	Bar string `query:"bar"`
}
```
Output:
```go
paths:
  "/pets":
    get:
#       ...other info
      parameters:
        - description: Bar parameter in query
          in: query
          name: Bar
          required: true
          type: string
          x-description-i18n:
            cn: 一个参数
```