### PR TITLE
build without -trimpath because it causes issues when generating a spec

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -244,22 +244,19 @@ jobs:
             if [[ $1 == "windows" ]]; then
               out="${out}.exe"
             fi
-            GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -trimpath -ldflags "$LDFLAGS" -tags osusergo,netgo -o "./dist/bin/$out" ./cmd/swagger
+            GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -tags osusergo,netgo -o "./dist/bin/$out" ./cmd/swagger
           }
 
           go mod download
 
-          build_binary linux amd64 &
-          build_binary linux arm64 &
-          build_binary linux arm &
-          build_binary linux ppc64le &
-          wait
-          build_binary darwin amd64 &
-          build_binary darwin arm64 &
-          wait
-          build_binary windows amd64 &
-          build_binary windows arm64 &
-          wait
+          build_binary linux amd64
+          build_binary linux arm64
+          build_binary linux arm
+          build_binary linux ppc64le
+          build_binary darwin amd64
+          build_binary darwin arm64
+          build_binary windows amd64
+          build_binary windows arm64
 
           nfpm p -p deb -t dist/build
           nfpm p -p rpm -t dist/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk --no-cache add ca-certificates shared-mime-info mailcap git build-base b
 RUN mkdir -p bin &&\
   LDFLAGS="$LDFLAGS -X github.com/go-swagger/go-swagger/cmd/swagger/commands.Commit=${commit_hash}" &&\
   LDFLAGS="$LDFLAGS -X github.com/go-swagger/go-swagger/cmd/swagger/commands.Version=${tag_name}" &&\
-  CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -tags osusergo,netgo -o bin/swagger -ldflags "$LDFLAGS" -a ./cmd/swagger
+  CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags osusergo,netgo -o bin/swagger -ldflags "$LDFLAGS" -a ./cmd/swagger
 
 FROM --platform=$TARGETPLATFORM golang:alpine
 


### PR DESCRIPTION
fixes #2838 
fixes #2841 
fixes #2842 