### PR TITLE
Configurable consumers in stratoscale templates

### DIFF
--- a/examples/contributed-templates/stratoscale/restapi/configure_petstore.go
+++ b/examples/contributed-templates/stratoscale/restapi/configure_petstore.go
@@ -85,6 +85,9 @@ type Config struct {
 	BasicAuthenticator func(security.UserPassAuthentication) runtime.Authenticator
 	// Authenticator to use for all Basic authentication
 	BearerAuthenticator func(string, security.ScopedTokenAuthentication) runtime.Authenticator
+
+	// JSONConsumer is a json consumer that will replace the default if not nil.
+	JSONConsumer runtime.Consumer
 }
 
 // Handler returns an http.Handler given the handler configuration
@@ -116,7 +119,11 @@ func HandlerAPI(c Config) (http.Handler, *operations.PetstoreAPI, error) {
 		api.BearerAuthenticator = c.BearerAuthenticator
 	}
 
-	api.JSONConsumer = runtime.JSONConsumer()
+	if c.JSONConsumer != nil {
+		api.JSONConsumer = c.JSONConsumer
+	} else {
+		api.JSONConsumer = runtime.JSONConsumer()
+	}
 	api.JSONProducer = runtime.JSONProducer()
 	api.RolesAuth = func(token string) (interface{}, error) {
 		if c.AuthRoles == nil {

--- a/examples/contributed-templates/stratoscale/restapi/operations/pet/pet_create_parameters.go
+++ b/examples/contributed-templates/stratoscale/restapi/operations/pet/pet_create_parameters.go
@@ -6,7 +6,6 @@ package pet
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -66,7 +65,7 @@ func (o *PetCreateParams) BindRequest(r *http.Request, route *middleware.Matched
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/contributed-templates/stratoscale/restapi/operations/pet/pet_update_parameters.go
+++ b/examples/contributed-templates/stratoscale/restapi/operations/pet/pet_update_parameters.go
@@ -6,7 +6,6 @@ package pet
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -66,7 +65,7 @@ func (o *PetUpdateParams) BindRequest(r *http.Request, route *middleware.Matched
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/contributed-templates/stratoscale/restapi/operations/store/order_create_parameters.go
+++ b/examples/contributed-templates/stratoscale/restapi/operations/store/order_create_parameters.go
@@ -6,7 +6,6 @@ package store
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -66,7 +65,7 @@ func (o *OrderCreateParams) BindRequest(r *http.Request, route *middleware.Match
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/generator/templates/contrib/stratoscale/server/configureapi.gotmpl
+++ b/generator/templates/contrib/stratoscale/server/configureapi.gotmpl
@@ -80,6 +80,13 @@ type Config struct {
 	BasicAuthenticator func(security.UserPassAuthentication) runtime.Authenticator
 	// Authenticator to use for all Basic authentication
 	BearerAuthenticator func(string, security.ScopedTokenAuthentication) runtime.Authenticator
+
+	{{ range .Consumes -}}
+	{{ if .Implementation -}}
+	// {{ pascalize .Name }}Consumer is a {{ .Name }} consumer that will replace the default if not nil.
+	{{ pascalize .Name }}Consumer runtime.Consumer
+	{{ end -}}
+	{{ end -}}
 }
 
 // Handler returns an http.Handler given the handler configuration
@@ -112,13 +119,17 @@ func HandlerAPI(c Config) (http.Handler, *{{.Package}}.{{ pascalize .Name }}API,
 	}
 
 	{{ range .Consumes -}}
-	{{ if .Implementation -}}
-	api.{{ pascalize .Name }}Consumer = {{ .Implementation }}
-	{{ else }}
-	api.{{ pascalize .Name }}Consumer = runtime.ConsumerFunc(func(r io.Reader, target interface{}) error {
-		return errors.NotImplemented("{{.Name}} consumer has not yet been implemented")
-	})
-	{{ end -}}
+	if c.{{ pascalize .Name }}Consumer != nil {
+		api.{{ pascalize .Name }}Consumer = c.{{ pascalize .Name }}Consumer
+	} else {
+		{{ if .Implementation -}}
+		api.{{ pascalize .Name }}Consumer = {{ .Implementation }}
+		{{ else }}
+		api.{{ pascalize .Name }}Consumer = runtime.ConsumerFunc(func(r io.Reader, target interface{}) error {
+			return errors.NotImplemented("{{.Name}} consumer has not yet been implemented")
+		})
+		{{ end -}}
+	}
 	{{ end -}}
 	{{ range .Produces -}}
 	{{ if .Implementation -}}


### PR DESCRIPTION
Currently the configuration code generated by the _stratoscale_ templates doesn't allow changing the consumers before creating the handler. This makes it difficult to use custom consumers. For example, we would like to use a JSON consumer that rejects unknown fields. To make that easier this patch changes the templates so that the _Config_ object that is passed to the _Handler_ function has additional fields to specify those custom consumers. With that in place we will be able to do something like this:

```go
// myConsumer is a consumer function that rejects unknown fields.
func myConsumer() runtime.Consumer {
        return runtime.ConsumerFunc(func(reader io.Reader, data interface{}) error {
                dec := json.NewDecoder(reader)
                dec.UseNumber()
                dec.DisallowUnknownFields()
                return dec.Decode(data)
        })
}

// Create the handler using our custom consumer:
handler, err := restapi.Handler(restapi.Config{
	....
	JSONConsumer: myConsumer(),
})
```

Existing code will not be affected because the default value for this new `JSONConsumer` field will be nil, and that results in the same behaviour than before this change.