### PR TITLE
fix route extensions not being parsed

### DIFF
--- a/fixtures/goparsing/classification/operations/todo_operation.go
+++ b/fixtures/goparsing/classification/operations/todo_operation.go
@@ -103,16 +103,16 @@ func ServeAPI(host, basePath string, schemes []string) error {
 	// Extensions:
 	// x-some-flag: false
 	// x-some-list:
-	//	- item1
-	//	- item2
-	//	- item3
+	//   - item1
+	//   - item2
+	//   - item3
 	// x-some-object:
-	//	key1: value1
-	//	key2: value2
-	//	subobject:
-	//		subkey1: subvalue1
-	//		subkey2: subvalue2
-	//	key3: value3
+	//   key1: value1
+	//   key2: value2
+	//   subobject:
+	//     subkey1: subvalue1
+	//     subkey2: subvalue2
+	//   key3: value3
 	mountItem("GET", basePath+"/orders", nil)
 
 	// swagger:route POST /orders orders createOrder

--- a/scan/routes.go
+++ b/scan/routes.go
@@ -74,6 +74,12 @@ type routesParser struct {
 	parameters  []*spec.Parameter
 }
 
+var routeVendorExtensibleParser = vendorExtensibleParser{
+	setExtensions: func(ext spec.Extensions, dest interface{}) {
+		dest.(*spec.Operation).Extensions = ext
+	},
+}
+
 func (rp *routesParser) Parse(gofile *ast.File, target interface{}, includeTags map[string]bool, excludeTags map[string]bool) error {
 	tgt := target.(*spec.Paths)
 	for _, comsec := range gofile.Comments {
@@ -109,6 +115,7 @@ func (rp *routesParser) Parse(gofile *ast.File, target interface{}, includeTags 
 			newMultiLineTagParser("Security", newSetSecurity(rxSecuritySchemes, opSecurityDefsSetter(op)), false),
 			newMultiLineTagParser("Parameters", spa, false),
 			newMultiLineTagParser("Responses", sr, false),
+			newMultiLineTagParser("YAMLExtensionsBlock", newYamlParser(rxExtensions, routeVendorExtensibleParser.ParseInto(op)), true),
 		}
 		if err := sp.Parse(content.Remaining); err != nil {
 			return fmt.Errorf("operation (%s): %v", op.ID, err)

--- a/scan/routes_test.go
+++ b/scan/routes_test.go
@@ -56,6 +56,11 @@ func TestRoutesParser(t *testing.T) {
 		[]string{"pets", "users"},
 		[]string{"read", "write"},
 	)
+	expectedListPetsExtensions := spec.Extensions{
+		"x-some-flag": true,
+	}
+	assert.EqualValues(t, expectedListPetsExtensions, po.Get.Extensions)
+
 	assertOperation(t,
 		po.Post,
 		"createPet",
@@ -76,6 +81,25 @@ func TestRoutesParser(t *testing.T) {
 		[]string{"orders"},
 		[]string{"orders:read", "https://www.googleapis.com/auth/userinfo.email"},
 	)
+	expectedListOrderExtensions := spec.Extensions{
+		"x-some-flag": false,
+		"x-some-list": []interface{}{
+			"item1",
+			"item2",
+			"item3",
+		},
+		"x-some-object": map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+			"subobject": map[string]interface{}{
+				"subkey1": "subvalue1",
+				"subkey2": "subvalue2",
+			},
+			"key3": "value3",
+		},
+	}
+	assert.EqualValues(t, expectedListOrderExtensions, po.Get.Extensions)
+
 	assertOperation(t,
 		po.Post,
 		"createOrder",

--- a/scan/schema.go
+++ b/scan/schema.go
@@ -18,7 +18,6 @@
 package scan
 
 import (
-	"encoding/json"
 	"fmt"
 	"go/ast"
 	"log"
@@ -744,21 +743,10 @@ func (scp *schemaParser) parseStructType(gofile *ast.File, bschema *spec.Schema,
 	return nil
 }
 
-func schemaVendorExtensibleSetter(meta *spec.Schema) func(json.RawMessage) error {
-	return func(jsonValue json.RawMessage) error {
-		var jsonData spec.Extensions
-		err := json.Unmarshal(jsonValue, &jsonData)
-		if err != nil {
-			return err
-		}
-		for k := range jsonData {
-			if !rxAllowedExtensions.MatchString(k) {
-				return fmt.Errorf("invalid schema extension name, should start from `x-`: %s", k)
-			}
-		}
-		meta.Extensions = jsonData
-		return nil
-	}
+var schemaVendorExtensibleParser = vendorExtensibleParser{
+	setExtensions: func(ext spec.Extensions, dest interface{}) {
+		dest.(*spec.Schema).Extensions = ext
+	},
 }
 
 func (scp *schemaParser) createParser(nm string, schema, ps *spec.Schema, fld *ast.Field) *sectionedParser {
@@ -788,7 +776,7 @@ func (scp *schemaParser) createParser(nm string, schema, ps *spec.Schema, fld *a
 			newSingleLineTagParser("required", &setRequiredSchema{schema, nm}),
 			newSingleLineTagParser("readOnly", &setReadOnlySchema{ps}),
 			newSingleLineTagParser("discriminator", &setDiscriminator{schema, nm}),
-			newMultiLineTagParser("YAMLExtensionsBlock", newYamlParser(rxExtensions, schemaVendorExtensibleSetter(ps)), true),
+			newMultiLineTagParser("YAMLExtensionsBlock", newYamlParser(rxExtensions, schemaVendorExtensibleParser.ParseInto(ps)), true),
 		}
 
 		itemsTaggers := func(items *spec.Schema, level int) []tagParser {


### PR DESCRIPTION
The tests I added in `scan/routes_test.go` used to fail, because the extensions put in routes weren't being parsed.

This PR fixes those tests - it makes the extensions be properly parsed.