### PR TITLE
Make stratoscale template easier to test

### DIFF
--- a/examples/contributed-templates/stratoscale/client/pet/pet_client.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_client.go
@@ -13,7 +13,7 @@ import (
 	strfmt "github.com/go-openapi/strfmt"
 )
 
-//go:generate mockery -name API -inpkg
+//go:generate mockery --name API --keeptree --with-expecter --case underscore
 
 // API is the interface of the pet client
 type API interface {

--- a/examples/contributed-templates/stratoscale/client/pet/pet_create_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_create_responses.go
@@ -46,7 +46,7 @@ func NewPetCreateCreated() *PetCreateCreated {
 }
 
 /*
-	PetCreateCreated describes a response with status code 201, with default header values.
+PetCreateCreated describes a response with status code 201, with default header values.
 
 Created
 */
@@ -54,27 +54,27 @@ type PetCreateCreated struct {
 	Payload *models.Pet
 }
 
-// IsSuccess returns true when this pet create created response returns a 2xx status code
+// IsSuccess returns true when this pet create created response has a 2xx status code
 func (o *PetCreateCreated) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this pet create created response returns a 3xx status code
+// IsRedirect returns true when this pet create created response has a 3xx status code
 func (o *PetCreateCreated) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet create created response returns a 4xx status code
+// IsClientError returns true when this pet create created response has a 4xx status code
 func (o *PetCreateCreated) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this pet create created response returns a 5xx status code
+// IsServerError returns true when this pet create created response has a 5xx status code
 func (o *PetCreateCreated) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet create created response returns a 4xx status code
+// IsCode returns true when this pet create created response a status code equal to that given
 func (o *PetCreateCreated) IsCode(code int) bool {
 	return code == 201
 }
@@ -109,34 +109,34 @@ func NewPetCreateMethodNotAllowed() *PetCreateMethodNotAllowed {
 }
 
 /*
-	PetCreateMethodNotAllowed describes a response with status code 405, with default header values.
+PetCreateMethodNotAllowed describes a response with status code 405, with default header values.
 
 Invalid input
 */
 type PetCreateMethodNotAllowed struct {
 }
 
-// IsSuccess returns true when this pet create method not allowed response returns a 2xx status code
+// IsSuccess returns true when this pet create method not allowed response has a 2xx status code
 func (o *PetCreateMethodNotAllowed) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet create method not allowed response returns a 3xx status code
+// IsRedirect returns true when this pet create method not allowed response has a 3xx status code
 func (o *PetCreateMethodNotAllowed) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet create method not allowed response returns a 4xx status code
+// IsClientError returns true when this pet create method not allowed response has a 4xx status code
 func (o *PetCreateMethodNotAllowed) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet create method not allowed response returns a 5xx status code
+// IsServerError returns true when this pet create method not allowed response has a 5xx status code
 func (o *PetCreateMethodNotAllowed) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet create method not allowed response returns a 4xx status code
+// IsCode returns true when this pet create method not allowed response a status code equal to that given
 func (o *PetCreateMethodNotAllowed) IsCode(code int) bool {
 	return code == 405
 }

--- a/examples/contributed-templates/stratoscale/client/pet/pet_delete_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_delete_responses.go
@@ -49,34 +49,34 @@ func NewPetDeleteNoContent() *PetDeleteNoContent {
 }
 
 /*
-	PetDeleteNoContent describes a response with status code 204, with default header values.
+PetDeleteNoContent describes a response with status code 204, with default header values.
 
 Deleted successfully
 */
 type PetDeleteNoContent struct {
 }
 
-// IsSuccess returns true when this pet delete no content response returns a 2xx status code
+// IsSuccess returns true when this pet delete no content response has a 2xx status code
 func (o *PetDeleteNoContent) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this pet delete no content response returns a 3xx status code
+// IsRedirect returns true when this pet delete no content response has a 3xx status code
 func (o *PetDeleteNoContent) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet delete no content response returns a 4xx status code
+// IsClientError returns true when this pet delete no content response has a 4xx status code
 func (o *PetDeleteNoContent) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this pet delete no content response returns a 5xx status code
+// IsServerError returns true when this pet delete no content response has a 5xx status code
 func (o *PetDeleteNoContent) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet delete no content response returns a 4xx status code
+// IsCode returns true when this pet delete no content response a status code equal to that given
 func (o *PetDeleteNoContent) IsCode(code int) bool {
 	return code == 204
 }
@@ -100,34 +100,34 @@ func NewPetDeleteBadRequest() *PetDeleteBadRequest {
 }
 
 /*
-	PetDeleteBadRequest describes a response with status code 400, with default header values.
+PetDeleteBadRequest describes a response with status code 400, with default header values.
 
 Invalid ID supplied
 */
 type PetDeleteBadRequest struct {
 }
 
-// IsSuccess returns true when this pet delete bad request response returns a 2xx status code
+// IsSuccess returns true when this pet delete bad request response has a 2xx status code
 func (o *PetDeleteBadRequest) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet delete bad request response returns a 3xx status code
+// IsRedirect returns true when this pet delete bad request response has a 3xx status code
 func (o *PetDeleteBadRequest) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet delete bad request response returns a 4xx status code
+// IsClientError returns true when this pet delete bad request response has a 4xx status code
 func (o *PetDeleteBadRequest) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet delete bad request response returns a 5xx status code
+// IsServerError returns true when this pet delete bad request response has a 5xx status code
 func (o *PetDeleteBadRequest) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet delete bad request response returns a 4xx status code
+// IsCode returns true when this pet delete bad request response a status code equal to that given
 func (o *PetDeleteBadRequest) IsCode(code int) bool {
 	return code == 400
 }
@@ -151,34 +151,34 @@ func NewPetDeleteNotFound() *PetDeleteNotFound {
 }
 
 /*
-	PetDeleteNotFound describes a response with status code 404, with default header values.
+PetDeleteNotFound describes a response with status code 404, with default header values.
 
 Pet not found
 */
 type PetDeleteNotFound struct {
 }
 
-// IsSuccess returns true when this pet delete not found response returns a 2xx status code
+// IsSuccess returns true when this pet delete not found response has a 2xx status code
 func (o *PetDeleteNotFound) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet delete not found response returns a 3xx status code
+// IsRedirect returns true when this pet delete not found response has a 3xx status code
 func (o *PetDeleteNotFound) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet delete not found response returns a 4xx status code
+// IsClientError returns true when this pet delete not found response has a 4xx status code
 func (o *PetDeleteNotFound) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet delete not found response returns a 5xx status code
+// IsServerError returns true when this pet delete not found response has a 5xx status code
 func (o *PetDeleteNotFound) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet delete not found response returns a 4xx status code
+// IsCode returns true when this pet delete not found response a status code equal to that given
 func (o *PetDeleteNotFound) IsCode(code int) bool {
 	return code == 404
 }

--- a/examples/contributed-templates/stratoscale/client/pet/pet_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_get_responses.go
@@ -52,7 +52,7 @@ func NewPetGetOK() *PetGetOK {
 }
 
 /*
-	PetGetOK describes a response with status code 200, with default header values.
+PetGetOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -60,27 +60,27 @@ type PetGetOK struct {
 	Payload *models.Pet
 }
 
-// IsSuccess returns true when this pet get o k response returns a 2xx status code
+// IsSuccess returns true when this pet get o k response has a 2xx status code
 func (o *PetGetOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this pet get o k response returns a 3xx status code
+// IsRedirect returns true when this pet get o k response has a 3xx status code
 func (o *PetGetOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet get o k response returns a 4xx status code
+// IsClientError returns true when this pet get o k response has a 4xx status code
 func (o *PetGetOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this pet get o k response returns a 5xx status code
+// IsServerError returns true when this pet get o k response has a 5xx status code
 func (o *PetGetOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet get o k response returns a 4xx status code
+// IsCode returns true when this pet get o k response a status code equal to that given
 func (o *PetGetOK) IsCode(code int) bool {
 	return code == 200
 }
@@ -115,34 +115,34 @@ func NewPetGetBadRequest() *PetGetBadRequest {
 }
 
 /*
-	PetGetBadRequest describes a response with status code 400, with default header values.
+PetGetBadRequest describes a response with status code 400, with default header values.
 
 Invalid ID supplied
 */
 type PetGetBadRequest struct {
 }
 
-// IsSuccess returns true when this pet get bad request response returns a 2xx status code
+// IsSuccess returns true when this pet get bad request response has a 2xx status code
 func (o *PetGetBadRequest) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet get bad request response returns a 3xx status code
+// IsRedirect returns true when this pet get bad request response has a 3xx status code
 func (o *PetGetBadRequest) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet get bad request response returns a 4xx status code
+// IsClientError returns true when this pet get bad request response has a 4xx status code
 func (o *PetGetBadRequest) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet get bad request response returns a 5xx status code
+// IsServerError returns true when this pet get bad request response has a 5xx status code
 func (o *PetGetBadRequest) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet get bad request response returns a 4xx status code
+// IsCode returns true when this pet get bad request response a status code equal to that given
 func (o *PetGetBadRequest) IsCode(code int) bool {
 	return code == 400
 }
@@ -166,34 +166,34 @@ func NewPetGetNotFound() *PetGetNotFound {
 }
 
 /*
-	PetGetNotFound describes a response with status code 404, with default header values.
+PetGetNotFound describes a response with status code 404, with default header values.
 
 Pet not found
 */
 type PetGetNotFound struct {
 }
 
-// IsSuccess returns true when this pet get not found response returns a 2xx status code
+// IsSuccess returns true when this pet get not found response has a 2xx status code
 func (o *PetGetNotFound) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet get not found response returns a 3xx status code
+// IsRedirect returns true when this pet get not found response has a 3xx status code
 func (o *PetGetNotFound) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet get not found response returns a 4xx status code
+// IsClientError returns true when this pet get not found response has a 4xx status code
 func (o *PetGetNotFound) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet get not found response returns a 5xx status code
+// IsServerError returns true when this pet get not found response has a 5xx status code
 func (o *PetGetNotFound) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet get not found response returns a 4xx status code
+// IsCode returns true when this pet get not found response a status code equal to that given
 func (o *PetGetNotFound) IsCode(code int) bool {
 	return code == 404
 }

--- a/examples/contributed-templates/stratoscale/client/pet/pet_list_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_list_responses.go
@@ -46,7 +46,7 @@ func NewPetListOK() *PetListOK {
 }
 
 /*
-	PetListOK describes a response with status code 200, with default header values.
+PetListOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -54,27 +54,27 @@ type PetListOK struct {
 	Payload []*models.Pet
 }
 
-// IsSuccess returns true when this pet list o k response returns a 2xx status code
+// IsSuccess returns true when this pet list o k response has a 2xx status code
 func (o *PetListOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this pet list o k response returns a 3xx status code
+// IsRedirect returns true when this pet list o k response has a 3xx status code
 func (o *PetListOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet list o k response returns a 4xx status code
+// IsClientError returns true when this pet list o k response has a 4xx status code
 func (o *PetListOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this pet list o k response returns a 5xx status code
+// IsServerError returns true when this pet list o k response has a 5xx status code
 func (o *PetListOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet list o k response returns a 4xx status code
+// IsCode returns true when this pet list o k response a status code equal to that given
 func (o *PetListOK) IsCode(code int) bool {
 	return code == 200
 }
@@ -107,34 +107,34 @@ func NewPetListBadRequest() *PetListBadRequest {
 }
 
 /*
-	PetListBadRequest describes a response with status code 400, with default header values.
+PetListBadRequest describes a response with status code 400, with default header values.
 
 Invalid status value
 */
 type PetListBadRequest struct {
 }
 
-// IsSuccess returns true when this pet list bad request response returns a 2xx status code
+// IsSuccess returns true when this pet list bad request response has a 2xx status code
 func (o *PetListBadRequest) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet list bad request response returns a 3xx status code
+// IsRedirect returns true when this pet list bad request response has a 3xx status code
 func (o *PetListBadRequest) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet list bad request response returns a 4xx status code
+// IsClientError returns true when this pet list bad request response has a 4xx status code
 func (o *PetListBadRequest) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet list bad request response returns a 5xx status code
+// IsServerError returns true when this pet list bad request response has a 5xx status code
 func (o *PetListBadRequest) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet list bad request response returns a 4xx status code
+// IsCode returns true when this pet list bad request response a status code equal to that given
 func (o *PetListBadRequest) IsCode(code int) bool {
 	return code == 400
 }

--- a/examples/contributed-templates/stratoscale/client/pet/pet_update_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_update_responses.go
@@ -58,7 +58,7 @@ func NewPetUpdateCreated() *PetUpdateCreated {
 }
 
 /*
-	PetUpdateCreated describes a response with status code 201, with default header values.
+PetUpdateCreated describes a response with status code 201, with default header values.
 
 Updated successfully
 */
@@ -66,27 +66,27 @@ type PetUpdateCreated struct {
 	Payload *models.Pet
 }
 
-// IsSuccess returns true when this pet update created response returns a 2xx status code
+// IsSuccess returns true when this pet update created response has a 2xx status code
 func (o *PetUpdateCreated) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this pet update created response returns a 3xx status code
+// IsRedirect returns true when this pet update created response has a 3xx status code
 func (o *PetUpdateCreated) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet update created response returns a 4xx status code
+// IsClientError returns true when this pet update created response has a 4xx status code
 func (o *PetUpdateCreated) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this pet update created response returns a 5xx status code
+// IsServerError returns true when this pet update created response has a 5xx status code
 func (o *PetUpdateCreated) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet update created response returns a 4xx status code
+// IsCode returns true when this pet update created response a status code equal to that given
 func (o *PetUpdateCreated) IsCode(code int) bool {
 	return code == 201
 }
@@ -121,34 +121,34 @@ func NewPetUpdateBadRequest() *PetUpdateBadRequest {
 }
 
 /*
-	PetUpdateBadRequest describes a response with status code 400, with default header values.
+PetUpdateBadRequest describes a response with status code 400, with default header values.
 
 Invalid ID supplied
 */
 type PetUpdateBadRequest struct {
 }
 
-// IsSuccess returns true when this pet update bad request response returns a 2xx status code
+// IsSuccess returns true when this pet update bad request response has a 2xx status code
 func (o *PetUpdateBadRequest) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet update bad request response returns a 3xx status code
+// IsRedirect returns true when this pet update bad request response has a 3xx status code
 func (o *PetUpdateBadRequest) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet update bad request response returns a 4xx status code
+// IsClientError returns true when this pet update bad request response has a 4xx status code
 func (o *PetUpdateBadRequest) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet update bad request response returns a 5xx status code
+// IsServerError returns true when this pet update bad request response has a 5xx status code
 func (o *PetUpdateBadRequest) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet update bad request response returns a 4xx status code
+// IsCode returns true when this pet update bad request response a status code equal to that given
 func (o *PetUpdateBadRequest) IsCode(code int) bool {
 	return code == 400
 }
@@ -172,34 +172,34 @@ func NewPetUpdateNotFound() *PetUpdateNotFound {
 }
 
 /*
-	PetUpdateNotFound describes a response with status code 404, with default header values.
+PetUpdateNotFound describes a response with status code 404, with default header values.
 
 Pet not found
 */
 type PetUpdateNotFound struct {
 }
 
-// IsSuccess returns true when this pet update not found response returns a 2xx status code
+// IsSuccess returns true when this pet update not found response has a 2xx status code
 func (o *PetUpdateNotFound) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet update not found response returns a 3xx status code
+// IsRedirect returns true when this pet update not found response has a 3xx status code
 func (o *PetUpdateNotFound) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet update not found response returns a 4xx status code
+// IsClientError returns true when this pet update not found response has a 4xx status code
 func (o *PetUpdateNotFound) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet update not found response returns a 5xx status code
+// IsServerError returns true when this pet update not found response has a 5xx status code
 func (o *PetUpdateNotFound) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet update not found response returns a 4xx status code
+// IsCode returns true when this pet update not found response a status code equal to that given
 func (o *PetUpdateNotFound) IsCode(code int) bool {
 	return code == 404
 }
@@ -223,34 +223,34 @@ func NewPetUpdateMethodNotAllowed() *PetUpdateMethodNotAllowed {
 }
 
 /*
-	PetUpdateMethodNotAllowed describes a response with status code 405, with default header values.
+PetUpdateMethodNotAllowed describes a response with status code 405, with default header values.
 
 Validation exception
 */
 type PetUpdateMethodNotAllowed struct {
 }
 
-// IsSuccess returns true when this pet update method not allowed response returns a 2xx status code
+// IsSuccess returns true when this pet update method not allowed response has a 2xx status code
 func (o *PetUpdateMethodNotAllowed) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this pet update method not allowed response returns a 3xx status code
+// IsRedirect returns true when this pet update method not allowed response has a 3xx status code
 func (o *PetUpdateMethodNotAllowed) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet update method not allowed response returns a 4xx status code
+// IsClientError returns true when this pet update method not allowed response has a 4xx status code
 func (o *PetUpdateMethodNotAllowed) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this pet update method not allowed response returns a 5xx status code
+// IsServerError returns true when this pet update method not allowed response has a 5xx status code
 func (o *PetUpdateMethodNotAllowed) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet update method not allowed response returns a 4xx status code
+// IsCode returns true when this pet update method not allowed response a status code equal to that given
 func (o *PetUpdateMethodNotAllowed) IsCode(code int) bool {
 	return code == 405
 }

--- a/examples/contributed-templates/stratoscale/client/pet/pet_upload_image_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_upload_image_responses.go
@@ -40,7 +40,7 @@ func NewPetUploadImageOK() *PetUploadImageOK {
 }
 
 /*
-	PetUploadImageOK describes a response with status code 200, with default header values.
+PetUploadImageOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -48,27 +48,27 @@ type PetUploadImageOK struct {
 	Payload *models.APIResponse
 }
 
-// IsSuccess returns true when this pet upload image o k response returns a 2xx status code
+// IsSuccess returns true when this pet upload image o k response has a 2xx status code
 func (o *PetUploadImageOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this pet upload image o k response returns a 3xx status code
+// IsRedirect returns true when this pet upload image o k response has a 3xx status code
 func (o *PetUploadImageOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this pet upload image o k response returns a 4xx status code
+// IsClientError returns true when this pet upload image o k response has a 4xx status code
 func (o *PetUploadImageOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this pet upload image o k response returns a 5xx status code
+// IsServerError returns true when this pet upload image o k response has a 5xx status code
 func (o *PetUploadImageOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this pet upload image o k response returns a 4xx status code
+// IsCode returns true when this pet upload image o k response a status code equal to that given
 func (o *PetUploadImageOK) IsCode(code int) bool {
 	return code == 200
 }

--- a/examples/contributed-templates/stratoscale/client/petstore_client.go
+++ b/examples/contributed-templates/stratoscale/client/petstore_client.go
@@ -66,7 +66,7 @@ func New(c Config) *Petstore {
 
 // Petstore is a client for petstore
 type Petstore struct {
-	Pet       *pet.Client
-	Store     *store.Client
+	Pet       pet.API
+	Store     store.API
 	Transport runtime.ClientTransport
 }

--- a/examples/contributed-templates/stratoscale/client/store/inventory_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/inventory_get_responses.go
@@ -38,7 +38,7 @@ func NewInventoryGetOK() *InventoryGetOK {
 }
 
 /*
-	InventoryGetOK describes a response with status code 200, with default header values.
+InventoryGetOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -46,27 +46,27 @@ type InventoryGetOK struct {
 	Payload map[string]int32
 }
 
-// IsSuccess returns true when this inventory get o k response returns a 2xx status code
+// IsSuccess returns true when this inventory get o k response has a 2xx status code
 func (o *InventoryGetOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this inventory get o k response returns a 3xx status code
+// IsRedirect returns true when this inventory get o k response has a 3xx status code
 func (o *InventoryGetOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this inventory get o k response returns a 4xx status code
+// IsClientError returns true when this inventory get o k response has a 4xx status code
 func (o *InventoryGetOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this inventory get o k response returns a 5xx status code
+// IsServerError returns true when this inventory get o k response has a 5xx status code
 func (o *InventoryGetOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this inventory get o k response returns a 4xx status code
+// IsCode returns true when this inventory get o k response a status code equal to that given
 func (o *InventoryGetOK) IsCode(code int) bool {
 	return code == 200
 }

--- a/examples/contributed-templates/stratoscale/client/store/order_create_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_create_responses.go
@@ -46,7 +46,7 @@ func NewOrderCreateOK() *OrderCreateOK {
 }
 
 /*
-	OrderCreateOK describes a response with status code 200, with default header values.
+OrderCreateOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -54,27 +54,27 @@ type OrderCreateOK struct {
 	Payload *models.Order
 }
 
-// IsSuccess returns true when this order create o k response returns a 2xx status code
+// IsSuccess returns true when this order create o k response has a 2xx status code
 func (o *OrderCreateOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this order create o k response returns a 3xx status code
+// IsRedirect returns true when this order create o k response has a 3xx status code
 func (o *OrderCreateOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this order create o k response returns a 4xx status code
+// IsClientError returns true when this order create o k response has a 4xx status code
 func (o *OrderCreateOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this order create o k response returns a 5xx status code
+// IsServerError returns true when this order create o k response has a 5xx status code
 func (o *OrderCreateOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this order create o k response returns a 4xx status code
+// IsCode returns true when this order create o k response a status code equal to that given
 func (o *OrderCreateOK) IsCode(code int) bool {
 	return code == 200
 }
@@ -109,34 +109,34 @@ func NewOrderCreateBadRequest() *OrderCreateBadRequest {
 }
 
 /*
-	OrderCreateBadRequest describes a response with status code 400, with default header values.
+OrderCreateBadRequest describes a response with status code 400, with default header values.
 
 Invalid Order
 */
 type OrderCreateBadRequest struct {
 }
 
-// IsSuccess returns true when this order create bad request response returns a 2xx status code
+// IsSuccess returns true when this order create bad request response has a 2xx status code
 func (o *OrderCreateBadRequest) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this order create bad request response returns a 3xx status code
+// IsRedirect returns true when this order create bad request response has a 3xx status code
 func (o *OrderCreateBadRequest) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this order create bad request response returns a 4xx status code
+// IsClientError returns true when this order create bad request response has a 4xx status code
 func (o *OrderCreateBadRequest) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this order create bad request response returns a 5xx status code
+// IsServerError returns true when this order create bad request response has a 5xx status code
 func (o *OrderCreateBadRequest) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this order create bad request response returns a 4xx status code
+// IsCode returns true when this order create bad request response a status code equal to that given
 func (o *OrderCreateBadRequest) IsCode(code int) bool {
 	return code == 400
 }

--- a/examples/contributed-templates/stratoscale/client/store/order_delete_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_delete_responses.go
@@ -49,34 +49,34 @@ func NewOrderDeleteNoContent() *OrderDeleteNoContent {
 }
 
 /*
-	OrderDeleteNoContent describes a response with status code 204, with default header values.
+OrderDeleteNoContent describes a response with status code 204, with default header values.
 
 Deleted successfully
 */
 type OrderDeleteNoContent struct {
 }
 
-// IsSuccess returns true when this order delete no content response returns a 2xx status code
+// IsSuccess returns true when this order delete no content response has a 2xx status code
 func (o *OrderDeleteNoContent) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this order delete no content response returns a 3xx status code
+// IsRedirect returns true when this order delete no content response has a 3xx status code
 func (o *OrderDeleteNoContent) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this order delete no content response returns a 4xx status code
+// IsClientError returns true when this order delete no content response has a 4xx status code
 func (o *OrderDeleteNoContent) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this order delete no content response returns a 5xx status code
+// IsServerError returns true when this order delete no content response has a 5xx status code
 func (o *OrderDeleteNoContent) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this order delete no content response returns a 4xx status code
+// IsCode returns true when this order delete no content response a status code equal to that given
 func (o *OrderDeleteNoContent) IsCode(code int) bool {
 	return code == 204
 }
@@ -100,34 +100,34 @@ func NewOrderDeleteBadRequest() *OrderDeleteBadRequest {
 }
 
 /*
-	OrderDeleteBadRequest describes a response with status code 400, with default header values.
+OrderDeleteBadRequest describes a response with status code 400, with default header values.
 
 Invalid ID supplied
 */
 type OrderDeleteBadRequest struct {
 }
 
-// IsSuccess returns true when this order delete bad request response returns a 2xx status code
+// IsSuccess returns true when this order delete bad request response has a 2xx status code
 func (o *OrderDeleteBadRequest) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this order delete bad request response returns a 3xx status code
+// IsRedirect returns true when this order delete bad request response has a 3xx status code
 func (o *OrderDeleteBadRequest) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this order delete bad request response returns a 4xx status code
+// IsClientError returns true when this order delete bad request response has a 4xx status code
 func (o *OrderDeleteBadRequest) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this order delete bad request response returns a 5xx status code
+// IsServerError returns true when this order delete bad request response has a 5xx status code
 func (o *OrderDeleteBadRequest) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this order delete bad request response returns a 4xx status code
+// IsCode returns true when this order delete bad request response a status code equal to that given
 func (o *OrderDeleteBadRequest) IsCode(code int) bool {
 	return code == 400
 }
@@ -151,34 +151,34 @@ func NewOrderDeleteNotFound() *OrderDeleteNotFound {
 }
 
 /*
-	OrderDeleteNotFound describes a response with status code 404, with default header values.
+OrderDeleteNotFound describes a response with status code 404, with default header values.
 
 Order not found
 */
 type OrderDeleteNotFound struct {
 }
 
-// IsSuccess returns true when this order delete not found response returns a 2xx status code
+// IsSuccess returns true when this order delete not found response has a 2xx status code
 func (o *OrderDeleteNotFound) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this order delete not found response returns a 3xx status code
+// IsRedirect returns true when this order delete not found response has a 3xx status code
 func (o *OrderDeleteNotFound) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this order delete not found response returns a 4xx status code
+// IsClientError returns true when this order delete not found response has a 4xx status code
 func (o *OrderDeleteNotFound) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this order delete not found response returns a 5xx status code
+// IsServerError returns true when this order delete not found response has a 5xx status code
 func (o *OrderDeleteNotFound) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this order delete not found response returns a 4xx status code
+// IsCode returns true when this order delete not found response a status code equal to that given
 func (o *OrderDeleteNotFound) IsCode(code int) bool {
 	return code == 404
 }

--- a/examples/contributed-templates/stratoscale/client/store/order_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_get_responses.go
@@ -52,7 +52,7 @@ func NewOrderGetOK() *OrderGetOK {
 }
 
 /*
-	OrderGetOK describes a response with status code 200, with default header values.
+OrderGetOK describes a response with status code 200, with default header values.
 
 successful operation
 */
@@ -60,27 +60,27 @@ type OrderGetOK struct {
 	Payload *models.Order
 }
 
-// IsSuccess returns true when this order get o k response returns a 2xx status code
+// IsSuccess returns true when this order get o k response has a 2xx status code
 func (o *OrderGetOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this order get o k response returns a 3xx status code
+// IsRedirect returns true when this order get o k response has a 3xx status code
 func (o *OrderGetOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this order get o k response returns a 4xx status code
+// IsClientError returns true when this order get o k response has a 4xx status code
 func (o *OrderGetOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this order get o k response returns a 5xx status code
+// IsServerError returns true when this order get o k response has a 5xx status code
 func (o *OrderGetOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this order get o k response returns a 4xx status code
+// IsCode returns true when this order get o k response a status code equal to that given
 func (o *OrderGetOK) IsCode(code int) bool {
 	return code == 200
 }
@@ -115,34 +115,34 @@ func NewOrderGetBadRequest() *OrderGetBadRequest {
 }
 
 /*
-	OrderGetBadRequest describes a response with status code 400, with default header values.
+OrderGetBadRequest describes a response with status code 400, with default header values.
 
 Invalid ID supplied
 */
 type OrderGetBadRequest struct {
 }
 
-// IsSuccess returns true when this order get bad request response returns a 2xx status code
+// IsSuccess returns true when this order get bad request response has a 2xx status code
 func (o *OrderGetBadRequest) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this order get bad request response returns a 3xx status code
+// IsRedirect returns true when this order get bad request response has a 3xx status code
 func (o *OrderGetBadRequest) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this order get bad request response returns a 4xx status code
+// IsClientError returns true when this order get bad request response has a 4xx status code
 func (o *OrderGetBadRequest) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this order get bad request response returns a 5xx status code
+// IsServerError returns true when this order get bad request response has a 5xx status code
 func (o *OrderGetBadRequest) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this order get bad request response returns a 4xx status code
+// IsCode returns true when this order get bad request response a status code equal to that given
 func (o *OrderGetBadRequest) IsCode(code int) bool {
 	return code == 400
 }
@@ -166,34 +166,34 @@ func NewOrderGetNotFound() *OrderGetNotFound {
 }
 
 /*
-	OrderGetNotFound describes a response with status code 404, with default header values.
+OrderGetNotFound describes a response with status code 404, with default header values.
 
 Order not found
 */
 type OrderGetNotFound struct {
 }
 
-// IsSuccess returns true when this order get not found response returns a 2xx status code
+// IsSuccess returns true when this order get not found response has a 2xx status code
 func (o *OrderGetNotFound) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this order get not found response returns a 3xx status code
+// IsRedirect returns true when this order get not found response has a 3xx status code
 func (o *OrderGetNotFound) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this order get not found response returns a 4xx status code
+// IsClientError returns true when this order get not found response has a 4xx status code
 func (o *OrderGetNotFound) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this order get not found response returns a 5xx status code
+// IsServerError returns true when this order get not found response has a 5xx status code
 func (o *OrderGetNotFound) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this order get not found response returns a 4xx status code
+// IsCode returns true when this order get not found response a status code equal to that given
 func (o *OrderGetNotFound) IsCode(code int) bool {
 	return code == 404
 }

--- a/examples/contributed-templates/stratoscale/client/store/store_client.go
+++ b/examples/contributed-templates/stratoscale/client/store/store_client.go
@@ -13,7 +13,7 @@ import (
 	strfmt "github.com/go-openapi/strfmt"
 )
 
-//go:generate mockery -name API -inpkg
+//go:generate mockery --name API --keeptree --with-expecter --case underscore
 
 // API is the interface of the store client
 type API interface {

--- a/generator/templates/contrib/stratoscale/client/client.gotmpl
+++ b/generator/templates/contrib/stratoscale/client/client.gotmpl
@@ -22,7 +22,7 @@ import (
   {{ imports .Imports }}
 )
 
-//go:generate mockery -name API -inpkg
+//go:generate mockery --name API --keeptree --with-expecter --case underscore
 
 // API is the interface of the {{ humanize .Name }} client
 type API interface {

--- a/generator/templates/contrib/stratoscale/client/facade.gotmpl
+++ b/generator/templates/contrib/stratoscale/client/facade.gotmpl
@@ -77,7 +77,7 @@ func New(c Config) *{{ pascalize .Name }} {
 // {{ pascalize .Name }} is a client for {{ humanize .Name }}
 type {{ pascalize .Name }} struct {
 	{{ range .OperationGroups -}}
-	  {{ pascalize .Name }} *{{ .PackageAlias }}.Client
+	  {{ pascalize .Name }} {{ .PackageAlias }}.API
 	{{ end -}}
 	Transport runtime.ClientTransport
 }


### PR DESCRIPTION
This PR modifies the stratoscale template to make it easier to test.

1. The facade uses the operation group interfaces (API) instead of using the actual client struct. This makes it easy to mock things out during tests.
2. mockery v2 is used instead of mockery v1. Mocks are generated in a mocks package inside the operation group package now instead of the same package. (--keeptree vs --inpackage)
3. Adds the expecter interface to mockery which is preferable and keeps the file casing as underscore to comply with golang file conventions.