### PR TITLE
Ensure that the stratoscale client is able to handle non success-response types

### DIFF
--- a/examples/authentication/client/customers/create_responses.go
+++ b/examples/authentication/client/customers/create_responses.go
@@ -47,7 +47,7 @@ func NewCreateCreated() *CreateCreated {
 }
 
 /*
-	CreateCreated describes a response with status code 201, with default header values.
+CreateCreated describes a response with status code 201, with default header values.
 
 created
 */
@@ -55,29 +55,34 @@ type CreateCreated struct {
 	Payload *models.Customer
 }
 
-// IsSuccess returns true when this create created response returns a 2xx status code
+// IsSuccess returns true when this create created response has a 2xx status code
 func (o *CreateCreated) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this create created response returns a 3xx status code
+// IsRedirect returns true when this create created response has a 3xx status code
 func (o *CreateCreated) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this create created response returns a 4xx status code
+// IsClientError returns true when this create created response has a 4xx status code
 func (o *CreateCreated) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this create created response returns a 5xx status code
+// IsServerError returns true when this create created response has a 5xx status code
 func (o *CreateCreated) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this create created response returns a 4xx status code
+// IsCode returns true when this create created response a status code equal to that given
 func (o *CreateCreated) IsCode(code int) bool {
 	return code == 201
+}
+
+// Code gets the status code for the create created response
+func (o *CreateCreated) Code() int {
+	return 201
 }
 
 func (o *CreateCreated) Error() string {
@@ -112,7 +117,7 @@ func NewCreateDefault(code int) *CreateDefault {
 }
 
 /*
-	CreateDefault describes a response with status code -1, with default header values.
+CreateDefault describes a response with status code -1, with default header values.
 
 error
 */
@@ -122,34 +127,34 @@ type CreateDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the create default response
-func (o *CreateDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this create default response returns a 2xx status code
+// IsSuccess returns true when this create default response has a 2xx status code
 func (o *CreateDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this create default response returns a 3xx status code
+// IsRedirect returns true when this create default response has a 3xx status code
 func (o *CreateDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this create default response returns a 4xx status code
+// IsClientError returns true when this create default response has a 4xx status code
 func (o *CreateDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this create default response returns a 5xx status code
+// IsServerError returns true when this create default response has a 5xx status code
 func (o *CreateDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this create default response returns a 4xx status code
+// IsCode returns true when this create default response a status code equal to that given
 func (o *CreateDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the create default response
+func (o *CreateDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *CreateDefault) Error() string {

--- a/examples/authentication/client/customers/get_id_responses.go
+++ b/examples/authentication/client/customers/get_id_responses.go
@@ -59,7 +59,7 @@ func NewGetIDOK() *GetIDOK {
 }
 
 /*
-	GetIDOK describes a response with status code 200, with default header values.
+GetIDOK describes a response with status code 200, with default header values.
 
 OK
 */
@@ -67,29 +67,34 @@ type GetIDOK struct {
 	Payload *models.Customer
 }
 
-// IsSuccess returns true when this get Id o k response returns a 2xx status code
+// IsSuccess returns true when this get Id o k response has a 2xx status code
 func (o *GetIDOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this get Id o k response returns a 3xx status code
+// IsRedirect returns true when this get Id o k response has a 3xx status code
 func (o *GetIDOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this get Id o k response returns a 4xx status code
+// IsClientError returns true when this get Id o k response has a 4xx status code
 func (o *GetIDOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this get Id o k response returns a 5xx status code
+// IsServerError returns true when this get Id o k response has a 5xx status code
 func (o *GetIDOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this get Id o k response returns a 4xx status code
+// IsCode returns true when this get Id o k response a status code equal to that given
 func (o *GetIDOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get Id o k response
+func (o *GetIDOK) Code() int {
+	return 200
 }
 
 func (o *GetIDOK) Error() string {
@@ -122,7 +127,7 @@ func NewGetIDUnauthorized() *GetIDUnauthorized {
 }
 
 /*
-	GetIDUnauthorized describes a response with status code 401, with default header values.
+GetIDUnauthorized describes a response with status code 401, with default header values.
 
 unauthorized
 */
@@ -130,29 +135,34 @@ type GetIDUnauthorized struct {
 	Payload *models.Error
 }
 
-// IsSuccess returns true when this get Id unauthorized response returns a 2xx status code
+// IsSuccess returns true when this get Id unauthorized response has a 2xx status code
 func (o *GetIDUnauthorized) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this get Id unauthorized response returns a 3xx status code
+// IsRedirect returns true when this get Id unauthorized response has a 3xx status code
 func (o *GetIDUnauthorized) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this get Id unauthorized response returns a 4xx status code
+// IsClientError returns true when this get Id unauthorized response has a 4xx status code
 func (o *GetIDUnauthorized) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this get Id unauthorized response returns a 5xx status code
+// IsServerError returns true when this get Id unauthorized response has a 5xx status code
 func (o *GetIDUnauthorized) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this get Id unauthorized response returns a 4xx status code
+// IsCode returns true when this get Id unauthorized response a status code equal to that given
 func (o *GetIDUnauthorized) IsCode(code int) bool {
 	return code == 401
+}
+
+// Code gets the status code for the get Id unauthorized response
+func (o *GetIDUnauthorized) Code() int {
+	return 401
 }
 
 func (o *GetIDUnauthorized) Error() string {
@@ -185,7 +195,7 @@ func NewGetIDNotFound() *GetIDNotFound {
 }
 
 /*
-	GetIDNotFound describes a response with status code 404, with default header values.
+GetIDNotFound describes a response with status code 404, with default header values.
 
 resource not found
 */
@@ -193,29 +203,34 @@ type GetIDNotFound struct {
 	Payload *models.Error
 }
 
-// IsSuccess returns true when this get Id not found response returns a 2xx status code
+// IsSuccess returns true when this get Id not found response has a 2xx status code
 func (o *GetIDNotFound) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this get Id not found response returns a 3xx status code
+// IsRedirect returns true when this get Id not found response has a 3xx status code
 func (o *GetIDNotFound) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this get Id not found response returns a 4xx status code
+// IsClientError returns true when this get Id not found response has a 4xx status code
 func (o *GetIDNotFound) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this get Id not found response returns a 5xx status code
+// IsServerError returns true when this get Id not found response has a 5xx status code
 func (o *GetIDNotFound) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this get Id not found response returns a 4xx status code
+// IsCode returns true when this get Id not found response a status code equal to that given
 func (o *GetIDNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the get Id not found response
+func (o *GetIDNotFound) Code() int {
+	return 404
 }
 
 func (o *GetIDNotFound) Error() string {
@@ -250,7 +265,7 @@ func NewGetIDDefault(code int) *GetIDDefault {
 }
 
 /*
-	GetIDDefault describes a response with status code -1, with default header values.
+GetIDDefault describes a response with status code -1, with default header values.
 
 error
 */
@@ -260,34 +275,34 @@ type GetIDDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the get Id default response
-func (o *GetIDDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this get Id default response returns a 2xx status code
+// IsSuccess returns true when this get Id default response has a 2xx status code
 func (o *GetIDDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this get Id default response returns a 3xx status code
+// IsRedirect returns true when this get Id default response has a 3xx status code
 func (o *GetIDDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this get Id default response returns a 4xx status code
+// IsClientError returns true when this get Id default response has a 4xx status code
 func (o *GetIDDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this get Id default response returns a 5xx status code
+// IsServerError returns true when this get Id default response has a 5xx status code
 func (o *GetIDDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this get Id default response returns a 4xx status code
+// IsCode returns true when this get Id default response a status code equal to that given
 func (o *GetIDDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the get Id default response
+func (o *GetIDDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *GetIDDefault) Error() string {

--- a/examples/authentication/restapi/operations/customers/create_parameters.go
+++ b/examples/authentication/restapi/operations/customers/create_parameters.go
@@ -6,7 +6,6 @@ package customers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *CreateParams) BindRequest(r *http.Request, route *middleware.MatchedRou
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/authentication/restapi/operations/customers/get_id_parameters.go
+++ b/examples/authentication/restapi/operations/customers/get_id_parameters.go
@@ -6,7 +6,6 @@ package customers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *GetIDParams) BindRequest(r *http.Request, route *middleware.MatchedRout
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/composed-auth/restapi/operations/add_order_parameters.go
+++ b/examples/composed-auth/restapi/operations/add_order_parameters.go
@@ -6,7 +6,6 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -66,7 +65,7 @@ func (o *AddOrderParams) BindRequest(r *http.Request, route *middleware.MatchedR
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/contributed-templates/stratoscale/client/pet/pet_client.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_client.go
@@ -7,6 +7,7 @@ package pet
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-openapi/runtime"
 
@@ -76,8 +77,15 @@ func (a *Client) PetCreate(ctx context.Context, params *PetCreateParams) (*PetCr
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PetCreateCreated), nil
-
+	switch value := result.(type) {
+	case *PetCreateCreated:
+		return value, nil
+	case *PetCreateMethodNotAllowed:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for PetCreate: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }
 
 /*
@@ -101,8 +109,17 @@ func (a *Client) PetDelete(ctx context.Context, params *PetDeleteParams) (*PetDe
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PetDeleteNoContent), nil
-
+	switch value := result.(type) {
+	case *PetDeleteNoContent:
+		return value, nil
+	case *PetDeleteBadRequest:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	case *PetDeleteNotFound:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for PetDelete: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }
 
 /*
@@ -126,8 +143,17 @@ func (a *Client) PetGet(ctx context.Context, params *PetGetParams) (*PetGetOK, e
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PetGetOK), nil
-
+	switch value := result.(type) {
+	case *PetGetOK:
+		return value, nil
+	case *PetGetBadRequest:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	case *PetGetNotFound:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for PetGet: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }
 
 /*
@@ -151,8 +177,15 @@ func (a *Client) PetList(ctx context.Context, params *PetListParams) (*PetListOK
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PetListOK), nil
-
+	switch value := result.(type) {
+	case *PetListOK:
+		return value, nil
+	case *PetListBadRequest:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for PetList: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }
 
 /*
@@ -176,8 +209,19 @@ func (a *Client) PetUpdate(ctx context.Context, params *PetUpdateParams) (*PetUp
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PetUpdateCreated), nil
-
+	switch value := result.(type) {
+	case *PetUpdateCreated:
+		return value, nil
+	case *PetUpdateBadRequest:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	case *PetUpdateNotFound:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	case *PetUpdateMethodNotAllowed:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for PetUpdate: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }
 
 /*
@@ -201,6 +245,11 @@ func (a *Client) PetUploadImage(ctx context.Context, params *PetUploadImageParam
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PetUploadImageOK), nil
-
+	switch value := result.(type) {
+	case *PetUploadImageOK:
+		return value, nil
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for PetUploadImage: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }

--- a/examples/contributed-templates/stratoscale/client/pet/pet_create_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_create_responses.go
@@ -79,6 +79,11 @@ func (o *PetCreateCreated) IsCode(code int) bool {
 	return code == 201
 }
 
+// Code gets the status code for the pet create created response
+func (o *PetCreateCreated) Code() int {
+	return 201
+}
+
 func (o *PetCreateCreated) Error() string {
 	return fmt.Sprintf("[POST /pet][%d] petCreateCreated  %+v", 201, o.Payload)
 }
@@ -139,6 +144,11 @@ func (o *PetCreateMethodNotAllowed) IsServerError() bool {
 // IsCode returns true when this pet create method not allowed response a status code equal to that given
 func (o *PetCreateMethodNotAllowed) IsCode(code int) bool {
 	return code == 405
+}
+
+// Code gets the status code for the pet create method not allowed response
+func (o *PetCreateMethodNotAllowed) Code() int {
+	return 405
 }
 
 func (o *PetCreateMethodNotAllowed) Error() string {

--- a/examples/contributed-templates/stratoscale/client/pet/pet_delete_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_delete_responses.go
@@ -81,6 +81,11 @@ func (o *PetDeleteNoContent) IsCode(code int) bool {
 	return code == 204
 }
 
+// Code gets the status code for the pet delete no content response
+func (o *PetDeleteNoContent) Code() int {
+	return 204
+}
+
 func (o *PetDeleteNoContent) Error() string {
 	return fmt.Sprintf("[DELETE /pet/{petId}][%d] petDeleteNoContent ", 204)
 }
@@ -132,6 +137,11 @@ func (o *PetDeleteBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the pet delete bad request response
+func (o *PetDeleteBadRequest) Code() int {
+	return 400
+}
+
 func (o *PetDeleteBadRequest) Error() string {
 	return fmt.Sprintf("[DELETE /pet/{petId}][%d] petDeleteBadRequest ", 400)
 }
@@ -181,6 +191,11 @@ func (o *PetDeleteNotFound) IsServerError() bool {
 // IsCode returns true when this pet delete not found response a status code equal to that given
 func (o *PetDeleteNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the pet delete not found response
+func (o *PetDeleteNotFound) Code() int {
+	return 404
 }
 
 func (o *PetDeleteNotFound) Error() string {

--- a/examples/contributed-templates/stratoscale/client/pet/pet_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_get_responses.go
@@ -85,6 +85,11 @@ func (o *PetGetOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the pet get o k response
+func (o *PetGetOK) Code() int {
+	return 200
+}
+
 func (o *PetGetOK) Error() string {
 	return fmt.Sprintf("[GET /pet/{petId}][%d] petGetOK  %+v", 200, o.Payload)
 }
@@ -147,6 +152,11 @@ func (o *PetGetBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the pet get bad request response
+func (o *PetGetBadRequest) Code() int {
+	return 400
+}
+
 func (o *PetGetBadRequest) Error() string {
 	return fmt.Sprintf("[GET /pet/{petId}][%d] petGetBadRequest ", 400)
 }
@@ -196,6 +206,11 @@ func (o *PetGetNotFound) IsServerError() bool {
 // IsCode returns true when this pet get not found response a status code equal to that given
 func (o *PetGetNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the pet get not found response
+func (o *PetGetNotFound) Code() int {
+	return 404
 }
 
 func (o *PetGetNotFound) Error() string {

--- a/examples/contributed-templates/stratoscale/client/pet/pet_list_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_list_responses.go
@@ -79,6 +79,11 @@ func (o *PetListOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the pet list o k response
+func (o *PetListOK) Code() int {
+	return 200
+}
+
 func (o *PetListOK) Error() string {
 	return fmt.Sprintf("[GET /pet][%d] petListOK  %+v", 200, o.Payload)
 }
@@ -137,6 +142,11 @@ func (o *PetListBadRequest) IsServerError() bool {
 // IsCode returns true when this pet list bad request response a status code equal to that given
 func (o *PetListBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the pet list bad request response
+func (o *PetListBadRequest) Code() int {
+	return 400
 }
 
 func (o *PetListBadRequest) Error() string {

--- a/examples/contributed-templates/stratoscale/client/pet/pet_update_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_update_responses.go
@@ -91,6 +91,11 @@ func (o *PetUpdateCreated) IsCode(code int) bool {
 	return code == 201
 }
 
+// Code gets the status code for the pet update created response
+func (o *PetUpdateCreated) Code() int {
+	return 201
+}
+
 func (o *PetUpdateCreated) Error() string {
 	return fmt.Sprintf("[PUT /pet][%d] petUpdateCreated  %+v", 201, o.Payload)
 }
@@ -153,6 +158,11 @@ func (o *PetUpdateBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the pet update bad request response
+func (o *PetUpdateBadRequest) Code() int {
+	return 400
+}
+
 func (o *PetUpdateBadRequest) Error() string {
 	return fmt.Sprintf("[PUT /pet][%d] petUpdateBadRequest ", 400)
 }
@@ -204,6 +214,11 @@ func (o *PetUpdateNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the pet update not found response
+func (o *PetUpdateNotFound) Code() int {
+	return 404
+}
+
 func (o *PetUpdateNotFound) Error() string {
 	return fmt.Sprintf("[PUT /pet][%d] petUpdateNotFound ", 404)
 }
@@ -253,6 +268,11 @@ func (o *PetUpdateMethodNotAllowed) IsServerError() bool {
 // IsCode returns true when this pet update method not allowed response a status code equal to that given
 func (o *PetUpdateMethodNotAllowed) IsCode(code int) bool {
 	return code == 405
+}
+
+// Code gets the status code for the pet update method not allowed response
+func (o *PetUpdateMethodNotAllowed) Code() int {
+	return 405
 }
 
 func (o *PetUpdateMethodNotAllowed) Error() string {

--- a/examples/contributed-templates/stratoscale/client/pet/pet_upload_image_responses.go
+++ b/examples/contributed-templates/stratoscale/client/pet/pet_upload_image_responses.go
@@ -73,6 +73,11 @@ func (o *PetUploadImageOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the pet upload image o k response
+func (o *PetUploadImageOK) Code() int {
+	return 200
+}
+
 func (o *PetUploadImageOK) Error() string {
 	return fmt.Sprintf("[POST /pet/{petId}/image][%d] petUploadImageOK  %+v", 200, o.Payload)
 }

--- a/examples/contributed-templates/stratoscale/client/store/inventory_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/inventory_get_responses.go
@@ -71,6 +71,11 @@ func (o *InventoryGetOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the inventory get o k response
+func (o *InventoryGetOK) Code() int {
+	return 200
+}
+
 func (o *InventoryGetOK) Error() string {
 	return fmt.Sprintf("[GET /store/inventory][%d] inventoryGetOK  %+v", 200, o.Payload)
 }

--- a/examples/contributed-templates/stratoscale/client/store/order_create_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_create_responses.go
@@ -79,6 +79,11 @@ func (o *OrderCreateOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the order create o k response
+func (o *OrderCreateOK) Code() int {
+	return 200
+}
+
 func (o *OrderCreateOK) Error() string {
 	return fmt.Sprintf("[POST /store/order][%d] orderCreateOK  %+v", 200, o.Payload)
 }
@@ -139,6 +144,11 @@ func (o *OrderCreateBadRequest) IsServerError() bool {
 // IsCode returns true when this order create bad request response a status code equal to that given
 func (o *OrderCreateBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the order create bad request response
+func (o *OrderCreateBadRequest) Code() int {
+	return 400
 }
 
 func (o *OrderCreateBadRequest) Error() string {

--- a/examples/contributed-templates/stratoscale/client/store/order_delete_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_delete_responses.go
@@ -81,6 +81,11 @@ func (o *OrderDeleteNoContent) IsCode(code int) bool {
 	return code == 204
 }
 
+// Code gets the status code for the order delete no content response
+func (o *OrderDeleteNoContent) Code() int {
+	return 204
+}
+
 func (o *OrderDeleteNoContent) Error() string {
 	return fmt.Sprintf("[DELETE /store/order/{orderId}][%d] orderDeleteNoContent ", 204)
 }
@@ -132,6 +137,11 @@ func (o *OrderDeleteBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the order delete bad request response
+func (o *OrderDeleteBadRequest) Code() int {
+	return 400
+}
+
 func (o *OrderDeleteBadRequest) Error() string {
 	return fmt.Sprintf("[DELETE /store/order/{orderId}][%d] orderDeleteBadRequest ", 400)
 }
@@ -181,6 +191,11 @@ func (o *OrderDeleteNotFound) IsServerError() bool {
 // IsCode returns true when this order delete not found response a status code equal to that given
 func (o *OrderDeleteNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the order delete not found response
+func (o *OrderDeleteNotFound) Code() int {
+	return 404
 }
 
 func (o *OrderDeleteNotFound) Error() string {

--- a/examples/contributed-templates/stratoscale/client/store/order_get_responses.go
+++ b/examples/contributed-templates/stratoscale/client/store/order_get_responses.go
@@ -85,6 +85,11 @@ func (o *OrderGetOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the order get o k response
+func (o *OrderGetOK) Code() int {
+	return 200
+}
+
 func (o *OrderGetOK) Error() string {
 	return fmt.Sprintf("[GET /store/order/{orderId}][%d] orderGetOK  %+v", 200, o.Payload)
 }
@@ -147,6 +152,11 @@ func (o *OrderGetBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the order get bad request response
+func (o *OrderGetBadRequest) Code() int {
+	return 400
+}
+
 func (o *OrderGetBadRequest) Error() string {
 	return fmt.Sprintf("[GET /store/order/{orderId}][%d] orderGetBadRequest ", 400)
 }
@@ -196,6 +206,11 @@ func (o *OrderGetNotFound) IsServerError() bool {
 // IsCode returns true when this order get not found response a status code equal to that given
 func (o *OrderGetNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the order get not found response
+func (o *OrderGetNotFound) Code() int {
+	return 404
 }
 
 func (o *OrderGetNotFound) Error() string {

--- a/examples/contributed-templates/stratoscale/client/store/store_client.go
+++ b/examples/contributed-templates/stratoscale/client/store/store_client.go
@@ -7,6 +7,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-openapi/runtime"
 
@@ -74,8 +75,13 @@ func (a *Client) InventoryGet(ctx context.Context, params *InventoryGetParams) (
 	if err != nil {
 		return nil, err
 	}
-	return result.(*InventoryGetOK), nil
-
+	switch value := result.(type) {
+	case *InventoryGetOK:
+		return value, nil
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for InventoryGet: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }
 
 /*
@@ -99,8 +105,15 @@ func (a *Client) OrderCreate(ctx context.Context, params *OrderCreateParams) (*O
 	if err != nil {
 		return nil, err
 	}
-	return result.(*OrderCreateOK), nil
-
+	switch value := result.(type) {
+	case *OrderCreateOK:
+		return value, nil
+	case *OrderCreateBadRequest:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for OrderCreate: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }
 
 /*
@@ -126,8 +139,17 @@ func (a *Client) OrderDelete(ctx context.Context, params *OrderDeleteParams) (*O
 	if err != nil {
 		return nil, err
 	}
-	return result.(*OrderDeleteNoContent), nil
-
+	switch value := result.(type) {
+	case *OrderDeleteNoContent:
+		return value, nil
+	case *OrderDeleteBadRequest:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	case *OrderDeleteNotFound:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for OrderDelete: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }
 
 /*
@@ -153,6 +175,15 @@ func (a *Client) OrderGet(ctx context.Context, params *OrderGetParams) (*OrderGe
 	if err != nil {
 		return nil, err
 	}
-	return result.(*OrderGetOK), nil
-
+	switch value := result.(type) {
+	case *OrderGetOK:
+		return value, nil
+	case *OrderGetBadRequest:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	case *OrderGetNotFound:
+		return nil, runtime.NewAPIError("unsuccessful response", value, value.Code())
+	}
+	// safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+	msg := fmt.Sprintf("unexpected success response for OrderGet: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+	panic(msg)
 }

--- a/examples/external-types/restapi/operations/put_test_swagger_parameters.go
+++ b/examples/external-types/restapi/operations/put_test_swagger_parameters.go
@@ -6,7 +6,6 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -70,7 +69,7 @@ func (o *PutTestParams) BindRequest(r *http.Request, route *middleware.MatchedRo
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/file-server/client/uploads/upload_file_responses.go
+++ b/examples/file-server/client/uploads/upload_file_responses.go
@@ -37,36 +37,41 @@ func NewUploadFileOK() *UploadFileOK {
 }
 
 /*
-	UploadFileOK describes a response with status code 200, with default header values.
+UploadFileOK describes a response with status code 200, with default header values.
 
 OK
 */
 type UploadFileOK struct {
 }
 
-// IsSuccess returns true when this upload file o k response returns a 2xx status code
+// IsSuccess returns true when this upload file o k response has a 2xx status code
 func (o *UploadFileOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this upload file o k response returns a 3xx status code
+// IsRedirect returns true when this upload file o k response has a 3xx status code
 func (o *UploadFileOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this upload file o k response returns a 4xx status code
+// IsClientError returns true when this upload file o k response has a 4xx status code
 func (o *UploadFileOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this upload file o k response returns a 5xx status code
+// IsServerError returns true when this upload file o k response has a 5xx status code
 func (o *UploadFileOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this upload file o k response returns a 4xx status code
+// IsCode returns true when this upload file o k response a status code equal to that given
 func (o *UploadFileOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the upload file o k response
+func (o *UploadFileOK) Code() int {
+	return 200
 }
 
 func (o *UploadFileOK) Error() string {

--- a/examples/generated/restapi/operations/pet/add_pet_parameters.go
+++ b/examples/generated/restapi/operations/pet/add_pet_parameters.go
@@ -6,7 +6,6 @@ package pet
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *AddPetParams) BindRequest(r *http.Request, route *middleware.MatchedRou
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/generated/restapi/operations/pet/update_pet_parameters.go
+++ b/examples/generated/restapi/operations/pet/update_pet_parameters.go
@@ -6,7 +6,6 @@ package pet
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *UpdatePetParams) BindRequest(r *http.Request, route *middleware.Matched
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/generated/restapi/operations/store/place_order_parameters.go
+++ b/examples/generated/restapi/operations/store/place_order_parameters.go
@@ -6,7 +6,6 @@ package store
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *PlaceOrderParams) BindRequest(r *http.Request, route *middleware.Matche
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/generated/restapi/operations/user/create_user_parameters.go
+++ b/examples/generated/restapi/operations/user/create_user_parameters.go
@@ -6,7 +6,6 @@ package user
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *CreateUserParams) BindRequest(r *http.Request, route *middleware.Matche
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/generated/restapi/operations/user/update_user_parameters.go
+++ b/examples/generated/restapi/operations/user/update_user_parameters.go
@@ -6,7 +6,6 @@ package user
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -66,7 +65,7 @@ func (o *UpdateUserParams) BindRequest(r *http.Request, route *middleware.Matche
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/oauth2/restapi/operations/customers/create_parameters.go
+++ b/examples/oauth2/restapi/operations/customers/create_parameters.go
@@ -6,7 +6,6 @@ package customers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *CreateParams) BindRequest(r *http.Request, route *middleware.MatchedRou
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/oauth2/restapi/operations/customers/get_id_parameters.go
+++ b/examples/oauth2/restapi/operations/customers/get_id_parameters.go
@@ -6,7 +6,6 @@ package customers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *GetIDParams) BindRequest(r *http.Request, route *middleware.MatchedRout
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/stream-client/client/operations/chunked_responses.go
+++ b/examples/stream-client/client/operations/chunked_responses.go
@@ -42,7 +42,7 @@ func NewChunkedOK(writer io.Writer) *ChunkedOK {
 }
 
 /*
-	ChunkedOK describes a response with status code 200, with default header values.
+ChunkedOK describes a response with status code 200, with default header values.
 
 chunked data delivered
 */
@@ -50,29 +50,34 @@ type ChunkedOK struct {
 	Payload io.Writer
 }
 
-// IsSuccess returns true when this chunked o k response returns a 2xx status code
+// IsSuccess returns true when this chunked o k response has a 2xx status code
 func (o *ChunkedOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this chunked o k response returns a 3xx status code
+// IsRedirect returns true when this chunked o k response has a 3xx status code
 func (o *ChunkedOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this chunked o k response returns a 4xx status code
+// IsClientError returns true when this chunked o k response has a 4xx status code
 func (o *ChunkedOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this chunked o k response returns a 5xx status code
+// IsServerError returns true when this chunked o k response has a 5xx status code
 func (o *ChunkedOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this chunked o k response returns a 4xx status code
+// IsCode returns true when this chunked o k response a status code equal to that given
 func (o *ChunkedOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the chunked o k response
+func (o *ChunkedOK) Code() int {
+	return 200
 }
 
 func (o *ChunkedOK) Error() string {

--- a/examples/stream-server/client/operations/elapse_responses.go
+++ b/examples/stream-server/client/operations/elapse_responses.go
@@ -48,7 +48,7 @@ func NewElapseOK(writer io.Writer) *ElapseOK {
 }
 
 /*
-	ElapseOK describes a response with status code 200, with default header values.
+ElapseOK describes a response with status code 200, with default header values.
 
 Secondly update on remaining time
 */
@@ -56,29 +56,34 @@ type ElapseOK struct {
 	Payload io.Writer
 }
 
-// IsSuccess returns true when this elapse o k response returns a 2xx status code
+// IsSuccess returns true when this elapse o k response has a 2xx status code
 func (o *ElapseOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this elapse o k response returns a 3xx status code
+// IsRedirect returns true when this elapse o k response has a 3xx status code
 func (o *ElapseOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this elapse o k response returns a 4xx status code
+// IsClientError returns true when this elapse o k response has a 4xx status code
 func (o *ElapseOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this elapse o k response returns a 5xx status code
+// IsServerError returns true when this elapse o k response has a 5xx status code
 func (o *ElapseOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this elapse o k response returns a 4xx status code
+// IsCode returns true when this elapse o k response a status code equal to that given
 func (o *ElapseOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the elapse o k response
+func (o *ElapseOK) Code() int {
+	return 200
 }
 
 func (o *ElapseOK) Error() string {
@@ -109,36 +114,41 @@ func NewElapseForbidden() *ElapseForbidden {
 }
 
 /*
-	ElapseForbidden describes a response with status code 403, with default header values.
+ElapseForbidden describes a response with status code 403, with default header values.
 
 Contrived - thrown when length of 11 is chosen
 */
 type ElapseForbidden struct {
 }
 
-// IsSuccess returns true when this elapse forbidden response returns a 2xx status code
+// IsSuccess returns true when this elapse forbidden response has a 2xx status code
 func (o *ElapseForbidden) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this elapse forbidden response returns a 3xx status code
+// IsRedirect returns true when this elapse forbidden response has a 3xx status code
 func (o *ElapseForbidden) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this elapse forbidden response returns a 4xx status code
+// IsClientError returns true when this elapse forbidden response has a 4xx status code
 func (o *ElapseForbidden) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this elapse forbidden response returns a 5xx status code
+// IsServerError returns true when this elapse forbidden response has a 5xx status code
 func (o *ElapseForbidden) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this elapse forbidden response returns a 4xx status code
+// IsCode returns true when this elapse forbidden response a status code equal to that given
 func (o *ElapseForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the elapse forbidden response
+func (o *ElapseForbidden) Code() int {
+	return 403
 }
 
 func (o *ElapseForbidden) Error() string {

--- a/examples/task-tracker/client/tasks/add_comment_to_task_responses.go
+++ b/examples/task-tracker/client/tasks/add_comment_to_task_responses.go
@@ -51,36 +51,41 @@ func NewAddCommentToTaskCreated() *AddCommentToTaskCreated {
 }
 
 /*
-	AddCommentToTaskCreated describes a response with status code 201, with default header values.
+AddCommentToTaskCreated describes a response with status code 201, with default header values.
 
 Comment added
 */
 type AddCommentToTaskCreated struct {
 }
 
-// IsSuccess returns true when this add comment to task created response returns a 2xx status code
+// IsSuccess returns true when this add comment to task created response has a 2xx status code
 func (o *AddCommentToTaskCreated) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this add comment to task created response returns a 3xx status code
+// IsRedirect returns true when this add comment to task created response has a 3xx status code
 func (o *AddCommentToTaskCreated) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this add comment to task created response returns a 4xx status code
+// IsClientError returns true when this add comment to task created response has a 4xx status code
 func (o *AddCommentToTaskCreated) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this add comment to task created response returns a 5xx status code
+// IsServerError returns true when this add comment to task created response has a 5xx status code
 func (o *AddCommentToTaskCreated) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this add comment to task created response returns a 4xx status code
+// IsCode returns true when this add comment to task created response a status code equal to that given
 func (o *AddCommentToTaskCreated) IsCode(code int) bool {
 	return code == 201
+}
+
+// Code gets the status code for the add comment to task created response
+func (o *AddCommentToTaskCreated) Code() int {
+	return 201
 }
 
 func (o *AddCommentToTaskCreated) Error() string {
@@ -104,7 +109,7 @@ func NewAddCommentToTaskDefault(code int) *AddCommentToTaskDefault {
 }
 
 /*
-	AddCommentToTaskDefault describes a response with status code -1, with default header values.
+AddCommentToTaskDefault describes a response with status code -1, with default header values.
 
 Error response
 */
@@ -115,34 +120,34 @@ type AddCommentToTaskDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the add comment to task default response
-func (o *AddCommentToTaskDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this add comment to task default response returns a 2xx status code
+// IsSuccess returns true when this add comment to task default response has a 2xx status code
 func (o *AddCommentToTaskDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this add comment to task default response returns a 3xx status code
+// IsRedirect returns true when this add comment to task default response has a 3xx status code
 func (o *AddCommentToTaskDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this add comment to task default response returns a 4xx status code
+// IsClientError returns true when this add comment to task default response has a 4xx status code
 func (o *AddCommentToTaskDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this add comment to task default response returns a 5xx status code
+// IsServerError returns true when this add comment to task default response has a 5xx status code
 func (o *AddCommentToTaskDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this add comment to task default response returns a 4xx status code
+// IsCode returns true when this add comment to task default response a status code equal to that given
 func (o *AddCommentToTaskDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the add comment to task default response
+func (o *AddCommentToTaskDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *AddCommentToTaskDefault) Error() string {

--- a/examples/task-tracker/client/tasks/create_task_responses.go
+++ b/examples/task-tracker/client/tasks/create_task_responses.go
@@ -48,7 +48,7 @@ func NewCreateTaskCreated() *CreateTaskCreated {
 }
 
 /*
-	CreateTaskCreated describes a response with status code 201, with default header values.
+CreateTaskCreated describes a response with status code 201, with default header values.
 
 Task created
 */
@@ -61,29 +61,34 @@ type CreateTaskCreated struct {
 	Location strfmt.URI
 }
 
-// IsSuccess returns true when this create task created response returns a 2xx status code
+// IsSuccess returns true when this create task created response has a 2xx status code
 func (o *CreateTaskCreated) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this create task created response returns a 3xx status code
+// IsRedirect returns true when this create task created response has a 3xx status code
 func (o *CreateTaskCreated) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this create task created response returns a 4xx status code
+// IsClientError returns true when this create task created response has a 4xx status code
 func (o *CreateTaskCreated) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this create task created response returns a 5xx status code
+// IsServerError returns true when this create task created response has a 5xx status code
 func (o *CreateTaskCreated) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this create task created response returns a 4xx status code
+// IsCode returns true when this create task created response a status code equal to that given
 func (o *CreateTaskCreated) IsCode(code int) bool {
 	return code == 201
+}
+
+// Code gets the status code for the create task created response
+func (o *CreateTaskCreated) Code() int {
+	return 201
 }
 
 func (o *CreateTaskCreated) Error() string {
@@ -118,7 +123,7 @@ func NewCreateTaskDefault(code int) *CreateTaskDefault {
 }
 
 /*
-	CreateTaskDefault describes a response with status code -1, with default header values.
+CreateTaskDefault describes a response with status code -1, with default header values.
 
 Error response
 */
@@ -129,34 +134,34 @@ type CreateTaskDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the create task default response
-func (o *CreateTaskDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this create task default response returns a 2xx status code
+// IsSuccess returns true when this create task default response has a 2xx status code
 func (o *CreateTaskDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this create task default response returns a 3xx status code
+// IsRedirect returns true when this create task default response has a 3xx status code
 func (o *CreateTaskDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this create task default response returns a 4xx status code
+// IsClientError returns true when this create task default response has a 4xx status code
 func (o *CreateTaskDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this create task default response returns a 5xx status code
+// IsServerError returns true when this create task default response has a 5xx status code
 func (o *CreateTaskDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this create task default response returns a 4xx status code
+// IsCode returns true when this create task default response a status code equal to that given
 func (o *CreateTaskDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the create task default response
+func (o *CreateTaskDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *CreateTaskDefault) Error() string {

--- a/examples/task-tracker/client/tasks/delete_task_responses.go
+++ b/examples/task-tracker/client/tasks/delete_task_responses.go
@@ -47,36 +47,41 @@ func NewDeleteTaskNoContent() *DeleteTaskNoContent {
 }
 
 /*
-	DeleteTaskNoContent describes a response with status code 204, with default header values.
+DeleteTaskNoContent describes a response with status code 204, with default header values.
 
 Task deleted
 */
 type DeleteTaskNoContent struct {
 }
 
-// IsSuccess returns true when this delete task no content response returns a 2xx status code
+// IsSuccess returns true when this delete task no content response has a 2xx status code
 func (o *DeleteTaskNoContent) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this delete task no content response returns a 3xx status code
+// IsRedirect returns true when this delete task no content response has a 3xx status code
 func (o *DeleteTaskNoContent) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this delete task no content response returns a 4xx status code
+// IsClientError returns true when this delete task no content response has a 4xx status code
 func (o *DeleteTaskNoContent) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this delete task no content response returns a 5xx status code
+// IsServerError returns true when this delete task no content response has a 5xx status code
 func (o *DeleteTaskNoContent) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this delete task no content response returns a 4xx status code
+// IsCode returns true when this delete task no content response a status code equal to that given
 func (o *DeleteTaskNoContent) IsCode(code int) bool {
 	return code == 204
+}
+
+// Code gets the status code for the delete task no content response
+func (o *DeleteTaskNoContent) Code() int {
+	return 204
 }
 
 func (o *DeleteTaskNoContent) Error() string {
@@ -100,7 +105,7 @@ func NewDeleteTaskDefault(code int) *DeleteTaskDefault {
 }
 
 /*
-	DeleteTaskDefault describes a response with status code -1, with default header values.
+DeleteTaskDefault describes a response with status code -1, with default header values.
 
 Error response
 */
@@ -111,34 +116,34 @@ type DeleteTaskDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the delete task default response
-func (o *DeleteTaskDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this delete task default response returns a 2xx status code
+// IsSuccess returns true when this delete task default response has a 2xx status code
 func (o *DeleteTaskDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this delete task default response returns a 3xx status code
+// IsRedirect returns true when this delete task default response has a 3xx status code
 func (o *DeleteTaskDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this delete task default response returns a 4xx status code
+// IsClientError returns true when this delete task default response has a 4xx status code
 func (o *DeleteTaskDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this delete task default response returns a 5xx status code
+// IsServerError returns true when this delete task default response has a 5xx status code
 func (o *DeleteTaskDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this delete task default response returns a 4xx status code
+// IsCode returns true when this delete task default response a status code equal to that given
 func (o *DeleteTaskDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the delete task default response
+func (o *DeleteTaskDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *DeleteTaskDefault) Error() string {

--- a/examples/task-tracker/client/tasks/get_task_comments_responses.go
+++ b/examples/task-tracker/client/tasks/get_task_comments_responses.go
@@ -47,7 +47,7 @@ func NewGetTaskCommentsOK() *GetTaskCommentsOK {
 }
 
 /*
-	GetTaskCommentsOK describes a response with status code 200, with default header values.
+GetTaskCommentsOK describes a response with status code 200, with default header values.
 
 The list of comments
 */
@@ -55,29 +55,34 @@ type GetTaskCommentsOK struct {
 	Payload []*models.Comment
 }
 
-// IsSuccess returns true when this get task comments o k response returns a 2xx status code
+// IsSuccess returns true when this get task comments o k response has a 2xx status code
 func (o *GetTaskCommentsOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this get task comments o k response returns a 3xx status code
+// IsRedirect returns true when this get task comments o k response has a 3xx status code
 func (o *GetTaskCommentsOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this get task comments o k response returns a 4xx status code
+// IsClientError returns true when this get task comments o k response has a 4xx status code
 func (o *GetTaskCommentsOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this get task comments o k response returns a 5xx status code
+// IsServerError returns true when this get task comments o k response has a 5xx status code
 func (o *GetTaskCommentsOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this get task comments o k response returns a 4xx status code
+// IsCode returns true when this get task comments o k response a status code equal to that given
 func (o *GetTaskCommentsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get task comments o k response
+func (o *GetTaskCommentsOK) Code() int {
+	return 200
 }
 
 func (o *GetTaskCommentsOK) Error() string {
@@ -110,7 +115,7 @@ func NewGetTaskCommentsDefault(code int) *GetTaskCommentsDefault {
 }
 
 /*
-	GetTaskCommentsDefault describes a response with status code -1, with default header values.
+GetTaskCommentsDefault describes a response with status code -1, with default header values.
 
 Error response
 */
@@ -121,34 +126,34 @@ type GetTaskCommentsDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the get task comments default response
-func (o *GetTaskCommentsDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this get task comments default response returns a 2xx status code
+// IsSuccess returns true when this get task comments default response has a 2xx status code
 func (o *GetTaskCommentsDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this get task comments default response returns a 3xx status code
+// IsRedirect returns true when this get task comments default response has a 3xx status code
 func (o *GetTaskCommentsDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this get task comments default response returns a 4xx status code
+// IsClientError returns true when this get task comments default response has a 4xx status code
 func (o *GetTaskCommentsDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this get task comments default response returns a 5xx status code
+// IsServerError returns true when this get task comments default response has a 5xx status code
 func (o *GetTaskCommentsDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this get task comments default response returns a 4xx status code
+// IsCode returns true when this get task comments default response a status code equal to that given
 func (o *GetTaskCommentsDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the get task comments default response
+func (o *GetTaskCommentsDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *GetTaskCommentsDefault) Error() string {

--- a/examples/task-tracker/client/tasks/get_task_details_responses.go
+++ b/examples/task-tracker/client/tasks/get_task_details_responses.go
@@ -53,7 +53,7 @@ func NewGetTaskDetailsOK() *GetTaskDetailsOK {
 }
 
 /*
-	GetTaskDetailsOK describes a response with status code 200, with default header values.
+GetTaskDetailsOK describes a response with status code 200, with default header values.
 
 Task details
 */
@@ -61,29 +61,34 @@ type GetTaskDetailsOK struct {
 	Payload *models.Task
 }
 
-// IsSuccess returns true when this get task details o k response returns a 2xx status code
+// IsSuccess returns true when this get task details o k response has a 2xx status code
 func (o *GetTaskDetailsOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this get task details o k response returns a 3xx status code
+// IsRedirect returns true when this get task details o k response has a 3xx status code
 func (o *GetTaskDetailsOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this get task details o k response returns a 4xx status code
+// IsClientError returns true when this get task details o k response has a 4xx status code
 func (o *GetTaskDetailsOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this get task details o k response returns a 5xx status code
+// IsServerError returns true when this get task details o k response has a 5xx status code
 func (o *GetTaskDetailsOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this get task details o k response returns a 4xx status code
+// IsCode returns true when this get task details o k response a status code equal to that given
 func (o *GetTaskDetailsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get task details o k response
+func (o *GetTaskDetailsOK) Code() int {
+	return 200
 }
 
 func (o *GetTaskDetailsOK) Error() string {
@@ -116,7 +121,7 @@ func NewGetTaskDetailsUnprocessableEntity() *GetTaskDetailsUnprocessableEntity {
 }
 
 /*
-	GetTaskDetailsUnprocessableEntity describes a response with status code 422, with default header values.
+GetTaskDetailsUnprocessableEntity describes a response with status code 422, with default header values.
 
 Validation error
 */
@@ -124,29 +129,34 @@ type GetTaskDetailsUnprocessableEntity struct {
 	Payload *models.ValidationError
 }
 
-// IsSuccess returns true when this get task details unprocessable entity response returns a 2xx status code
+// IsSuccess returns true when this get task details unprocessable entity response has a 2xx status code
 func (o *GetTaskDetailsUnprocessableEntity) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this get task details unprocessable entity response returns a 3xx status code
+// IsRedirect returns true when this get task details unprocessable entity response has a 3xx status code
 func (o *GetTaskDetailsUnprocessableEntity) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this get task details unprocessable entity response returns a 4xx status code
+// IsClientError returns true when this get task details unprocessable entity response has a 4xx status code
 func (o *GetTaskDetailsUnprocessableEntity) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this get task details unprocessable entity response returns a 5xx status code
+// IsServerError returns true when this get task details unprocessable entity response has a 5xx status code
 func (o *GetTaskDetailsUnprocessableEntity) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this get task details unprocessable entity response returns a 4xx status code
+// IsCode returns true when this get task details unprocessable entity response a status code equal to that given
 func (o *GetTaskDetailsUnprocessableEntity) IsCode(code int) bool {
 	return code == 422
+}
+
+// Code gets the status code for the get task details unprocessable entity response
+func (o *GetTaskDetailsUnprocessableEntity) Code() int {
+	return 422
 }
 
 func (o *GetTaskDetailsUnprocessableEntity) Error() string {
@@ -181,7 +191,7 @@ func NewGetTaskDetailsDefault(code int) *GetTaskDetailsDefault {
 }
 
 /*
-	GetTaskDetailsDefault describes a response with status code -1, with default header values.
+GetTaskDetailsDefault describes a response with status code -1, with default header values.
 
 Error response
 */
@@ -192,34 +202,34 @@ type GetTaskDetailsDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the get task details default response
-func (o *GetTaskDetailsDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this get task details default response returns a 2xx status code
+// IsSuccess returns true when this get task details default response has a 2xx status code
 func (o *GetTaskDetailsDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this get task details default response returns a 3xx status code
+// IsRedirect returns true when this get task details default response has a 3xx status code
 func (o *GetTaskDetailsDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this get task details default response returns a 4xx status code
+// IsClientError returns true when this get task details default response has a 4xx status code
 func (o *GetTaskDetailsDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this get task details default response returns a 5xx status code
+// IsServerError returns true when this get task details default response has a 5xx status code
 func (o *GetTaskDetailsDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this get task details default response returns a 4xx status code
+// IsCode returns true when this get task details default response a status code equal to that given
 func (o *GetTaskDetailsDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the get task details default response
+func (o *GetTaskDetailsDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *GetTaskDetailsDefault) Error() string {

--- a/examples/task-tracker/client/tasks/list_tasks_responses.go
+++ b/examples/task-tracker/client/tasks/list_tasks_responses.go
@@ -55,7 +55,7 @@ func NewListTasksOK() *ListTasksOK {
 }
 
 /*
-	ListTasksOK describes a response with status code 200, with default header values.
+ListTasksOK describes a response with status code 200, with default header values.
 
 Successful response
 */
@@ -70,29 +70,34 @@ type ListTasksOK struct {
 	Payload []*models.TaskCard
 }
 
-// IsSuccess returns true when this list tasks o k response returns a 2xx status code
+// IsSuccess returns true when this list tasks o k response has a 2xx status code
 func (o *ListTasksOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this list tasks o k response returns a 3xx status code
+// IsRedirect returns true when this list tasks o k response has a 3xx status code
 func (o *ListTasksOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this list tasks o k response returns a 4xx status code
+// IsClientError returns true when this list tasks o k response has a 4xx status code
 func (o *ListTasksOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this list tasks o k response returns a 5xx status code
+// IsServerError returns true when this list tasks o k response has a 5xx status code
 func (o *ListTasksOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this list tasks o k response returns a 4xx status code
+// IsCode returns true when this list tasks o k response a status code equal to that given
 func (o *ListTasksOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the list tasks o k response
+func (o *ListTasksOK) Code() int {
+	return 200
 }
 
 func (o *ListTasksOK) Error() string {
@@ -134,7 +139,7 @@ func NewListTasksUnprocessableEntity() *ListTasksUnprocessableEntity {
 }
 
 /*
-	ListTasksUnprocessableEntity describes a response with status code 422, with default header values.
+ListTasksUnprocessableEntity describes a response with status code 422, with default header values.
 
 Validation error
 */
@@ -142,29 +147,34 @@ type ListTasksUnprocessableEntity struct {
 	Payload *models.ValidationError
 }
 
-// IsSuccess returns true when this list tasks unprocessable entity response returns a 2xx status code
+// IsSuccess returns true when this list tasks unprocessable entity response has a 2xx status code
 func (o *ListTasksUnprocessableEntity) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this list tasks unprocessable entity response returns a 3xx status code
+// IsRedirect returns true when this list tasks unprocessable entity response has a 3xx status code
 func (o *ListTasksUnprocessableEntity) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this list tasks unprocessable entity response returns a 4xx status code
+// IsClientError returns true when this list tasks unprocessable entity response has a 4xx status code
 func (o *ListTasksUnprocessableEntity) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this list tasks unprocessable entity response returns a 5xx status code
+// IsServerError returns true when this list tasks unprocessable entity response has a 5xx status code
 func (o *ListTasksUnprocessableEntity) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this list tasks unprocessable entity response returns a 4xx status code
+// IsCode returns true when this list tasks unprocessable entity response a status code equal to that given
 func (o *ListTasksUnprocessableEntity) IsCode(code int) bool {
 	return code == 422
+}
+
+// Code gets the status code for the list tasks unprocessable entity response
+func (o *ListTasksUnprocessableEntity) Code() int {
+	return 422
 }
 
 func (o *ListTasksUnprocessableEntity) Error() string {
@@ -199,7 +209,7 @@ func NewListTasksDefault(code int) *ListTasksDefault {
 }
 
 /*
-	ListTasksDefault describes a response with status code -1, with default header values.
+ListTasksDefault describes a response with status code -1, with default header values.
 
 Error response
 */
@@ -210,34 +220,34 @@ type ListTasksDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the list tasks default response
-func (o *ListTasksDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this list tasks default response returns a 2xx status code
+// IsSuccess returns true when this list tasks default response has a 2xx status code
 func (o *ListTasksDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this list tasks default response returns a 3xx status code
+// IsRedirect returns true when this list tasks default response has a 3xx status code
 func (o *ListTasksDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this list tasks default response returns a 4xx status code
+// IsClientError returns true when this list tasks default response has a 4xx status code
 func (o *ListTasksDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this list tasks default response returns a 5xx status code
+// IsServerError returns true when this list tasks default response has a 5xx status code
 func (o *ListTasksDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this list tasks default response returns a 4xx status code
+// IsCode returns true when this list tasks default response a status code equal to that given
 func (o *ListTasksDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the list tasks default response
+func (o *ListTasksDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *ListTasksDefault) Error() string {

--- a/examples/task-tracker/client/tasks/update_task_responses.go
+++ b/examples/task-tracker/client/tasks/update_task_responses.go
@@ -53,7 +53,7 @@ func NewUpdateTaskOK() *UpdateTaskOK {
 }
 
 /*
-	UpdateTaskOK describes a response with status code 200, with default header values.
+UpdateTaskOK describes a response with status code 200, with default header values.
 
 Task details
 */
@@ -61,29 +61,34 @@ type UpdateTaskOK struct {
 	Payload *models.Task
 }
 
-// IsSuccess returns true when this update task o k response returns a 2xx status code
+// IsSuccess returns true when this update task o k response has a 2xx status code
 func (o *UpdateTaskOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this update task o k response returns a 3xx status code
+// IsRedirect returns true when this update task o k response has a 3xx status code
 func (o *UpdateTaskOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this update task o k response returns a 4xx status code
+// IsClientError returns true when this update task o k response has a 4xx status code
 func (o *UpdateTaskOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this update task o k response returns a 5xx status code
+// IsServerError returns true when this update task o k response has a 5xx status code
 func (o *UpdateTaskOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this update task o k response returns a 4xx status code
+// IsCode returns true when this update task o k response a status code equal to that given
 func (o *UpdateTaskOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the update task o k response
+func (o *UpdateTaskOK) Code() int {
+	return 200
 }
 
 func (o *UpdateTaskOK) Error() string {
@@ -116,7 +121,7 @@ func NewUpdateTaskUnprocessableEntity() *UpdateTaskUnprocessableEntity {
 }
 
 /*
-	UpdateTaskUnprocessableEntity describes a response with status code 422, with default header values.
+UpdateTaskUnprocessableEntity describes a response with status code 422, with default header values.
 
 Validation error
 */
@@ -124,29 +129,34 @@ type UpdateTaskUnprocessableEntity struct {
 	Payload *models.ValidationError
 }
 
-// IsSuccess returns true when this update task unprocessable entity response returns a 2xx status code
+// IsSuccess returns true when this update task unprocessable entity response has a 2xx status code
 func (o *UpdateTaskUnprocessableEntity) IsSuccess() bool {
 	return false
 }
 
-// IsRedirect returns true when this update task unprocessable entity response returns a 3xx status code
+// IsRedirect returns true when this update task unprocessable entity response has a 3xx status code
 func (o *UpdateTaskUnprocessableEntity) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this update task unprocessable entity response returns a 4xx status code
+// IsClientError returns true when this update task unprocessable entity response has a 4xx status code
 func (o *UpdateTaskUnprocessableEntity) IsClientError() bool {
 	return true
 }
 
-// IsServerError returns true when this update task unprocessable entity response returns a 5xx status code
+// IsServerError returns true when this update task unprocessable entity response has a 5xx status code
 func (o *UpdateTaskUnprocessableEntity) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this update task unprocessable entity response returns a 4xx status code
+// IsCode returns true when this update task unprocessable entity response a status code equal to that given
 func (o *UpdateTaskUnprocessableEntity) IsCode(code int) bool {
 	return code == 422
+}
+
+// Code gets the status code for the update task unprocessable entity response
+func (o *UpdateTaskUnprocessableEntity) Code() int {
+	return 422
 }
 
 func (o *UpdateTaskUnprocessableEntity) Error() string {
@@ -181,7 +191,7 @@ func NewUpdateTaskDefault(code int) *UpdateTaskDefault {
 }
 
 /*
-	UpdateTaskDefault describes a response with status code -1, with default header values.
+UpdateTaskDefault describes a response with status code -1, with default header values.
 
 Error response
 */
@@ -192,34 +202,34 @@ type UpdateTaskDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the update task default response
-func (o *UpdateTaskDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this update task default response returns a 2xx status code
+// IsSuccess returns true when this update task default response has a 2xx status code
 func (o *UpdateTaskDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this update task default response returns a 3xx status code
+// IsRedirect returns true when this update task default response has a 3xx status code
 func (o *UpdateTaskDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this update task default response returns a 4xx status code
+// IsClientError returns true when this update task default response has a 4xx status code
 func (o *UpdateTaskDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this update task default response returns a 5xx status code
+// IsServerError returns true when this update task default response has a 5xx status code
 func (o *UpdateTaskDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this update task default response returns a 4xx status code
+// IsCode returns true when this update task default response a status code equal to that given
 func (o *UpdateTaskDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the update task default response
+func (o *UpdateTaskDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *UpdateTaskDefault) Error() string {

--- a/examples/task-tracker/client/tasks/upload_task_file_responses.go
+++ b/examples/task-tracker/client/tasks/upload_task_file_responses.go
@@ -47,36 +47,41 @@ func NewUploadTaskFileCreated() *UploadTaskFileCreated {
 }
 
 /*
-	UploadTaskFileCreated describes a response with status code 201, with default header values.
+UploadTaskFileCreated describes a response with status code 201, with default header values.
 
 File added
 */
 type UploadTaskFileCreated struct {
 }
 
-// IsSuccess returns true when this upload task file created response returns a 2xx status code
+// IsSuccess returns true when this upload task file created response has a 2xx status code
 func (o *UploadTaskFileCreated) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this upload task file created response returns a 3xx status code
+// IsRedirect returns true when this upload task file created response has a 3xx status code
 func (o *UploadTaskFileCreated) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this upload task file created response returns a 4xx status code
+// IsClientError returns true when this upload task file created response has a 4xx status code
 func (o *UploadTaskFileCreated) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this upload task file created response returns a 5xx status code
+// IsServerError returns true when this upload task file created response has a 5xx status code
 func (o *UploadTaskFileCreated) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this upload task file created response returns a 4xx status code
+// IsCode returns true when this upload task file created response a status code equal to that given
 func (o *UploadTaskFileCreated) IsCode(code int) bool {
 	return code == 201
+}
+
+// Code gets the status code for the upload task file created response
+func (o *UploadTaskFileCreated) Code() int {
+	return 201
 }
 
 func (o *UploadTaskFileCreated) Error() string {
@@ -100,7 +105,7 @@ func NewUploadTaskFileDefault(code int) *UploadTaskFileDefault {
 }
 
 /*
-	UploadTaskFileDefault describes a response with status code -1, with default header values.
+UploadTaskFileDefault describes a response with status code -1, with default header values.
 
 Error response
 */
@@ -111,34 +116,34 @@ type UploadTaskFileDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the upload task file default response
-func (o *UploadTaskFileDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this upload task file default response returns a 2xx status code
+// IsSuccess returns true when this upload task file default response has a 2xx status code
 func (o *UploadTaskFileDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this upload task file default response returns a 3xx status code
+// IsRedirect returns true when this upload task file default response has a 3xx status code
 func (o *UploadTaskFileDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this upload task file default response returns a 4xx status code
+// IsClientError returns true when this upload task file default response has a 4xx status code
 func (o *UploadTaskFileDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this upload task file default response returns a 5xx status code
+// IsServerError returns true when this upload task file default response has a 5xx status code
 func (o *UploadTaskFileDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this upload task file default response returns a 4xx status code
+// IsCode returns true when this upload task file default response a status code equal to that given
 func (o *UploadTaskFileDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the upload task file default response
+func (o *UploadTaskFileDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *UploadTaskFileDefault) Error() string {

--- a/examples/task-tracker/restapi/operations/tasks/add_comment_to_task_parameters.go
+++ b/examples/task-tracker/restapi/operations/tasks/add_comment_to_task_parameters.go
@@ -6,7 +6,6 @@ package tasks
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -65,7 +64,7 @@ func (o *AddCommentToTaskParams) BindRequest(r *http.Request, route *middleware.
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/task-tracker/restapi/operations/tasks/create_task_parameters.go
+++ b/examples/task-tracker/restapi/operations/tasks/create_task_parameters.go
@@ -6,7 +6,6 @@ package tasks
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -66,7 +65,7 @@ func (o *CreateTaskParams) BindRequest(r *http.Request, route *middleware.Matche
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/task-tracker/restapi/operations/tasks/update_task_parameters.go
+++ b/examples/task-tracker/restapi/operations/tasks/update_task_parameters.go
@@ -6,7 +6,6 @@ package tasks
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -73,7 +72,7 @@ func (o *UpdateTaskParams) BindRequest(r *http.Request, route *middleware.Matche
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/todo-list/client/todos/add_one_responses.go
+++ b/examples/todo-list/client/todos/add_one_responses.go
@@ -47,7 +47,7 @@ func NewAddOneCreated() *AddOneCreated {
 }
 
 /*
-	AddOneCreated describes a response with status code 201, with default header values.
+AddOneCreated describes a response with status code 201, with default header values.
 
 Created
 */
@@ -55,29 +55,34 @@ type AddOneCreated struct {
 	Payload *models.Item
 }
 
-// IsSuccess returns true when this add one created response returns a 2xx status code
+// IsSuccess returns true when this add one created response has a 2xx status code
 func (o *AddOneCreated) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this add one created response returns a 3xx status code
+// IsRedirect returns true when this add one created response has a 3xx status code
 func (o *AddOneCreated) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this add one created response returns a 4xx status code
+// IsClientError returns true when this add one created response has a 4xx status code
 func (o *AddOneCreated) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this add one created response returns a 5xx status code
+// IsServerError returns true when this add one created response has a 5xx status code
 func (o *AddOneCreated) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this add one created response returns a 4xx status code
+// IsCode returns true when this add one created response a status code equal to that given
 func (o *AddOneCreated) IsCode(code int) bool {
 	return code == 201
+}
+
+// Code gets the status code for the add one created response
+func (o *AddOneCreated) Code() int {
+	return 201
 }
 
 func (o *AddOneCreated) Error() string {
@@ -112,7 +117,7 @@ func NewAddOneDefault(code int) *AddOneDefault {
 }
 
 /*
-	AddOneDefault describes a response with status code -1, with default header values.
+AddOneDefault describes a response with status code -1, with default header values.
 
 error
 */
@@ -122,34 +127,34 @@ type AddOneDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the add one default response
-func (o *AddOneDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this add one default response returns a 2xx status code
+// IsSuccess returns true when this add one default response has a 2xx status code
 func (o *AddOneDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this add one default response returns a 3xx status code
+// IsRedirect returns true when this add one default response has a 3xx status code
 func (o *AddOneDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this add one default response returns a 4xx status code
+// IsClientError returns true when this add one default response has a 4xx status code
 func (o *AddOneDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this add one default response returns a 5xx status code
+// IsServerError returns true when this add one default response has a 5xx status code
 func (o *AddOneDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this add one default response returns a 4xx status code
+// IsCode returns true when this add one default response a status code equal to that given
 func (o *AddOneDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the add one default response
+func (o *AddOneDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *AddOneDefault) Error() string {

--- a/examples/todo-list/client/todos/destroy_one_responses.go
+++ b/examples/todo-list/client/todos/destroy_one_responses.go
@@ -47,36 +47,41 @@ func NewDestroyOneNoContent() *DestroyOneNoContent {
 }
 
 /*
-	DestroyOneNoContent describes a response with status code 204, with default header values.
+DestroyOneNoContent describes a response with status code 204, with default header values.
 
 Deleted
 */
 type DestroyOneNoContent struct {
 }
 
-// IsSuccess returns true when this destroy one no content response returns a 2xx status code
+// IsSuccess returns true when this destroy one no content response has a 2xx status code
 func (o *DestroyOneNoContent) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this destroy one no content response returns a 3xx status code
+// IsRedirect returns true when this destroy one no content response has a 3xx status code
 func (o *DestroyOneNoContent) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this destroy one no content response returns a 4xx status code
+// IsClientError returns true when this destroy one no content response has a 4xx status code
 func (o *DestroyOneNoContent) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this destroy one no content response returns a 5xx status code
+// IsServerError returns true when this destroy one no content response has a 5xx status code
 func (o *DestroyOneNoContent) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this destroy one no content response returns a 4xx status code
+// IsCode returns true when this destroy one no content response a status code equal to that given
 func (o *DestroyOneNoContent) IsCode(code int) bool {
 	return code == 204
+}
+
+// Code gets the status code for the destroy one no content response
+func (o *DestroyOneNoContent) Code() int {
+	return 204
 }
 
 func (o *DestroyOneNoContent) Error() string {
@@ -100,7 +105,7 @@ func NewDestroyOneDefault(code int) *DestroyOneDefault {
 }
 
 /*
-	DestroyOneDefault describes a response with status code -1, with default header values.
+DestroyOneDefault describes a response with status code -1, with default header values.
 
 error
 */
@@ -110,34 +115,34 @@ type DestroyOneDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the destroy one default response
-func (o *DestroyOneDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this destroy one default response returns a 2xx status code
+// IsSuccess returns true when this destroy one default response has a 2xx status code
 func (o *DestroyOneDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this destroy one default response returns a 3xx status code
+// IsRedirect returns true when this destroy one default response has a 3xx status code
 func (o *DestroyOneDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this destroy one default response returns a 4xx status code
+// IsClientError returns true when this destroy one default response has a 4xx status code
 func (o *DestroyOneDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this destroy one default response returns a 5xx status code
+// IsServerError returns true when this destroy one default response has a 5xx status code
 func (o *DestroyOneDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this destroy one default response returns a 4xx status code
+// IsCode returns true when this destroy one default response a status code equal to that given
 func (o *DestroyOneDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the destroy one default response
+func (o *DestroyOneDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *DestroyOneDefault) Error() string {

--- a/examples/todo-list/client/todos/find_responses.go
+++ b/examples/todo-list/client/todos/find_responses.go
@@ -47,7 +47,7 @@ func NewFindOK() *FindOK {
 }
 
 /*
-	FindOK describes a response with status code 200, with default header values.
+FindOK describes a response with status code 200, with default header values.
 
 OK
 */
@@ -55,29 +55,34 @@ type FindOK struct {
 	Payload []*models.Item
 }
 
-// IsSuccess returns true when this find o k response returns a 2xx status code
+// IsSuccess returns true when this find o k response has a 2xx status code
 func (o *FindOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this find o k response returns a 3xx status code
+// IsRedirect returns true when this find o k response has a 3xx status code
 func (o *FindOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this find o k response returns a 4xx status code
+// IsClientError returns true when this find o k response has a 4xx status code
 func (o *FindOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this find o k response returns a 5xx status code
+// IsServerError returns true when this find o k response has a 5xx status code
 func (o *FindOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this find o k response returns a 4xx status code
+// IsCode returns true when this find o k response a status code equal to that given
 func (o *FindOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the find o k response
+func (o *FindOK) Code() int {
+	return 200
 }
 
 func (o *FindOK) Error() string {
@@ -110,7 +115,7 @@ func NewFindDefault(code int) *FindDefault {
 }
 
 /*
-	FindDefault describes a response with status code -1, with default header values.
+FindDefault describes a response with status code -1, with default header values.
 
 error
 */
@@ -120,34 +125,34 @@ type FindDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the find default response
-func (o *FindDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this find default response returns a 2xx status code
+// IsSuccess returns true when this find default response has a 2xx status code
 func (o *FindDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this find default response returns a 3xx status code
+// IsRedirect returns true when this find default response has a 3xx status code
 func (o *FindDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this find default response returns a 4xx status code
+// IsClientError returns true when this find default response has a 4xx status code
 func (o *FindDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this find default response returns a 5xx status code
+// IsServerError returns true when this find default response has a 5xx status code
 func (o *FindDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this find default response returns a 4xx status code
+// IsCode returns true when this find default response a status code equal to that given
 func (o *FindDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the find default response
+func (o *FindDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *FindDefault) Error() string {

--- a/examples/todo-list/client/todos/update_one_responses.go
+++ b/examples/todo-list/client/todos/update_one_responses.go
@@ -47,7 +47,7 @@ func NewUpdateOneOK() *UpdateOneOK {
 }
 
 /*
-	UpdateOneOK describes a response with status code 200, with default header values.
+UpdateOneOK describes a response with status code 200, with default header values.
 
 OK
 */
@@ -55,29 +55,34 @@ type UpdateOneOK struct {
 	Payload *models.Item
 }
 
-// IsSuccess returns true when this update one o k response returns a 2xx status code
+// IsSuccess returns true when this update one o k response has a 2xx status code
 func (o *UpdateOneOK) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this update one o k response returns a 3xx status code
+// IsRedirect returns true when this update one o k response has a 3xx status code
 func (o *UpdateOneOK) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this update one o k response returns a 4xx status code
+// IsClientError returns true when this update one o k response has a 4xx status code
 func (o *UpdateOneOK) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this update one o k response returns a 5xx status code
+// IsServerError returns true when this update one o k response has a 5xx status code
 func (o *UpdateOneOK) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this update one o k response returns a 4xx status code
+// IsCode returns true when this update one o k response a status code equal to that given
 func (o *UpdateOneOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the update one o k response
+func (o *UpdateOneOK) Code() int {
+	return 200
 }
 
 func (o *UpdateOneOK) Error() string {
@@ -112,7 +117,7 @@ func NewUpdateOneDefault(code int) *UpdateOneDefault {
 }
 
 /*
-	UpdateOneDefault describes a response with status code -1, with default header values.
+UpdateOneDefault describes a response with status code -1, with default header values.
 
 error
 */
@@ -122,34 +127,34 @@ type UpdateOneDefault struct {
 	Payload *models.Error
 }
 
-// Code gets the status code for the update one default response
-func (o *UpdateOneDefault) Code() int {
-	return o._statusCode
-}
-
-// IsSuccess returns true when this update one default response returns a 2xx status code
+// IsSuccess returns true when this update one default response has a 2xx status code
 func (o *UpdateOneDefault) IsSuccess() bool {
 	return o._statusCode/100 == 2
 }
 
-// IsRedirect returns true when this update one default response returns a 3xx status code
+// IsRedirect returns true when this update one default response has a 3xx status code
 func (o *UpdateOneDefault) IsRedirect() bool {
 	return o._statusCode/100 == 3
 }
 
-// IsClientError returns true when this update one default response returns a 4xx status code
+// IsClientError returns true when this update one default response has a 4xx status code
 func (o *UpdateOneDefault) IsClientError() bool {
 	return o._statusCode/100 == 4
 }
 
-// IsServerError returns true when this update one default response returns a 5xx status code
+// IsServerError returns true when this update one default response has a 5xx status code
 func (o *UpdateOneDefault) IsServerError() bool {
 	return o._statusCode/100 == 5
 }
 
-// IsCode returns true when this update one default response returns a 4xx status code
+// IsCode returns true when this update one default response a status code equal to that given
 func (o *UpdateOneDefault) IsCode(code int) bool {
 	return o._statusCode == code
+}
+
+// Code gets the status code for the update one default response
+func (o *UpdateOneDefault) Code() int {
+	return o._statusCode
 }
 
 func (o *UpdateOneDefault) Error() string {

--- a/examples/todo-list/restapi/operations/todos/add_one_parameters.go
+++ b/examples/todo-list/restapi/operations/todos/add_one_parameters.go
@@ -6,7 +6,6 @@ package todos
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *AddOneParams) BindRequest(r *http.Request, route *middleware.MatchedRou
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/todo-list/restapi/operations/todos/update_one_parameters.go
+++ b/examples/todo-list/restapi/operations/todos/update_one_parameters.go
@@ -6,7 +6,6 @@ package todos
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -66,7 +65,7 @@ func (o *UpdateOneParams) BindRequest(r *http.Request, route *middleware.Matched
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/tutorials/todo-list/server-2/restapi/operations/todos/add_one_parameters.go
+++ b/examples/tutorials/todo-list/server-2/restapi/operations/todos/add_one_parameters.go
@@ -6,7 +6,6 @@ package todos
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *AddOneParams) BindRequest(r *http.Request, route *middleware.MatchedRou
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/tutorials/todo-list/server-2/restapi/operations/todos/update_one_parameters.go
+++ b/examples/tutorials/todo-list/server-2/restapi/operations/todos/update_one_parameters.go
@@ -6,7 +6,6 @@ package todos
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -67,7 +66,7 @@ func (o *UpdateOneParams) BindRequest(r *http.Request, route *middleware.Matched
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/tutorials/todo-list/server-complete/restapi/operations/todos/add_one_parameters.go
+++ b/examples/tutorials/todo-list/server-complete/restapi/operations/todos/add_one_parameters.go
@@ -6,7 +6,6 @@ package todos
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -60,7 +59,7 @@ func (o *AddOneParams) BindRequest(r *http.Request, route *middleware.MatchedRou
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/examples/tutorials/todo-list/server-complete/restapi/operations/todos/update_one_parameters.go
+++ b/examples/tutorials/todo-list/server-complete/restapi/operations/todos/update_one_parameters.go
@@ -6,7 +6,6 @@ package todos
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -67,7 +66,7 @@ func (o *UpdateOneParams) BindRequest(r *http.Request, route *middleware.Matched
 				res = append(res, err)
 			}
 
-			ctx := validate.WithOperationRequest(context.Background())
+			ctx := validate.WithOperationRequest(r.Context())
 			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}

--- a/generator/templates/client/response.gotmpl
+++ b/generator/templates/client/response.gotmpl
@@ -63,13 +63,6 @@ type {{ pascalize .Name }} struct {
   Payload {{ if and (not .Schema.IsBaseType) (not .Schema.IsInterface) .Schema.IsComplexObject (not .Schema.IsStream) }}*{{ end }}{{ if (not .Schema.IsStream) }}{{ .Schema.GoType }}{{ else }}io.Writer{{end}}
   {{- end }}
 }
-  {{- if eq .Code -1 }}
-
-// Code gets the status code for the {{ humanize .Name }} response
-func ({{ .ReceiverName }} *{{ pascalize .Name }}) Code() int {
-  return {{ .ReceiverName }}._statusCode
-}
-  {{- end }}
 
 // IsSuccess returns true when this {{ humanize .Name }} response has a 2xx status code
 func ({{ .ReceiverName }} *{{ pascalize .Name }}) IsSuccess() bool {
@@ -113,6 +106,15 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) IsCode(code int) bool {
   return {{ .ReceiverName }}._statusCode == code
   {{- else }}
   return code == {{ .Code }}
+  {{- end }}
+}
+
+// Code gets the status code for the {{ humanize .Name }} response
+func ({{ .ReceiverName }} *{{ pascalize .Name }}) Code() int {
+  {{- if eq .Code -1 }}
+  return {{ .ReceiverName }}._statusCode
+  {{- else }}
+  return {{ .Code }}
   {{- end }}
 }
 

--- a/generator/templates/contrib/stratoscale/client/client.gotmpl
+++ b/generator/templates/contrib/stratoscale/client/client.gotmpl
@@ -10,6 +10,7 @@ package {{ .Name }}
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+  "fmt"
   "net/http"
   "github.com/go-openapi/errors"
   "github.com/go-openapi/swag"
@@ -64,7 +65,8 @@ type Client struct {
 */
 func (a *Client) {{ pascalize .Name }}(ctx context.Context, params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
   {{ $length := len .SuccessResponses }}
-  {{ if .SuccessResponse }}result{{else}}_{{ end }}, err := a.transport.Submit(&runtime.ClientOperation{
+  {{ $success := .SuccessResponses }}
+  {{ if .Responses }}result{{else}}_{{end}}, err := a.transport.Submit(&runtime.ClientOperation{
     ID: {{ printf "%q" .Name }},
     Method: {{ printf "%q" .Method }},
     PathPattern: {{ printf "%q" .Path }},
@@ -80,13 +82,30 @@ func (a *Client) {{ pascalize .Name }}(ctx context.Context, params *{{ pascalize
     Client:  params.HTTPClient,
   })
   if err != nil {
-    return {{ if .SuccessResponse }}{{ padSurround "nil" "nil" 0 $length }}, {{ end }}err
+    return {{ if $success }}{{ padSurround "nil" "nil" 0 $length }}, {{ end }}err
   }
-  {{ if .SuccessResponse }}{{ if eq $length 1 }}return result.(*{{ pascalize .SuccessResponse.Name }}), nil{{ else }}switch value := result.(type) { {{ range $i, $v := .SuccessResponses }}
-    case *{{ pascalize $v.Name }}:
-      return {{ padSurround "value" "nil" $i $length }}, nil{{ end }} }
-  return {{ padSurround "nil" "nil" 0 $length }}, nil{{ end }}
-  {{ else }}return nil{{ end }}
-
+  {{- if .Responses }}
+  switch value := result.(type) {
+    {{- range $i, $v := .Responses }}
+  case *{{ pascalize $v.Name }}:
+    {{- if $v.IsSuccess }}
+    return {{ if $success }}{{ padSurround "value" "nil" $i $length }},{{ end }}nil
+    {{- else }}
+    return {{ if $success }}{{ padSurround "nil" "nil" 0 $length }},{{ end }}runtime.NewAPIError("unsuccessful response", value, value.Code())
+    {{- end }}
+    {{- end }}
+  }
+  {{- if .DefaultResponse }}
+  // unexpected success response
+  unexpectedSuccess := result.(*{{ pascalize .DefaultResponse.Name }})
+  return {{ if $success }}{{ padSurround "nil" "nil" 0 $length }}, {{ end }}runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+  {{- else }}
+  // safeguard: normally, absent a default response, unknown success responses return an error above: so this is a codegen issue
+  msg := fmt.Sprintf("unexpected success response for {{ .Name }}: API contract not enforced by server. Client expected to get an error, but got: %T", result)
+  panic(msg)
+  {{- end }}
+  {{- else }}
+  return nil
+  {{- end }}
 }
 {{ end }}


### PR DESCRIPTION
This change adds 2 things

- Expose a Code method that returns the status code from a response
- Handle non-success response types in the stratoscale template.