### PR TITLE
Indicate consumer parse error and provide server response code and message body

### DIFF
--- a/generator/templates/client/response.gotmpl
+++ b/generator/templates/client/response.gotmpl
@@ -191,8 +191,17 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) readResponse(response runtime.
     {{- if not .Schema.IsBaseType }}
 
   // response payload
-  if err := consumer.Consume(response.Body(), {{ if not (or .Schema.IsComplexObject .Schema.IsStream) }}&{{ end}}{{ .ReceiverName }}.Payload); err != nil && err != io.EOF {
-    return err
+
+	buf := new(bytes.Buffer)
+	_, err := buf.ReadFrom(response.Body())
+	if err != nil {
+		return err
+	}
+	b := buf.Bytes()
+	responseBodyStr := string(b)
+  
+  if err := consumer.Consume(bytes.NewReader(b), {{ if not (or .Schema.IsComplexObject .Schema.IsStream) }}&{{ end}}{{ .ReceiverName }}.Payload); err != nil && err != io.EOF {
+		return fmt.Errorf("error occured while consuming server response payload.\n%d\n%s", response.Code(), responseBodyStr)
   }
     {{- end }}
   {{- end }}

--- a/generator/templates/client/response.gotmpl
+++ b/generator/templates/client/response.gotmpl
@@ -200,9 +200,16 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) readResponse(response runtime.
 	b := buf.Bytes()
 	responseBodyStr := string(b)
   
+  {{- if .Schema.IsArray and not .Schema.IsComplexObject}}
+	err = json.Unmarshal(b, &{{ .ReceiverName }}.Payload)
+	if err != nil {
+		return fmt.Errorf("error occured while consuming server response payload.\n%d\n%s", response.Code(), responseBodyStr)
+	}
+  {{- else }}
   if err := consumer.Consume(bytes.NewReader(b), {{ if not (or .Schema.IsComplexObject .Schema.IsStream) }}&{{ end}}{{ .ReceiverName }}.Payload); err != nil && err != io.EOF {
 		return fmt.Errorf("error occured while consuming server response payload.\n%d\n%s", response.Code(), responseBodyStr)
   }
+  {{- end }}
     {{- end }}
   {{- end }}
 


### PR DESCRIPTION
When the server returns an error for unexpected communication errors eg. using http schema instead of https, the parser error message could be misleading and not helpful at all.