### PR TITLE
fix issue: change scan parameter `in` from `form` to `formData`

### DIFF
--- a/codescan/route_params.go
+++ b/codescan/route_params.go
@@ -54,7 +54,7 @@ const (
 )
 
 var (
-	validIn    = []string{"path", "query", "header", "body", "form"}
+	validIn    = []string{"path", "query", "header", "body", "formData"}
 	basicTypes = []string{TypeInteger, TypeNumber, TypeString, TypeBoolean, TypeBool, TypeArray}
 )
 

--- a/scan/route_params.go
+++ b/scan/route_params.go
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	validIn    = []string{"path", "query", "header", "body", "form"}
+	validIn    = []string{"path", "query", "header", "body", "formData"}
 	basicTypes = []string{TypeInteger, TypeNumber, TypeString, TypeBoolean, TypeBool, TypeArray}
 )
 


### PR DESCRIPTION
validIn parameters seems incorrect, should use formData instead of form