### PR TITLE
Fixes PropertiesSpecOrder not being used

### DIFF
--- a/generator/spec.go
+++ b/generator/spec.go
@@ -98,6 +98,10 @@ func (g *GenOpts) analyzeSpec() (*loads.Document, *analysis.Spec, error) {
 	// spec preprocessing option
 	if g.PropertiesSpecOrder {
 		g.Spec = WithAutoXOrder(g.Spec)
+		specDoc, err = loads.Spec(g.Spec)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	// analyze the spec


### PR DESCRIPTION
Users can pass in --keep-spec-order to maintain the field order when generating go code. This flag is not actually respected, and fields are generated in alphabetical order. The reason for this is WithAutoXOrder generates a new YAML with x-order set on definition properties, however the new spec YAML is never actually used. This PR fixes this by reloading g.Spec if PropertiesSpecOrder is set.

The bug can be reproduced by running swagger@HEAD against `https://github.com/go-swagger/go-swagger/blob/master/fixtures/codegen/keep-spec-order.yml`, e.g. `swagger generate client --spec keep-spec-order.yml --keep-spec-order`

cc @casualjim 