### PR TITLE
Skip `ContextValidate` when the field is `nil` avoiding a panic fixing #2911

### DIFF
--- a/fixtures/bugs/2911/fixture-2911.yaml
+++ b/fixtures/bugs/2911/fixture-2911.yaml
@@ -1,0 +1,49 @@
+swagger: '2.0'
+info:
+  title: Title
+  description: some description
+  contact:
+    name: John Doe
+    url: https://www.acme.com/support
+    email: support@acme.com
+  version: "1.0.0"
+paths:
+  /:
+    get:
+      responses:
+        200:
+          description: Example path
+          schema:
+            type: string
+        default:
+          description: generic error
+          schema:
+            type: string
+definitions:
+  animal:
+    type: 'object'
+    properties:
+      kind:
+        $ref: '#/definitions/pet'
+  pet:
+    type: object
+    required: [type]
+    discriminator: type
+    properties:
+      type:
+        $ref: '#/definitions/petType'
+
+  petType:
+    type: string
+    enum:
+      - dog
+      - cat
+
+  dog:
+    allOf:
+      - $ref: '#/definitions/pet'
+        type: object
+  cat:
+    allOf:
+      - $ref: '#/definitions/pet'
+        type: object

--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -451,6 +451,15 @@
       {{- if and .IsNullable (not .IsMapNullOverride) }}
       if {{ .ValueExpression }} != nil {
       {{- end }}
+      {{ if not .Required }}
+              {{- if .IsInterface }}
+      if {{ .ValueExpression }} == nil { // not required
+              {{- else }}
+      if swag.IsZero({{ .ValueExpression }}) { // not required
+              {{- end }}
+        return nil
+      }
+      {{ end }}
       if err := {{.ValueExpression }}.ContextValidate(ctx, formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
           return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})


### PR DESCRIPTION
Fixes issue #2911 

- a4b8a2de152c56ed58d299d402a4a8e523689035 modifies the model template to add the `swag.IsZero` condition.
- 90c671d3a324075dba949a6f79fb50c851bf4593 adds a small test verifying that the added condition is indeed in the resulting code