### PR TITLE
Fixed panic in AddMiddlewareFor method if method is not uppercase

### DIFF
--- a/generator/templates/server/builder.gotmpl
+++ b/generator/templates/server/builder.gotmpl
@@ -441,6 +441,6 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}API) AddMiddlewareFor(method, path
   }
   {{.ReceiverName}}.Init()
   if h, ok := {{.ReceiverName}}.handlers[um][path]; ok {
-    {{.ReceiverName}}.handlers[method][path] = builder(h)
+    {{.ReceiverName}}.handlers[um][path] = builder(h)
   }
 }


### PR DESCRIPTION
If you call a method and pass a non uppercase word as an argument to method, it will inevitably panics because we are not using the same (that we checked when getting) value as the key when setting the value.