### PR TITLE
fix timeout of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ run:
     - playground
     - fixtures
     - cmd
+  timeout: 5m
 
 linters:
   enable:


### PR DESCRIPTION
golangci-lint often exit with code 4, which represents timeout, after PR merge into master.
This is due to the default settings of golangci-lint, [which is 1m](https://golangci-lint.run/usage/configuration/), and timeout option can be set.
In most cases, they're over the time limit slightly, which were just a few seconds, so that I think it's good to pass timeout option and set as 5m as lots of OSS do.
<img width="1320" alt="image" src="https://github.com/go-swagger/go-swagger/assets/64164948/7af005f7-210e-4a12-8463-e5f6f8955cf1">
