### PR TITLE
Fix typo in codescan/spec.go

### DIFF
--- a/codescan/spec.go
+++ b/codescan/spec.go
@@ -54,7 +54,7 @@ func (s *specBuilder) Build() (*spec.Swagger, error) {
 		return nil, err
 	}
 
-	if err := s.buildRespones(); err != nil {
+	if err := s.buildResponses(); err != nil {
 		return nil, err
 	}
 
@@ -160,7 +160,7 @@ func (s *specBuilder) buildRoutes() error {
 	return nil
 }
 
-func (s *specBuilder) buildRespones() error {
+func (s *specBuilder) buildResponses() error {
 	// build responses dictionary
 	for _, decl := range s.ctx.app.Responses {
 		rb := &responseBuilder{


### PR DESCRIPTION
I was reading through your project's code and noticed a small typo in the codescan/spec. 
I've corrected it in this pull request.