### PR TITLE
Support type alias when generating spec

### DIFF
--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -358,9 +358,12 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 			return nil
 		}
 
+		if s.decl.Spec.Assign.IsValid() {
+			return s.buildFromType(titpe.Underlying(), tgt)
+		}
+
 		switch utitpe := tpe.Underlying().(type) {
 		case *types.Struct:
-
 			if decl, ok := s.ctx.FindModel(tio.Pkg().Path(), tio.Name()); ok {
 				if decl.Type.Obj().Pkg().Path() == "time" && decl.Type.Obj().Name() == "Time" {
 					tgt.Typed("string", "date-time")

--- a/fixtures/goparsing/spec/api.go
+++ b/fixtures/goparsing/spec/api.go
@@ -25,7 +25,9 @@ import (
 // Customer of the site.
 //
 // swagger:model Customer
-type Customer struct {
+type Customer = User
+
+type User struct {
 	Name string `json:"name"`
 }
 


### PR DESCRIPTION
I'd like to support type alias when generating spec.

Changed test will generate spec like this:
```json
"Customer": {
    "title": "Customer of the site.",
    "$ref": "#/definitions/Customer"
}
```

After adding 3 lines of code, the spec is back to normal.