### PR TITLE
Add support for x-go-custom-tag in generated parameter

### DIFF
--- a/generator/operation.go
+++ b/generator/operation.go
@@ -739,6 +739,16 @@ func (b *codeGenOpBuilder) MakeParameter(receiver string, resolver *typeResolver
 		Extensions:       param.Extensions,
 	}
 
+	if goCustomTag, ok := param.Extensions["x-go-custom-tag"]; ok {
+		customTag, ok := goCustomTag.(string)
+		if !ok {
+			return GenParameter{}, fmt.Errorf(`%s %s, parameter %q: "x-go-custom-tag" field must be a string, not a %T`,
+				b.Method, b.Path, param.Name, goCustomTag)
+		}
+
+		res.CustomTag = customTag
+	}
+
 	if param.In == "body" {
 		// Process parameters declared in body (i.e. have a Schema)
 		res.Required = param.Required

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -361,6 +361,8 @@ type GenParameter struct {
 
 	CollectionFormat string
 
+	CustomTag string
+
 	Child  *GenItems
 	Parent *GenItems
 


### PR DESCRIPTION
Sometimes we need to give a custom tag to parameters for handling specific needs, such as creating identifier which parameters is used as a pagination filter