### PR TITLE
Fix description for write timeout default value

### DIFF
--- a/docs/generate/server.md
+++ b/docs/generate/server.md
@@ -101,7 +101,7 @@ The generated server allows for a number of command line parameters to customize
       --tls-port int                 the port to listen on for secure connections, defaults to a random value
       --tls-read-timeout duration    maximum duration before timing out read of the request (default 30s)
       --tls-write-timeout duration   maximum duration before timing out write of the response (default 30s)
-      --write-timeout duration       maximum duration before timing out write of the response (default 30s)
+      --write-timeout duration       maximum duration before timing out write of the response (default 60s)
 ```
 
 The server takes care of a number of things when a request arrives:

--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -124,7 +124,7 @@ func init() {
 	flag.IntVar(&listenLimit, "listen-limit", 0, "limit the number of outstanding requests")
 	flag.DurationVar(&keepAlive, "keep-alive", 3*time.Minute, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")
 	flag.DurationVar(&readTimeout, "read-timeout", 30*time.Second, "maximum duration before timing out read of the request")
-	flag.DurationVar(&writeTimeout, "write-timeout", 30*time.Second, "maximum duration before timing out write of the response")
+	flag.DurationVar(&writeTimeout, "write-timeout", 60*time.Second, "maximum duration before timing out write of the response")
 
 	flag.StringVar(&tlsHost, "tls-host", "localhost", "the IP to listen on")
 	flag.IntVar(&tlsPort, "tls-port", 0, "the port to listen on for secure connections, defaults to a random value")


### PR DESCRIPTION
The default value for --write-timeout is defined in gotmple (generated server struct part):
https://github.com/go-swagger/go-swagger/blob/6a14cbceb631a433899a34201dc9eca44f46a1b2/generator/templates/server/server.gotmpl#L233