### PR TITLE
Updated to handle cases where 'body' is not present in the YAML file …

### DIFF
--- a/cmd/swagger/commands/diff/spec_analyser.go
+++ b/cmd/swagger/commands/diff/spec_analyser.go
@@ -231,7 +231,15 @@ func (sd *SpecAnalyser) analyseResponseParams() {
 			// deleted responses
 			for code1 := range op1Responses {
 				if _, ok := op2Responses[code1]; !ok {
-					location := DifferenceLocation{URL: eachURLMethodFrom2.Path, Method: eachURLMethodFrom2.Method, Response: code1, Node: getSchemaDiffNode("Body", op1Responses[code1].Schema)}
+					location := DifferenceLocation{
+						URL:      eachURLMethodFrom2.Path,
+						Method:   eachURLMethodFrom2.Method,
+						Response: code1,
+						Node:     getNameOnlyDiffNode("NoContent"),
+					}
+					if op1Responses[code1].Schema != nil {
+						location.Node = getSchemaDiffNode("Body", op1Responses[code1].Schema)
+					}
 					sd.Diffs = sd.Diffs.addDiff(SpecDifference{DifferenceLocation: location, Code: DeletedResponse})
 				}
 			}


### PR DESCRIPTION
I have addressed GitHub Issue https://github.com/go-swagger/go-swagger/issues/2952 
Updated to handle cases where 'body' is not present in the YAML file without causing an error.
