### PR TITLE
Feat: new client constructors wo go-openapi

### DIFF
--- a/generator/templates/client/client.gotmpl
+++ b/generator/templates/client/client.gotmpl
@@ -16,7 +16,7 @@ import (
 
   "github.com/go-openapi/errors"
   "github.com/go-openapi/runtime"
-  "github.com/go-openapi/runtime/client"
+  httptransport "github.com/go-openapi/runtime/client"
   "github.com/go-openapi/strfmt"
   "github.com/go-openapi/swag"
   "github.com/go-openapi/validate"
@@ -38,8 +38,8 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientServi
 // - user: user for basic authentication header.
 // - password: password for basic authentication header.
 func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
-  transport := client.New(host, basePath, []string{scheme})
-  transport.DefaultAuthentication = client.BasicAuth(user, password)
+  transport := httptransport.New(host, basePath, []string{scheme})
+  transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
   return &Client{transport: transport, formats: strfmt.Default}
 }
 
@@ -50,8 +50,8 @@ func NewClientWithBasicAuth(host, basePath, scheme, user, password string) Clien
 // - scheme: http scheme ("http", "https").
 // - bearerToken: bearer token for Bearer authentication header.
 func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
-  transport := client.New(host, basePath, []string{scheme})
-  transport.DefaultAuthentication = client.BearerToken(bearerToken)
+  transport := httptransport.New(host, basePath, []string{scheme})
+  transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
   return &Client{transport: transport, formats: strfmt.Default}
 }
 

--- a/generator/templates/client/client.gotmpl
+++ b/generator/templates/client/client.gotmpl
@@ -16,6 +16,7 @@ import (
 
   "github.com/go-openapi/errors"
   "github.com/go-openapi/runtime"
+  "github.com/go-openapi/runtime/client"
   "github.com/go-openapi/strfmt"
   "github.com/go-openapi/swag"
   "github.com/go-openapi/validate"
@@ -37,8 +38,8 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientServi
 // - user: user for basic authentication header.
 // - password: password for basic authentication header.
 func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
-  transport := httptransport.New(host, basePath, []string{scheme})
-  transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+  transport := client.New(host, basePath, []string{scheme})
+  transport.DefaultAuthentication = client.BasicAuth(user, password)
   return &Client{transport: transport, formats: strfmt.Default}
 }
 
@@ -49,8 +50,8 @@ func NewClientWithBasicAuth(host, basePath, scheme, user, password string) Clien
 // - scheme: http scheme ("http", "https").
 // - bearerToken: bearer token for Bearer authentication header.
 func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
-  transport := httptransport.New(host, basePath, []string{scheme})
-  transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+  transport := client.New(host, basePath, []string{scheme})
+  transport.DefaultAuthentication = client.BearerToken(bearerToken)
   return &Client{transport: transport, formats: strfmt.Default}
 }
 

--- a/generator/templates/client/client.gotmpl
+++ b/generator/templates/client/client.gotmpl
@@ -29,6 +29,31 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientServi
   return &Client{transport: transport, formats: formats}
 }
 
+// New creates a new {{ humanize .Name }} API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+  transport := httptransport.New(host, basePath, []string{scheme})
+  transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+  return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new {{ humanize .Name }} API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+  transport := httptransport.New(host, basePath, []string{scheme})
+  transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+  return &Client{transport: transport, formats: strfmt.Default}
+}
+
 /*
 Client {{ if .Summary }}{{ .Summary }}{{ if .Description }}
 


### PR DESCRIPTION
This adds a couple constructors for initializing a client WITHOUT having to use the `go-openapi` structs. 

Note: I tried running the tests and most passed, but the build_test.go file that uses the fixtures did not seem to pass. The errors were related to httptransport being undefined. I do have this installed, so not sure why I got this error. I did build the project successfully, so not sure why these errors were occurring? Any guidance appreciated. 