### PR TITLE
use Go standard errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,24 @@
 linters-settings:
-  govet:
-    check-shadowing: true
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 25
-  maligned:
-    suggest-new: true
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages-with-error-message:
+      - github.com/pkg/errors: "Use errors or fmt instead of github.com/pkg/errors"
   dupl:
     threshold: 200
   goconst:
     min-len: 2
     min-occurrences: 2
+  gocyclo:
+    min-complexity: 25
+  goimports:
+    local-prefixes: github.com/go-swagger/go-swagger
+  golint:
+    min-confidence: 0
+  govet:
+    check-shadowing: true
+  maligned:
+    suggest-new: true
 
 run:
   skip-dirs:
@@ -22,18 +29,20 @@ run:
 
 linters:
   enable:
-    - revive
+    - depguard
+    - errorlint
     - gocritic
-    - stylecheck
-    # - goimports
+    - gofumpt
+    - goimports
     - gosec
+    - revive
+    - stylecheck
     - unconvert
   disable:
-    - maligned
-    - unparam
-    - lll
-    - gochecknoinits
-    - gochecknoglobals
     - dupl
+    - gochecknoglobals
+    - gochecknoinits
+    - lll
+    - maligned
     - nakedret
-
+    - unparam

--- a/cmd/swagger/commands/diff.go
+++ b/cmd/swagger/commands/diff.go
@@ -2,12 +2,11 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
-
-	"errors"
 
 	"github.com/go-openapi/loads"
 	"github.com/go-swagger/go-swagger/cmd/swagger/commands/diff"

--- a/codescan/parameters.go
+++ b/codescan/parameters.go
@@ -8,8 +8,6 @@ import (
 
 	"golang.org/x/tools/go/ast/astutil"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-openapi/spec"
 )
 
@@ -117,6 +115,7 @@ func (sv paramValidations) SetMaximum(val float64, exclusive bool) {
 	sv.current.Maximum = &val
 	sv.current.ExclusiveMaximum = exclusive
 }
+
 func (sv paramValidations) SetMinimum(val float64, exclusive bool) {
 	sv.current.Minimum = &val
 	sv.current.ExclusiveMinimum = exclusive
@@ -143,6 +142,7 @@ func (sv itemsValidations) SetMaximum(val float64, exclusive bool) {
 	sv.current.Maximum = &val
 	sv.current.ExclusiveMaximum = exclusive
 }
+
 func (sv itemsValidations) SetMinimum(val float64, exclusive bool) {
 	sv.current.Minimum = &val
 	sv.current.ExclusiveMinimum = exclusive
@@ -168,7 +168,6 @@ type parameterBuilder struct {
 }
 
 func (p *parameterBuilder) Build(operations map[string]*spec.Operation) error {
-
 	// check if there is a swagger:parameters tag that is followed by one or more words,
 	// these words are the ids of the operations this parameter struct applies to
 	// once type name is found convert it to a schema, by looking up the schema in the
@@ -210,10 +209,10 @@ func (p *parameterBuilder) buildFromType(otpe types.Type, op *spec.Operation, se
 			}
 			return p.buildFromStruct(p.decl, stpe, op, seen)
 		default:
-			return errors.Errorf("unhandled type (%T): %s", stpe, o.Type().Underlying().String())
+			return fmt.Errorf("unhandled type (%T): %s", stpe, o.Type().Underlying().String())
 		}
 	default:
-		return errors.Errorf("unhandled type (%T): %s", otpe, tpe.String())
+		return fmt.Errorf("unhandled type (%T): %s", otpe, tpe.String())
 	}
 }
 
@@ -279,9 +278,9 @@ func (p *parameterBuilder) buildFromField(fld *types.Var, tpe types.Type, typabl
 			p.postDecls = append(p.postDecls, sb.postDecls...)
 			return nil
 		}
-		return errors.Errorf("unable to find package and source file for: %s", ftpe.String())
+		return fmt.Errorf("unable to find package and source file for: %s", ftpe.String())
 	default:
-		return errors.Errorf("unknown type for %s: %T", fld.String(), fld.Type())
+		return fmt.Errorf("unknown type for %s: %T", fld.String(), fld.Type())
 	}
 }
 

--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -2,6 +2,7 @@ package codescan
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/ast"
 	"reflect"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/go-openapi/loads/fmts"
 	"github.com/go-openapi/spec"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 

--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -1,12 +1,11 @@
 package codescan
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/types"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"golang.org/x/tools/go/ast/astutil"
 
@@ -215,9 +214,9 @@ func (r *responseBuilder) buildFromField(fld *types.Var, tpe types.Type, typable
 			r.postDecls = append(r.postDecls, sb.postDecls...)
 			return nil
 		}
-		return errors.Errorf("unable to find package and source file for: %s", ftpe.String())
+		return fmt.Errorf("unable to find package and source file for: %s", ftpe.String())
 	default:
-		return errors.Errorf("unknown type for %s: %T", fld.String(), fld.Type())
+		return fmt.Errorf("unknown type for %s: %T", fld.String(), fld.Type())
 	}
 }
 
@@ -256,7 +255,7 @@ func (r *responseBuilder) buildFromType(otpe types.Type, resp *spec.Response, se
 				r.postDecls = append(r.postDecls, sb.postDecls...)
 				return nil
 			}
-			return errors.Errorf("responses can only be structs, did you mean for %s to be the response body?", otpe.String())
+			return fmt.Errorf("responses can only be structs, did you mean for %s to be the response body?", otpe.String())
 		}
 	default:
 		return errors.New("anonymous types are currently not supported for responses")

--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -2,6 +2,7 @@ package codescan
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/importer"
@@ -15,7 +16,6 @@ import (
 	"golang.org/x/tools/go/ast/astutil"
 
 	"github.com/go-openapi/spec"
-	"github.com/pkg/errors"
 )
 
 func addExtension(ve *spec.VendorExtensible, key string, value interface{}) {
@@ -92,6 +92,7 @@ func (sv schemaValidations) SetMaximum(val float64, exclusive bool) {
 	sv.current.Maximum = &val
 	sv.current.ExclusiveMaximum = exclusive
 }
+
 func (sv schemaValidations) SetMinimum(val float64, exclusive bool) {
 	sv.current.Minimum = &val
 	sv.current.ExclusiveMinimum = exclusive
@@ -895,7 +896,7 @@ func (s *schemaBuilder) buildAllOf(tpe types.Type, schema *spec.Schema) error {
 				}
 				return s.buildFromStruct(decl, utpe, schema, make(map[string]string))
 			}
-			return errors.Errorf("can't find source file for struct: %s", ftpe.String())
+			return fmt.Errorf("can't find source file for struct: %s", ftpe.String())
 		case *types.Interface:
 			decl, found := s.ctx.FindModel(ftpe.Obj().Pkg().Path(), ftpe.Obj().Name())
 			if found {
@@ -908,7 +909,7 @@ func (s *schemaBuilder) buildAllOf(tpe types.Type, schema *spec.Schema) error {
 				}
 				return s.buildFromInterface(decl, utpe, schema, make(map[string]string))
 			}
-			return errors.Errorf("can't find source file for interface: %s", ftpe.String())
+			return fmt.Errorf("can't find source file for interface: %s", ftpe.String())
 		default:
 			log.Printf("WARNING: can't figure out object type for allOf named type (%T): %v", ftpe, ftpe.Underlying())
 			return fmt.Errorf("unable to locate source file for allOf %s", utpe.String())
@@ -932,13 +933,13 @@ func (s *schemaBuilder) buildEmbedded(tpe types.Type, schema *spec.Schema, seen 
 			if found {
 				return s.buildFromStruct(decl, utpe, schema, seen)
 			}
-			return errors.Errorf("can't find source file for struct: %s", ftpe.String())
+			return fmt.Errorf("can't find source file for struct: %s", ftpe.String())
 		case *types.Interface:
 			decl, found := s.ctx.FindModel(ftpe.Obj().Pkg().Path(), ftpe.Obj().Name())
 			if found {
 				return s.buildFromInterface(decl, utpe, schema, seen)
 			}
-			return errors.Errorf("can't find source file for struct: %s", ftpe.String())
+			return fmt.Errorf("can't find source file for struct: %s", ftpe.String())
 		default:
 			log.Printf("WARNING: can't figure out object type for embedded named type (%T): %v", ftpe, ftpe.Underlying())
 		}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -289,7 +289,6 @@ github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNc
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
* Since Dec 1, 2021, github.com/pkg/errors is an archived project.
* Since go 1.13, there is a standard errors and fmt modules that provides equivalent ways to handle errors.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>