### PR TITLE
fix(yaml): fixed panic when MarshalYAML returns an error

### DIFF
--- a/cmd/swagger/commands/expand.go
+++ b/cmd/swagger/commands/expand.go
@@ -63,9 +63,10 @@ func writeToFile(swspec *spec.Swagger, pretty bool, format string, output string
 			}
 			var bb interface{}
 			bb, err = data.MarshalYAML()
-			b = bb.([]byte)
+			if err == nil {
+				b = bb.([]byte)
+			}
 		}
-
 	}
 
 	if err != nil {


### PR DESCRIPTION
* contributes #2919

The full fix is provided by https://github.com/go-openapi/swag/pull/75