### PR TITLE
fix(markdown): added support for --target flag

### DIFF
--- a/generator/support.go
+++ b/generator/support.go
@@ -58,6 +58,9 @@ func GenerateMarkdown(output string, modelNames, operationIDs []string, opts *Ge
 	if err := opts.EnsureDefaults(); err != nil {
 		return err
 	}
+	if opts.Target != "" && opts.Target != "." {
+		output = filepath.Join(opts.Target, output)
+	}
 	MarkdownSectionOpts(opts, output)
 
 	generator, err := newAppGenerator("", modelNames, operationIDs, opts)


### PR DESCRIPTION
This PR allows the generate markdown command to abide by the --target flag like other commands.

* fixes #2938