### PR TITLE
fix(diff): fixed diff status on added required property

### DIFF
--- a/cmd/swagger/commands/diff/checks.go
+++ b/cmd/swagger/commands/diff/checks.go
@@ -42,8 +42,8 @@ func CompareProperties(location DifferenceLocation, schema1 *spec.Schema, schema
 
 	schema1Props := propertiesFor(schema1, getRefFn1)
 	schema2Props := propertiesFor(schema2, getRefFn2)
-	// find deleted and changed properties
 
+	// find deleted and changed properties
 	for eachProp1Name, eachProp1 := range schema1Props {
 		eachProp1 := eachProp1
 		childLoc := addChildDiffNode(location, eachProp1Name, eachProp1.Schema)
@@ -66,7 +66,13 @@ func CompareProperties(location DifferenceLocation, schema1 *spec.Schema, schema
 		eachProp2 := eachProp2
 		if _, ok := schema1.Properties[eachProp2Name]; !ok {
 			childLoc := addChildDiffNode(location, eachProp2Name, &eachProp2)
-			propDiffs = append(propDiffs, SpecDifference{DifferenceLocation: childLoc, Code: AddedProperty})
+
+			analyzedProp2 := schema2Props[eachProp2Name]
+			if analyzedProp2.Required {
+				propDiffs = append(propDiffs, SpecDifference{DifferenceLocation: childLoc, Code: AddedRequiredProperty})
+			} else {
+				propDiffs = append(propDiffs, SpecDifference{DifferenceLocation: childLoc, Code: AddedProperty})
+			}
 		}
 	}
 	return propDiffs

--- a/cmd/swagger/commands/diff/compatibility.go
+++ b/cmd/swagger/commands/diff/compatibility.go
@@ -41,7 +41,7 @@ func init() {
 		ForRequest: map[SpecChangeCode]Compatibility{
 			AddedRequiredProperty:     Breaking,
 			DeletedProperty:           Breaking,
-			AddedProperty:             Breaking,
+			AddedProperty:             NonBreaking,
 			AddedOptionalParam:        NonBreaking,
 			AddedRequiredParam:        Breaking,
 			DeletedOptionalParam:      NonBreaking,

--- a/cmd/swagger/commands/diff/spec_analyser_test.go
+++ b/cmd/swagger/commands/diff/spec_analyser_test.go
@@ -117,3 +117,13 @@ func linesInFile(t testing.TB, fileName string) io.ReadCloser {
 	require.NoError(t, err)
 	return file
 }
+
+func TestIssue2962(t *testing.T) {
+	oldSpec := filepath.Join("..", "..", "..", "..", "fixtures", "bugs", "2962", "old.json")
+	newSpec := filepath.Join("..", "..", "..", "..", "fixtures", "bugs", "2962", "new.json")
+	diffs, err := getDiffs(oldSpec, newSpec)
+	require.NoError(t, err)
+
+	require.Len(t, diffs, 3)
+	require.Equal(t, 1, diffs.BreakingChangeCount())
+}

--- a/fixtures/bugs/2962/new.json
+++ b/fixtures/bugs/2962/new.json
@@ -1,0 +1,55 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Fixture",
+    "version": "1.0"
+  },
+  "paths": {
+    "/a/{id}": {
+      "post": {
+        "parameters": [
+          {
+            "name": "",
+            "in": "body",
+            "schema": { "$ref": "#/definitions/A2" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": { "$ref": "#/definitions/A3" }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "A2": {
+      "type": "object",
+      "required": [ "name", "field4" ],
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "field3": { "type": "string" },
+        "field4": { "type": "string" }
+      }
+    },
+    "A3": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "name": { "type": "string" },
+        "otherDeletedName":{"type":"string","deprecated":true},
+        "description": { "type": "string" },
+        "letters": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/fixtures/bugs/2962/old.json
+++ b/fixtures/bugs/2962/old.json
@@ -1,0 +1,53 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Fixture",
+    "version": "1.0"
+  },
+  "paths": {
+    "/a/{id}": {
+      "post": {
+        "parameters": [
+          {
+            "name": "",
+            "in": "body",
+            "schema": { "$ref": "#/definitions/A2" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": { "$ref": "#/definitions/A3" }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "A2": {
+      "type": "object",
+      "required": [ "name", "description" ],
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "A3": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "name": { "type": "string" },
+        "otherDeletedName":{"type":"string","deprecated":true},
+        "description": { "type": "string" },
+        "letters": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A non-required added property in a request should not be reported as a breaking change.

Fixed the change status of added properties depending on being required or not in the new specification.

* fixes #2962