### PR TITLE
fix(client): alleviates issues with pointers in error reporting

### DIFF
--- a/fixtures/bugs/2590/2590.yaml
+++ b/fixtures/bugs/2590/2590.yaml
@@ -1,0 +1,76 @@
+swagger: "2.0"
+info:
+  version: "1.0.0"
+  title: generating client with error reporting
+  description: verify that generated code prints errors
+paths:
+  /abc:
+    post:
+      tags:
+        - "abc"
+      summary: "Create a new ABC"
+      description: ""
+      operationId: "create"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "body"
+          name: "abc"
+          required: true
+          schema:
+            $ref: "#/definitions/abc"
+      responses:
+        202:
+          description: "Accepted"
+          schema:
+            $ref: '#/definitions/abc'
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        409:
+          $ref: '#/responses/Conflict'
+        500:
+          $ref: '#/responses/InternalError'
+        default:
+          description: "default response"
+          schema:
+
+definitions:
+  abc:
+    type: string
+
+  Error:
+    type: "object"
+    properties:
+      message:
+        type: string
+        x-nullable: false
+        minLength: 1
+    required:
+      - message
+
+responses:
+  Unauthorized:
+    description: "Unauthorized"
+    schema:
+      $ref: '#/definitions/Error'
+  NotFound:
+    description: "Not found"
+    schema:
+      $ref: '#/definitions/Error'
+  InternalError:
+    description: "Inernal Server Error"
+    schema:
+      $ref: '#/definitions/Error'
+  BadRequest:
+    description: "Bad Request"
+    schema:
+      $ref: '#/definitions/Error'
+  Conflict:
+    description: "Conflict"
+    schema:
+      $ref: '#/definitions/Error'
+

--- a/generator/templates/client/response.gotmpl
+++ b/generator/templates/client/response.gotmpl
@@ -119,11 +119,17 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) Code() int {
 }
 
 func ({{ .ReceiverName }} *{{ pascalize .Name }}) Error() string {
-	return fmt.Sprintf("[{{ upper .Method }} {{ .Path }}][%d] {{ if .Name }}{{ .Name }} {{ else }}unknown error {{ end }}{{ if .Schema }} %+v{{ end }}", {{ if eq .Code -1 }}{{ .ReceiverName }}._statusCode{{ else }}{{ .Code }}{{ end }}{{ if .Schema }}, o.Payload{{ end }})
+  {{- if .Schema }}{{ if (not .Schema.IsStream) }}
+  payload, _ := json.Marshal(o.Payload)
+  {{- end }}{{- end }}
+	return fmt.Sprintf("[{{ upper .Method }} {{ .Path }}][%d] {{ if .Name }}{{ .Name }} {{ else }}unknown error {{ end }}{{ if .Schema }} %s{{ end }}", {{ if eq .Code -1 }}{{ .ReceiverName }}._statusCode{{ else }}{{ .Code }}{{ end }}{{ if .Schema }}{{ if not .Schema.IsStream }}, payload{{ end }}{{ end }})
 }
 
 func ({{ .ReceiverName }} *{{ pascalize .Name }}) String() string {
-	return fmt.Sprintf("[{{ upper .Method }} {{ .Path }}][%d] {{ if .Name }}{{ .Name }} {{ else }}unknown response {{ end }}{{ if .Schema }} %+v{{ end }}", {{ if eq .Code -1 }}{{ .ReceiverName }}._statusCode{{ else }}{{ .Code }}{{ end }}{{ if .Schema }}, o.Payload{{ end }})
+  {{- if .Schema }}{{ if (not .Schema.IsStream) }}
+  payload, _ := json.Marshal(o.Payload)
+  {{- end }}{{- end }}
+	return fmt.Sprintf("[{{ upper .Method }} {{ .Path }}][%d] {{ if .Name }}{{ .Name }} {{ else }}unknown response {{ end }}{{ if .Schema }} %s{{ end }}", {{ if eq .Code -1 }}{{ .ReceiverName }}._statusCode{{ else }}{{ .Code }}{{ end }}{{ if .Schema }}{{ if not .Schema.IsStream }}, payload{{ end }}{{ end }})
 }
 
 {{ if .Schema }}


### PR DESCRIPTION
As suggested in #2590, this PR replaces
fmt.Sprintf("%+v", somePayloadPossiblyAPointer)
by a JSON representation of the payload

This is only enabled when the response has a Schema and this is not a stream.

* fixes #2590