### PR TITLE
fix(mangling): fixes name mangling in the presence of a special character

### DIFF
--- a/fixtures/bugs/2821/ServiceManagementBody.json
+++ b/fixtures/bugs/2821/ServiceManagementBody.json
@@ -1,0 +1,5502 @@
+{
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "http"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "description": "API Gateway Service Management Service allows you to manage the APIs in the API Gateway. Any user with the 'Manage APIs' functional privilege can manage the APIs in the API Gateway. By default, the users who are part of either API-Gateway-Providers or API-Gateway-Administrators groups will have this privilege.\n\nAPI Gateway supports four types of APIs - REST APIs, SOAP APIs, WebSocket APIs and OData APIs. REST APIs can be created by providing the swagger (file/url), openAPI (file/url), raml (file/url) or can be created from scratch. SOAP APIs can be created using the WSDL (file/url). If the API definitions has reference schemas, then an archive containing all the definitions can be provided as an input. WebSocket APIs can be created from scratch. OData APIs can be created using their service document or metadata document url.\n\nThis service provides you with the options to create, update, read and delete of all the above API types.\n\nAn API can either be in an Active or an InActive state. An Active state indicates that the API is available for consumers. The users can use this service to activate or deactivate the API. Post activation, API Gateway generates 'Gateway Endpoints' which can be used by the API consumers to access the API.  Generally API consumers use their applications to consume the APIs.\n\nThis service can also be used to manage the API Scopes. An API Scope is a collection of resources or operations in the API. Users can create multiple scopes for a single API.\n\nOnce the API is created, users can enforce the access restrictions and other rules on the API by add the policies to the API. Policies can be attached to REST, SOAP and OData APIs.  Refer to the Policy Management API documentation for more details on the policies. Refer to the Document Management API documentation for more details on attaching documents to an API.\n\nThis service can also be used to publish/unpublish the APIs to/from a service registry.  An API in an active state can be registered (published) to one or more service registries.",
+    "title": "API Gateway Service Management Service",
+    "version": "10.7"
+  },
+  "host": "localhost:5555",
+  "basePath": "/rest/apigateway",
+  "paths": {
+    "/apis": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Get all APIs or subset of APIs",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getAPIs",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864,353bd366-47d4-4703-aecf-9cb40cdcc345",
+            "description": "API Ids for the API to be retrieved",
+            "name": "apiIds",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "Starting index from the list of APIs to be retrieved",
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "Number of APIs to be retrieved",
+            "name": "size",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the list of all APIs",
+            "schema": {
+              "$ref": "#/definitions/APIResponsesModel"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"apiResponse\": [\r\n    {\r\n      \"api\": {\r\n        \"apiName\": \"ChuckNorrisAPI\",\r\n        \"apiVersion\": \"v2\",\r\n        \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n        \"isActive\": false,\r\n        \"type\": \"REST\",\r\n        \"publishedPortals\": [],\r\n        \"systemVersion\": 2,\r\n        \"id\": \"46df4227-a100-486c-9580-0bf388ec6ec7\"\r\n      },\r\n      \"responseStatus\": \"SUCCESS\"\r\n    },\r\n    {\r\n      \"api\": {\r\n        \"apiName\": \"ChuckNorrisAPI\",\r\n        \"apiVersion\": \"1.0\",\r\n        \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n        \"isActive\": false,\r\n        \"type\": \"REST\",\r\n        \"publishedPortals\": [],\r\n        \"systemVersion\": 1,\r\n        \"id\": \"25fb937a-8360-41ab-8be5-987b14fe631d\"\r\n      },\r\n      \"responseStatus\": \"SUCCESS\",\r\n  \"teams\": [\r\n                {\r\n                    \"id\": \"Administrators\",\r\n                    \"name\": \"Administrators\",\r\n                    \"canDelete\": \"false\"\r\n                },\r\n                {\r\n                    \"id\": \"Default\",\r\n                    \"name\": \"Default\",\r\n                    \"canDelete\": \"true\"\r\n                }\r\n            ]\r\n      }\r\n  ]\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "This REST operation is used to create an API by importing a file, url or from scratch",
+        "consumes": [
+          "application/json",
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "createAPI",
+        "parameters": [
+          {
+            "x-examples": {
+              "application/json": "{\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\",\r\n           \r\n\t\"teams\": [\r\n\t\t{\r\n\t\t\t\"id\": \"Default\"\r\n\t\t}\r\n\t]\r\n     }"
+            },
+            "description": "API request payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InputAPI"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the created API object",
+            "schema": {
+              "$ref": "#/definitions/APIResponseCreate"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"1.0\",\r\n                \"apiId\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n            }\r\n        ],\r\n        \"teams\": [\r\n            {\r\n                \"id\": \"Administrators\",\r\n                \"name\": \"Administrators\",\r\n                \"canDelete\": \"false\"\r\n            },\r\n            {\r\n                \"id\": \"Default\",\r\n                \"name\": \"Default\",\r\n                \"canDelete\": \"true\"\r\n            }\r\n        ]   }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the user missed the mandatory fields like type, file/url/apiDefinition in the request or provide a invalid request body"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Delete the inactive APIs",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "deleteAPIs",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864,353bd366-47d4-4703-aecf-9cb40cdcc854",
+            "description": "API Ids for the APIs to be deleted. Multiple API ids combined by comma",
+            "name": "apiIds",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "x-example": true,
+            "description": "Flag for force delete. Required when API is associated with some applications",
+            "name": "forceDelete",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the apiId along with the error when unsuccessful",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/APIResponseDelete"
+              }
+            }
+          },
+          "204": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "This response code returns when the mandatory parameter apiIds is missing in the query parameter"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          }
+        }
+      }
+    },
+    "/apis/{apiId}": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Retrieve an API based on the API id.",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be retrieved",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-example": "raml",
+            "description": "Output format of the API. If the value is 'swagger', you get a API definition in swagger format. If the value is 'raml', you get a raml document. If the value is 'openapi', you get a open API document. If the value is 'odata', you get a zip file holding the OData metadata and service document.",
+            "name": "format",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-example": "http://hostname:5555/gateway/servicename/1.0",
+            "description": "User selected endpoint for API definition in swagger/raml format.",
+            "name": "url",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "If the format is swagger, returns the swagger content in json and raml returns the raml content in yaml. If the format is openapi, returns the open api content in json. If the format is odata, you get a zip file holding the OData metadata and service document.",
+            "schema": {
+              "$ref": "#/definitions/APIResponseGetAPI"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"1.0\",\r\n                \"apiId\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n       \r\n       }\r\n        ],\r\n        \"teams\": [\r\n            {\r\n                \"id\": \"Administrators\",\r\n                \"name\": \"Administrators\",\r\n                \"canDelete\": \"false\"\r\n            },\r\n            {\r\n                \"id\": \"Default\",\r\n                \"name\": \"Default\",\r\n                \"canDelete\": \"true\"\r\n            }\r\n        ]    }\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "This REST operation is used to update an API by importing a file, url or inline.\n\nWhile updating the API, visibility of the operations can be set by enabling or disabling the operations. Disabled operations will not be exposed to the customers. By default, all the operations are exposed to the consumers.\n\nWhen updating the API using file or url, API Gateway overwrite the resources/operations for the API. But it will retain the maturity state, scopes, visibility and if API mocking is enabled, then default mocked responses, mocked conditions and IS services will also be retained.",
+        "consumes": [
+          "application/json",
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "updateAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be updated",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "x-example": true,
+            "description": "When an API is updated using a URL / file, the existing tags will be overwritten if this value is true.",
+            "name": "overwriteTags",
+            "in": "query"
+          },
+          {
+            "x-examples": {
+              "application/json": "{\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n        }"
+            },
+            "description": "API request payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GatewayAPI"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated API object",
+            "schema": {
+              "$ref": "#/definitions/APIResponseCreate"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"1.0\",\r\n                \"apiId\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n            }\r\n        ]\r\n    }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the user missed the mandatory fields like type, file/url/apiDefinition in the request or provide a invalid request body"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Delete the inactive API",
+        "operationId": "deleteAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be deleted",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "x-example": true,
+            "description": "Flag for force delete. Required when API is associated with some applications",
+            "name": "forceDelete",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the apiId along with the error when unsuccessful",
+            "schema": {
+              "$ref": "#/definitions/APIResponseDelete"
+            }
+          },
+          "204": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "This response code returns when the deleted API is published to API portal or in active state"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API"
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/activate": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Activate an API so that API is exposed to consumers",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "activateAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be activated",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the API object after successful activation",
+            "schema": {
+              "$ref": "#/definitions/APIResponse"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"1.0\",\r\n                \"apiId\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n            }\r\n        ]\r\n    }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the API is already in activated state or when no operations/resources are present or none are enabled"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/applications": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Retrieves the list of registered applications of an API",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getApplications",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to find the associated applications",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the list of associated applications",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Application"
+              }
+            },
+            "examples": {
+              "application/json": "{\r\n  \"applications\": [\r\n    {\r\n      \"name\": \"app1\",\r\n      \"description\": null,\r\n      \"contactEmails\": [],\r\n      \"identifiers\": [],\r\n      \"siteURLs\": [],\r\n      \"version\": \"1.0\",\r\n      \"id\": \"ae48cd69-421e-4bdf-a4d0-e86996a78f68\",\r\n      \"created\": \"2017-03-13 13:12:03 GMT\",\r\n      \"lastupdated\": null,\r\n      \"consumingAPIs\": [\r\n        \"25fb937a-8360-41ab-8be5-987b14fe631d\"\r\n      ],\r\n      \"accessTokens\": {\r\n        \"apiAccessKey_credentials\": {\r\n          \"apiAccessKey\": \"cec4b46b-3569-4f73-a561-172dd67c182a\",\r\n          \"expirationInterval\": null\r\n        },\r\n        \"oauth_credentials\": {\r\n          \"clientID\": \"40b78ed3-d171-4bd3-99db-51dd2fa71753\",\r\n          \"clientSecret\": \"024b9525-6526-45c8-a66c-d192442064e1\",\r\n          \"clientName\": \"app1-6b753c2a-0567-462d-a4ea-1b143ab7a381\",\r\n          \"scopes\": [\r\n            \"25fb937a-8360-41ab-8be5-987b14fe631d\"\r\n          ],\r\n          \"token_lifetime\": \"3600\",\r\n          \"token_refresh_limit\": \"0\",\r\n          \"redirect_uris\": [\r\n            \"https://placeholder_redirect_uri\"\r\n          ],\r\n          \"Type\": \"confidential\"\r\n        }\r\n      }\r\n    }\r\n  ]\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/deactivate": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Deactivate an API so that API is not exposed to consumers",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "deactivateAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be deactivated",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the API object after successful deactivation",
+            "schema": {
+              "$ref": "#/definitions/APIResponse"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"1.0\",\r\n                \"apiId\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n            }\r\n        ]\r\n    }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the API is already in de-activated state"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/gatewayEndpoints": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "This operation can be used to create / update / delete a custom gateway endpoing of an API",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "gatewayEndpoints",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be updated",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "x-examples": {
+              "application/json": "{\r\n\t            \"gatewayEndpoints\": {\r\n\t                \"add\": { \r\n\t                    \"endpointName\" : \"name\", \r\n\t                    \"gatewayEndpoint\":\"/prefix/${apiName}/${apiVersion}\" \r\n\t                },\r\n\t                \"update\": { \r\n\t                \"oldEndpointName\" : \"oldName\", \r\n\t                    \"newEndpointName\" : \"newName\", \r\n\t                    \"gatewayEndpoint\" :\"/newPrefix/chocolateApi/${apiVersion}\" \r\n\t                },\r\n\t                \"remove\": { \r\n\t                    \"endpointName\":\"nameOfAnExistingEndpoint\"\r\n\t                }\r\n\t            }\r\n\t        }"
+            },
+            "description": "API Gateway endpoints request payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InputGatewayEndpoints"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns status of the operation along with request payload",
+            "schema": {
+              "$ref": "#/definitions/APIResponse"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the user provide an invalid request body"
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/globalPolicies": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Retrieves the list of active global policies applicable to this API",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getAssociatedGlobalPolicies",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to find the list of applicable global policies",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the list of global policy names",
+            "schema": {
+              "$ref": "#/definitions/APIResponseGetGlobalPolicies"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"globalPolicies\": [\r\n    \"GlobalLogInvocationPolicy\"\r\n  ]\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/implementation": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "This operation can be used to update an API with its implementation endpoints details and optionally the corresponding maturity state after the implementation has been completed",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "notifyAPIImplementation",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be updated",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "x-examples": {
+              "application/json": "{           \r\n\t\"nativeBaseURLs\" :     [\"https://localhost:5556/restv2/calc/v1\",       \"http://localhost:5555/restv2/calc/v1\"],                               \r\n\t\"maturityState\" : \"Implemented\"\r\n}"
+            },
+            "description": "API publish request payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InputAPIImplementation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated API object",
+            "schema": {
+              "$ref": "#/definitions/APIResponse"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the user missed the mandatory fields like type, file/url/apiDefinition in the request or provide a invalid request body"
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/mock/disable": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Once API is disabled from mocking capability, at runtime all the API invocations are redirected to the native service instead of sending the mocked response",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "disableMockAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be deactivated",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the API object after successful disabling mocking of an API",
+            "schema": {
+              "$ref": "#/definitions/APIResponse"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"API to demonstrate mocking functionality in international developers day\",\r\n                    \"version\": \"v1\",\r\n                    \"title\": \"API_MOCKING\"\r\n                },\r\n                \"host\": \"localhost\",\r\n                \"schemes\": [\r\n                    \"http\"\r\n                ],\r\n                \"consumes\": [\r\n                    \"application/json\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/conditionBasedMockedResponse\": {\r\n                        \"post\": {\r\n                            \"summary\": \"Configure condition and mocked response\",\r\n                            \"operationId\": \"conditionBasedMockedResponse\",\r\n                            \"produces\": [\r\n                                \"text/plain\"\r\n                            ],\r\n                            \"responses\": {\r\n                                \"200\": {\r\n                                    \"description\": \"200 response\",\r\n                                    \"content\": {\r\n                                        \"text/plain\": {\r\n                                            \"example\": \"No condition evaluates to true. \\nSo API-Gateway sent this default response.\"\r\n                                        }\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"mockedResponses\": {\r\n                                \"200\": {\r\n                                    \"responseBody\": {\r\n                                        \"text/plain\": \"No condition evaluates to true. \\nSo API-Gateway sent this default response.\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"enabled\": true\r\n                        },\r\n                        \"parameters\": [],\r\n                        \"displayName\": \"/conditionBasedMockedResponse\",\r\n                        \"enabled\": true\r\n                    },\r\n                    \"/customESBMockedResponse\": {\r\n                        \"post\": {\r\n                            \"summary\": \"Configure custom ESB mocked response\",\r\n                            \"operationId\": \"customESBMockedResponse\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {\r\n                                \"200\": {\r\n                                    \"description\": \"200 response\"\r\n                                }\r\n                            },\r\n                            \"mockedResponses\": {\r\n                                \"200\": {\r\n                                    \"responseBody\": {\r\n                                        \"application/json\": \"\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"enabled\": true\r\n                        },\r\n                        \"parameters\": [],\r\n                        \"displayName\": \"/customESBMockedResponse\",\r\n                        \"enabled\": true\r\n                    },\r\n                    \"/dynamicMockedResponse\": {\r\n                        \"post\": {\r\n                            \"summary\": \"Dynamic mocked response set\",\r\n                            \"operationId\": \"dynamicMockedResponse\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {\r\n                                \"200\": {\r\n                                    \"description\": \"200 response\"\r\n                                }\r\n                            },\r\n                            \"mockedResponses\": {\r\n                                \"200\": {\r\n                                    \"responseBody\": {\r\n                                        \"application/json\": \"\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"enabled\": true\r\n                        },\r\n                        \"parameters\": [],\r\n                        \"displayName\": \"/dynamicMockedResponse\",\r\n                        \"enabled\": true\r\n                    },\r\n                    \"/staticMockedResponse\": {\r\n                        \"post\": {\r\n                            \"summary\": \"Default mocked response from example\",\r\n                            \"operationId\": \"generateFromExample\",\r\n                            \"produces\": [\r\n                                \"application/json\",\r\n                                \"application/xml\"\r\n                            ],\r\n                            \"responses\": {\r\n                                \"200\": {\r\n                                    \"description\": \"200 response generated from example\",\r\n                                    \"content\": {\r\n                                        \"application/json\": {\r\n                                            \"example\": \"{\\\"resource\\\" : \\\"/generateFromExample\\\",\\\"description\\\" : \\\"Default mocked response from example for status code 200\\\"}\"\r\n                                        },\r\n                                        \"application/xml\": {\r\n                                            \"example\": \"\u003croot\u003e\u003cresource\u003e/generateFromExample\u003c/resource\u003e\u003cdescription\u003eDefault mocked response from example for status code 200\u003c/description\u003e\u003c/root\u003e\"\r\n                                        }\r\n                                    }\r\n                                },\r\n                                \"201\": {\r\n                                    \"description\": \"201 response generated from schema\",\r\n                                    \"content\": {\r\n                                        \"application/json\": {\r\n                                            \"schema\": {\r\n                                                \"$ref\": \"#/components/schemas/Pet\"\r\n                                            }\r\n                                        },\r\n                                        \"application/xml\": {\r\n                                            \"schema\": {\r\n                                                \"$ref\": \"#/components/schemas/Pet\"\r\n                                            }\r\n                                        }\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"mockedResponses\": {\r\n                                \"200\": {\r\n                                    \"responseBody\": {\r\n                                        \"application/json\": \"{\\\"resource\\\" : \\\"/generateFromExample\\\",\\\"description\\\" : \\\"Default mocked response from example for status code 200\\\"}\",\r\n                                        \"application/xml\": \"\u003croot\u003e\u003cresource\u003e/generateFromExample\u003c/resource\u003e\u003cdescription\u003eDefault mocked response from example for status code 200\u003c/description\u003e\u003c/root\u003e\"\r\n                                    }\r\n                                },\r\n                                \"201\": {\r\n                                    \"responseBody\": {\r\n                                        \"application/json\": \"{\\\"birthday\\\":2059397944,\\\"name\\\":\\\"\\\"}\",\r\n                                        \"application/xml\": \"\u003cbirthday\u003e921604684\u003c/birthday\u003e\u003cname/\u003e\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"enabled\": true\r\n                        },\r\n                        \"parameters\": [],\r\n                        \"displayName\": \"/staticMockedResponse\",\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"http://localhost\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {\r\n                        \"Pet\": {\r\n                            \"required\": [\r\n                                \"name\"\r\n                            ],\r\n                            \"type\": \"object\",\r\n                            \"properties\": {\r\n                                \"birthday\": {\r\n                                    \"type\": \"integer\",\r\n                                    \"format\": \"int32\"\r\n                                },\r\n                                \"name\": {\r\n                                    \"type\": \"string\"\r\n                                }\r\n                            }\r\n                        }\r\n                    }\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"http://localhost\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"APIMocking\",\r\n            \"apiVersion\": \"v1\",\r\n            \"apiDescription\": \"API to demonstrate mocking functionality in international developers day\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"19773e29-2838-4efc-aa04-793b48f4d22b\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-11-01 13:44:58 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"mockService\": {\r\n                \"enableMock\": false\r\n            },\r\n            \"id\": \"afd8eb5e-bba8-447b-8e28-76aac23ba074\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"v1\",\r\n                \"apiId\": \"afd8eb5e-bba8-447b-8e28-76aac23ba074\"\r\n            }\r\n        ]\r\n    }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the API is already in activated state or in mocked state"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/mock/enable": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "In API Gateway, you can mock an API implementation. API Gateway lets you mock an API by simulating the native service. API Mocking is useful feature in API first approach, where in the provider may choose to expose the mocked API to the consumers when the actual API doesn't exist or isn't complete. \n In API Gateway, when you enable mocking for an API, a default mock response is created for each combination of resource, operation, status code and content-type based on the example and schema set in the API definition. As an API Provider, you can add or modify the default mock responses.\n\nYou can specify conditions at the operation level and configure IS services at the API level for a mocked API in the update API operation. At runtime, when the mocked API is invoked instead of calling the native service, API Gateway returns the mocked response to the consumer based on the below priorities:\n1. If any of the conditions for the invoked operation satisfies, API Gateway returns the associated mocked response.\n2. If no condition is specified or none of the condition for the invoked operation is satisfied, then API Gateway will return \na. the response from an IS service, if an IS service is configured b. default mocked response, if no IS services are configured",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "enableMockAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be activated",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "x-example": true,
+            "description": "Flag to retain generated mocked responses. When this is set to true, default mocked responses will be retained. If it's set to false, new default mocked responses will be generated using the examples, schema in the API",
+            "name": "retainDefaultMockResponses",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the API object after successfully enabling mocking of an API",
+            "schema": {
+              "$ref": "#/definitions/APIResponse"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"API to demonstrate mocking functionality in international developers day\",\r\n                    \"version\": \"v1\",\r\n                    \"title\": \"API_MOCKING\"\r\n                },\r\n                \"host\": \"localhost\",\r\n                \"schemes\": [\r\n                    \"http\"\r\n                ],\r\n                \"consumes\": [\r\n                    \"application/json\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/conditionBasedMockedResponse\": {\r\n                        \"post\": {\r\n                            \"summary\": \"Configure condition and mocked response\",\r\n                            \"operationId\": \"conditionBasedMockedResponse\",\r\n                            \"produces\": [\r\n                                \"text/plain\"\r\n                            ],\r\n                            \"responses\": {\r\n                                \"200\": {\r\n                                    \"description\": \"200 response\",\r\n                                    \"content\": {\r\n                                        \"text/plain\": {\r\n                                            \"example\": \"No condition evaluates to true. \\nSo API-Gateway sent this default response.\"\r\n                                        }\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"mockedResponses\": {\r\n                                \"200\": {\r\n                                    \"responseBody\": {\r\n                                        \"text/plain\": \"No condition evaluates to true. \\nSo API-Gateway sent this default response.\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"enabled\": true\r\n                        },\r\n                        \"parameters\": [],\r\n                        \"displayName\": \"/conditionBasedMockedResponse\",\r\n                        \"enabled\": true\r\n                    },\r\n                    \"/customESBMockedResponse\": {\r\n                        \"post\": {\r\n                            \"summary\": \"Configure custom ESB mocked response\",\r\n                            \"operationId\": \"customESBMockedResponse\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {\r\n                                \"200\": {\r\n                                    \"description\": \"200 response\"\r\n                                }\r\n                            },\r\n                            \"mockedResponses\": {\r\n                                \"200\": {\r\n                                    \"responseBody\": {\r\n                                        \"application/json\": \"\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"enabled\": true\r\n                        },\r\n                        \"parameters\": [],\r\n                        \"displayName\": \"/customESBMockedResponse\",\r\n                        \"enabled\": true\r\n                    },\r\n                    \"/dynamicMockedResponse\": {\r\n                        \"post\": {\r\n                            \"summary\": \"Dynamic mocked response set\",\r\n                            \"operationId\": \"dynamicMockedResponse\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {\r\n                                \"200\": {\r\n                                    \"description\": \"200 response\"\r\n                                }\r\n                            },\r\n                            \"mockedResponses\": {\r\n                                \"200\": {\r\n                                    \"responseBody\": {\r\n                                        \"application/json\": \"\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"enabled\": true\r\n                        },\r\n                        \"parameters\": [],\r\n                        \"displayName\": \"/dynamicMockedResponse\",\r\n                        \"enabled\": true\r\n                    },\r\n                    \"/staticMockedResponse\": {\r\n                        \"post\": {\r\n                            \"summary\": \"Default mocked response from example\",\r\n                            \"operationId\": \"generateFromExample\",\r\n                            \"produces\": [\r\n                                \"application/json\",\r\n                                \"application/xml\"\r\n                            ],\r\n                            \"responses\": {\r\n                                \"200\": {\r\n                                    \"description\": \"200 response generated from example\",\r\n                                    \"content\": {\r\n                                        \"application/json\": {\r\n                                            \"example\": \"{\\\"resource\\\" : \\\"/generateFromExample\\\",\\\"description\\\" : \\\"Default mocked response from example for status code 200\\\"}\"\r\n                                        },\r\n                                        \"application/xml\": {\r\n                                            \"example\": \"\u003croot\u003e\u003cresource\u003e/generateFromExample\u003c/resource\u003e\u003cdescription\u003eDefault mocked response from example for status code 200\u003c/description\u003e\u003c/root\u003e\"\r\n                                        }\r\n                                    }\r\n                                },\r\n                                \"201\": {\r\n                                    \"description\": \"201 response generated from schema\",\r\n                                    \"content\": {\r\n                                        \"application/json\": {\r\n                                            \"schema\": {\r\n                                                \"$ref\": \"#/components/schemas/Pet\"\r\n                                            }\r\n                                        },\r\n                                        \"application/xml\": {\r\n                                            \"schema\": {\r\n                                                \"$ref\": \"#/components/schemas/Pet\"\r\n                                            }\r\n                                        }\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"mockedResponses\": {\r\n                                \"200\": {\r\n                                    \"responseBody\": {\r\n                                        \"application/json\": \"{\\\"resource\\\" : \\\"/generateFromExample\\\",\\\"description\\\" : \\\"Default mocked response from example for status code 200\\\"}\",\r\n                                        \"application/xml\": \"\u003croot\u003e\u003cresource\u003e/generateFromExample\u003c/resource\u003e\u003cdescription\u003eDefault mocked response from example for status code 200\u003c/description\u003e\u003c/root\u003e\"\r\n                                    }\r\n                                },\r\n                                \"201\": {\r\n                                    \"responseBody\": {\r\n                                        \"application/json\": \"{\\\"birthday\\\":2059397944,\\\"name\\\":\\\"\\\"}\",\r\n                                        \"application/xml\": \"\u003cbirthday\u003e921604684\u003c/birthday\u003e\u003cname/\u003e\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"enabled\": true\r\n                        },\r\n                        \"parameters\": [],\r\n                        \"displayName\": \"/staticMockedResponse\",\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"http://localhost\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {\r\n                        \"Pet\": {\r\n                            \"required\": [\r\n                                \"name\"\r\n                            ],\r\n                            \"type\": \"object\",\r\n                            \"properties\": {\r\n                                \"birthday\": {\r\n                                    \"type\": \"integer\",\r\n                                    \"format\": \"int32\"\r\n                                },\r\n                                \"name\": {\r\n                                    \"type\": \"string\"\r\n                                }\r\n                            }\r\n                        }\r\n                    }\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"http://localhost\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"APIMocking\",\r\n            \"apiVersion\": \"v1\",\r\n            \"apiDescription\": \"API to demonstrate mocking functionality in international developers day\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"19773e29-2838-4efc-aa04-793b48f4d22b\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-11-01 13:44:58 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"mockService\": {\r\n                \"enableMock\": true\r\n            },\r\n            \"id\": \"afd8eb5e-bba8-447b-8e28-76aac23ba074\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"v1\",\r\n                \"apiId\": \"afd8eb5e-bba8-447b-8e28-76aac23ba074\"\r\n            }\r\n        ]\r\n    }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the API is already in activated state or when invalid json or xml is provided in the example part of the operation"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/providerspecification": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Downloads the provider specification of REST and SOAP based APIs. Provider specification is nothing but, the specification file (in swagger or wsdl format) with out the concrete API Gateway endpoint and contains all resources/methods/operation irrespective of whether they are exposed to consumer",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "downloadProviderSpecification",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to retrieve the versions",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "enum": [
+              "swagger",
+              "wsdl"
+            ],
+            "type": "string",
+            "x-example": "swagger",
+            "description": "Output format of the API specification. For REST APIs the value is 'swagger'; for SOAP APIs use the value as 'wsdl'",
+            "name": "format",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "If the format is swagger, returns the swagger content in json. If the format is wsdl, returns the wsdl content in xml.",
+            "schema": {
+              "$ref": "#/definitions/APIResponseGetAPI"
+            }
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/publish": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "This REST operation is used to publish API to the registered API Portal",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "publishAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be published",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "x-examples": {
+              "application/json": "{\r\n\t\"portalGatewayId\" : \"69bac781-6c60-4db3-86f7-50af3ec4963a\",\r\n\t\"communities\" : [\"3bdf8005-5685-3ef5-b132-de4681963fb6\"],\r\n\t\"endpoints\" : [\"https://api.chucknorris.io/jokes\"]\r\n}"
+            },
+            "description": "API publish request payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InputPublish"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the API object after successful publish",
+            "schema": {
+              "$ref": "#/definitions/APIResponseCreate"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"apiResponse\": {\r\n    \"api\": {\r\n      \"apiDefinition\": {\r\n        \"type\": \"rest\",\r\n        \"info\": {\r\n          \"vendorExtensions\": {},\r\n          \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n          \"version\": \"1.0\",\r\n          \"title\": \"ChuckNorrisAPI\"\r\n        },\r\n        \"host\": \"api.chucknorris.io\",\r\n        \"basePath\": \"/jokes\",\r\n        \"schemes\": [\r\n          \"https\"\r\n        ],\r\n        \"paths\": {\r\n          \"/random\": {\r\n            \"get\": {\r\n              \"summary\": \"GET\",\r\n              \"description\": \"\",\r\n              \"operationId\": \"GET\",\r\n              \"produces\": [\r\n                \"application/json\"\r\n              ],\r\n              \"parameters\": [],\r\n              \"responses\": {},\r\n              \"enabled\": true\r\n            },\r\n            \"enabled\": true\r\n          }\r\n        },\r\n        \"definitions\": {}\r\n      },\r\n      \"nativeEndpoint\": [\r\n        {\r\n          \"passSecurityHeaders\": true,\r\n          \"uri\": \"https://api.chucknorris.io/jokes\",\r\n          \"connectionTimeoutDuration\": 0,\r\n          \"alias\": false\r\n        }\r\n      ],\r\n      \"apiName\": \"ChuckNorrisAPI\",\r\n      \"apiVersion\": \"1.0\",\r\n      \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n      \"maturityState\": \"Beta\",\r\n      \"isActive\": false,\r\n      \"type\": \"REST\",\r\n      \"owner\": \"Administrator\",\r\n      \"policies\": [\r\n        \"879068cd-8628-4f2a-b903-4e6613ca12ba\"\r\n      ],\r\n      \"referencedFiles\": {\r\n        \"ChuckNorrisAPI.json\": \"{\\r\\n  \\\"swagger\\\": \\\"2.0\\\",\\r\\n  \\\"info\\\": {\\r\\n    \\\"description\\\": \\\"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\\\",\\r\\n    \\\"title\\\": \\\"ChuckNorrisAPI\\\",\\r\\n    \\\"version\\\": \\\"1.0\\\"\\r\\n  },\\r\\n  \\\"host\\\": \\\"api.chucknorris.io\\\",\\r\\n  \\\"basePath\\\": \\\"/jokes\\\",\\r\\n  \\\"schemes\\\": [\\r\\n    \\\"https\\\"\\r\\n  ],\\r\\n  \\\"paths\\\": {\\r\\n    \\\"/random\\\": {\\r\\n      \\\"get\\\": {\\r\\n        \\\"summary\\\": \\\"GET\\\",\\r\\n        \\\"deprecated\\\": false,\\r\\n        \\\"produces\\\": [\\r\\n          \\\"application/json\\\"\\r\\n        ],\\r\\n        \\\"description\\\": \\\"\\\",\\r\\n        \\\"operationId\\\": \\\"GET\\\"\\r\\n      }\\r\\n    }\\r\\n  }\\r\\n}\\r\\n\"\r\n      },\r\n      \"scopes\": [],\r\n      \"publishedPortals\": [],\r\n      \"creationDate\": \"2017-03-13 09:38:30 GMT\",\r\n      \"systemVersion\": 1,\r\n      \"id\": \"25fb937a-8360-41ab-8be5-987b14fe631d\",\r\n      \"oauth2ScopeName\": \"25fb937a-8360-41ab-8be5-987b14fe631d\"\r\n    },\r\n    \"responseStatus\": \"SUCCESS\"\r\n  }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the user missed the mandatory portalGatewayId or invalid portalGatewayId in the request body"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/scopes": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "An API Scope is a collection of resources or operations in an API. Users can create multiple scopes for a single API. Policies can be attached to an API level or scope level. This method retrieves the scopes of an API.\n\nYou can create, modify or delete the scopes in the update API operation using PUT /api/{apiId}",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getScopes",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to retrieve the versions",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns API scopes",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ScopeResourceIndex"
+              }
+            },
+            "examples": {
+              "application/json": "{\r\n  \"scopeReferences\": [\r\n    {\r\n      \"references\": [\r\n        {\r\n          \"resourcePath\": \"/random\",\r\n          \"supportedOperations\": []\r\n        }\r\n      ],\r\n      \"scope\": {\r\n        \"name\": \"Get_Scopes\",\r\n        \"description\": \"Dummy description of the scope\",\r\n        \"policies\": [\r\n          \"db1a42f4-e038-4a1b-82f4-8fee6fbd5687\"\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/scopes/{scopeName}": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Retrieve scopes of an API based on the scope name",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getScopeByScopeName",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to retrieve the versions",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-example": "getScope",
+            "description": "Name of the scope",
+            "name": "scopeName",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns API scopes",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ScopeResourceIndex"
+              }
+            },
+            "examples": {
+              "application/json": "{\r\n  \"scopeReferences\": [\r\n    {\r\n      \"references\": [\r\n        {\r\n          \"resourcePath\": \"/random\",\r\n          \"supportedOperations\": []\r\n        }\r\n      ],\r\n      \"scope\": {\r\n        \"name\": \"Get_Scopes\",\r\n        \"description\": \"Dummy description of the scope\",\r\n        \"policies\": [\r\n          \"db1a42f4-e038-4a1b-82f4-8fee6fbd5687\"\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway or scopeName is not found in the list of scopes"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/source": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Download the API definition that was used to create the API. This is applicable only for SOAP APIs.",
+        "produces": [
+          "multipart/mixed"
+        ],
+        "operationId": "getSource",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to download the source content",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the source files along with the root file name",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Multipart"
+              }
+            },
+            "examples": {
+              "multipart/mixed": "Message-ID: \u003c296841806.5.1489555643275.JavaMail.MRIZ@MCMRIZ01\u003e\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; \r\n\tboundary=\"----=_Part_4_1098332532.1489555643274\"\r\n\r\n------=_Part_4_1098332532.1489555643274\r\ncontent-type: application/zip\r\nContent-Disposition: attachment; filename=\"echoService.zip\"\r\n\r\nfile content in zip format\r\n------=_Part_4_1098332532.1489555643274\r\ncontent-type: text/plain\r\nContent-Disposition: inline; name=\"rootFileName\"\r\n\r\necho.wsdl\r\n------=_Part_4_1098332532.1489555643274--"
+            }
+          },
+          "400": {
+            "description": "This status code returns when the specified API is not a SOAP API"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/unpublish": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Unpublish API from the registered API Portal",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "unpublishAPI",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be unpublished",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the API object after successful unpublish",
+            "schema": {
+              "$ref": "#/definitions/APIResponseCreate"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"apiResponse\": {\r\n    \"api\": {\r\n      \"apiDefinition\": {\r\n        \"type\": \"rest\",\r\n        \"info\": {\r\n          \"vendorExtensions\": {},\r\n          \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n          \"version\": \"1.0\",\r\n          \"title\": \"ChuckNorrisAPI\"\r\n        },\r\n        \"host\": \"api.chucknorris.io\",\r\n        \"basePath\": \"/jokes\",\r\n        \"schemes\": [\r\n          \"https\"\r\n        ],\r\n        \"paths\": {\r\n          \"/random\": {\r\n            \"get\": {\r\n              \"summary\": \"GET\",\r\n              \"description\": \"\",\r\n              \"operationId\": \"GET\",\r\n              \"produces\": [\r\n                \"application/json\"\r\n              ],\r\n              \"parameters\": [],\r\n              \"responses\": {},\r\n              \"enabled\": true\r\n            },\r\n            \"enabled\": true\r\n          }\r\n        },\r\n        \"definitions\": {}\r\n      },\r\n      \"nativeEndpoint\": [\r\n        {\r\n          \"passSecurityHeaders\": true,\r\n          \"uri\": \"https://api.chucknorris.io/jokes\",\r\n          \"connectionTimeoutDuration\": 0,\r\n          \"alias\": false\r\n        }\r\n      ],\r\n      \"apiName\": \"ChuckNorrisAPI\",\r\n      \"apiVersion\": \"1.0\",\r\n      \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n      \"maturityState\": \"Beta\",\r\n      \"isActive\": false,\r\n      \"type\": \"REST\",\r\n      \"owner\": \"Administrator\",\r\n      \"policies\": [\r\n        \"879068cd-8628-4f2a-b903-4e6613ca12ba\"\r\n      ],\r\n      \"referencedFiles\": {\r\n        \"ChuckNorrisAPI.json\": \"{\\r\\n  \\\"swagger\\\": \\\"2.0\\\",\\r\\n  \\\"info\\\": {\\r\\n    \\\"description\\\": \\\"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\\\",\\r\\n    \\\"title\\\": \\\"ChuckNorrisAPI\\\",\\r\\n    \\\"version\\\": \\\"1.0\\\"\\r\\n  },\\r\\n  \\\"host\\\": \\\"api.chucknorris.io\\\",\\r\\n  \\\"basePath\\\": \\\"/jokes\\\",\\r\\n  \\\"schemes\\\": [\\r\\n    \\\"https\\\"\\r\\n  ],\\r\\n  \\\"paths\\\": {\\r\\n    \\\"/random\\\": {\\r\\n      \\\"get\\\": {\\r\\n        \\\"summary\\\": \\\"GET\\\",\\r\\n        \\\"deprecated\\\": false,\\r\\n        \\\"produces\\\": [\\r\\n          \\\"application/json\\\"\\r\\n        ],\\r\\n        \\\"description\\\": \\\"\\\",\\r\\n        \\\"operationId\\\": \\\"GET\\\"\\r\\n      }\\r\\n    }\\r\\n  }\\r\\n}\\r\\n\"\r\n      },\r\n      \"scopes\": [],\r\n      \"publishedPortals\": [],\r\n      \"creationDate\": \"2017-03-13 09:38:30 GMT\",\r\n      \"systemVersion\": 1,\r\n      \"id\": \"25fb937a-8360-41ab-8be5-987b14fe631d\",\r\n      \"oauth2ScopeName\": \"25fb937a-8360-41ab-8be5-987b14fe631d\"\r\n    },\r\n    \"responseStatus\": \"SUCCESS\"\r\n  }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code shows when the user missed the mandatory portalGatewayId or invalid portalGatewayId in the request body"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      }
+    },
+    "/apis/{apiId}/versions": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Retrieve all the versions of the API",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getVersions",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to retrieve the versions",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the API versions",
+            "schema": {
+              "$ref": "#/definitions/APIResponseGetAPIs"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"1.0\",\r\n                \"apiId\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n            }\r\n        ]\r\n    }\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that the apiId specified is not found in the API Gateway"
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Create a new version of an API and retain applications if required",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "createVersion",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id for the API to be versioned",
+            "name": "apiId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "x-examples": {
+              "application/json": "{\r\n\t\"newApiVersion\" : \"v2\",\r\n\t\"retainApplications\" : true\r\n}"
+            },
+            "description": "Create version request payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InputVersion"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return the newly created version of the API",
+            "schema": {
+              "$ref": "#/definitions/APIResponse"
+            },
+            "examples": {
+              "application/json": "{\r\n    \"apiResponse\": {\r\n        \"api\": {\r\n            \"apiDefinition\": {\r\n                \"type\": \"rest\",\r\n                \"info\": {\r\n                    \"description\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n                    \"version\": \"1.0\",\r\n                    \"title\": \"ChuckNorrisAPI\"\r\n                },\r\n                \"host\": \"api.chucknorris.io\",\r\n                \"basePath\": \"/jokes\",\r\n                \"schemes\": [\r\n                    \"https\"\r\n                ],\r\n                \"security\": [],\r\n                \"paths\": {\r\n                    \"/random\": {\r\n                        \"get\": {\r\n                            \"summary\": \"GET\",\r\n                            \"description\": \"\",\r\n                            \"operationId\": \"GET\",\r\n                            \"produces\": [\r\n                                \"application/json\"\r\n                            ],\r\n                            \"responses\": {},\r\n                            \"enabled\": true\r\n                        },\r\n                        \"enabled\": true\r\n                    }\r\n                },\r\n                \"securityDefinitions\": {},\r\n                \"definitions\": {},\r\n                \"baseUriParameters\": [],\r\n                \"externalDocs\": [],\r\n                \"servers\": [\r\n                    {\r\n                        \"url\": \"https://api.chucknorris.io/jokes\"\r\n                    }\r\n                ],\r\n                \"components\": {\r\n                    \"schemas\": {}\r\n                }\r\n            },\r\n            \"nativeEndpoint\": [\r\n                {\r\n                    \"passSecurityHeaders\": true,\r\n                    \"uri\": \"https://api.chucknorris.io/jokes\",\r\n                    \"connectionTimeoutDuration\": 0,\r\n                    \"alias\": false\r\n                }\r\n            ],\r\n            \"apiName\": \"ChuckNorris\",\r\n            \"apiVersion\": \"1.0\",\r\n            \"apiDescription\": \"Chuck Norris facts are satirical factoids about martial artist and actor Chuck Norris that have become an Internet phenomenon and as a result have become widespread in popular culture. The 'facts' are normally absurd hyperbolic claims about Norris' toughness, attitude, virility, sophistication, and masculinity.\",\r\n            \"maturityState\": \"Beta\",\r\n            \"isActive\": false,\r\n            \"type\": \"REST\",\r\n            \"owner\": \"Administrator\",\r\n            \"policies\": [\r\n                \"08afbfa9-78e1-4c23-bb19-c0012464047e\"\r\n            ],\r\n            \"scopes\": [],\r\n            \"publishedPortals\": [],\r\n            \"creationDate\": \"2018-09-03 11:56:21 GMT\",\r\n            \"systemVersion\": 1,\r\n            \"id\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n        },\r\n        \"responseStatus\": \"SUCCESS\",\r\n        \"versions\": [\r\n            {\r\n                \"versionNumber\": \"1.0\",\r\n                \"apiId\": \"badc18e6-446f-4aa3-96cd-33e46bd40fb5\"\r\n            }\r\n        ]\r\n    }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code returns when the specified api is not the latest version or if the newApiVersion is empty"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/integrationServer/publish": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Retrieve the integration server publish information for the API. Only REST and SOAP APIs are supported.",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getIntegrationServerPublishInfo",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id of the API for which IntegrationServerPublishInfo is to be fetched",
+            "name": "apiId",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the integration server publish info for the API",
+            "schema": {
+              "$ref": "#/definitions/ServiceRegistryPublishGetResponse"
+            }
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": "This status code indicates that Publish Info for the apiId specified is not found in API Gateway"
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Publish one or more APIs to one or more integration servers. Only REST and SOAP APIs are supported.",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "publishToIntegrationServer",
+        "parameters": [
+          {
+            "description": "Integration server publish payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InputIntegrationServerPublish"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the status of the publish operations given in the request.",
+            "schema": {
+              "$ref": "#/definitions/ServiceRegistryPublishPutResponse"
+            }
+          },
+          "400": {
+            "description": "This status code indicates an invalid request body"
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": "This status code indicates that API with given apiId is not found in API Gateway"
+          }
+        }
+      }
+    },
+    "/scopes": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "This method retrieves a list of available OAuth scope mappings in API Gateway. OAuth scope mappings map the authorization server scope with APIs or API scopes",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getOAuthScopes",
+        "responses": {
+          "200": {
+            "description": "This status code indicates that a list of the available OAuth scopes are retrieved successfully.",
+            "schema": {
+              "$ref": "#/definitions/GatewayScope"
+            },
+            "examples": {
+              "application/json": "{\r\n\t\"scopes\": [\r\n\t\t{\r\n\t\t\t\"id\": \"ef084e4a-c30b-40f5-8ed9-2a6b7fb6ca34\",\r\n\t\t\t\"scopeName\": \"scopeMapping2\",\r\n\t\t\t\"scopeDescription\": \"scopeMapping2 description\",\r\n\t\t\t\"audience\": \"audienceName\",\r\n\t\t\t\"apiScopes\": [\r\n\t\t\t\t\"911c700d-1344-4d3e-9495-4f4e93cc8cce\"\r\n\t\t\t],\r\n\t\t\t\"requiredAuthScopes\": [\r\n\t\t\t\t{\r\n\t\t\t\t\t\"authServerAlias\": \"local\",\r\n\t\t\t\t\t\"scopeName\": \"scope1\"\r\n\t\t\t\t}\r\n\t\t\t]\r\n\t\t},\r\n\t\t{\r\n\t\t\t\"id\": \"9f8f2cbb-e993-4935-aa3c-ee513c9badbb\",\r\n\t\t\t\"scopeName\": \"scopeMapping1\",\r\n\t\t\t\"scopeDescription\": \"scopeMapping1 description\",\r\n\t\t\t\"audience\": \"audienceName\",\r\n\t\t\t\"apiScopes\": [\r\n\t\t\t\t\"911c700d-1344-4d3e-9495-4f4e93cc8cce\"\r\n\t\t\t],\r\n\t\t\t\"requiredAuthScopes\": [\r\n\t\t\t\t{\r\n\t\t\t\t\t\"authServerAlias\": \"local\",\r\n\t\t\t\t\t\"scopeName\": \"scope1\"\r\n\t\t\t\t}\r\n\t\t\t]\r\n\t\t}\r\n\t]\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Use this method to create an OAuth scope mapping",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "createOAuthScope",
+        "parameters": [
+          {
+            "x-examples": {
+              "application/json": "{\r\n\t\"scopeName\": \"scopeMapping\",\r\n\t\"scopeDescription\": \"scopeMapping description\",\r\n\t\"apiScopes\": [\r\n\t\t\"911c700d-1344-4d3e-9495-4f4e93cc8cce\"\r\n\t],\r\n\t\"requiredAuthScopes\": [\r\n\t\t{\r\n\t\t\t\"authServerAlias\": \"local\",\r\n\t\t\t\"scopeName\": \"scope1\"\r\n\t\t}\r\n\t],\r\n\t\"audience\": \"audienceName\"\r\n}"
+            },
+            "description": "This parameter describes the request payload of an OAuth scope that is to be created in API Gateway.",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GatewayScope"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "This status code indicates that the OAuth scope has been successfully created in API Gateway.",
+            "schema": {
+              "$ref": "#/definitions/GatewayScope"
+            },
+            "examples": {
+              "application/json": "{\r\n\t\"scope\": {\r\n\t\t\"id\": \"d550df0c-78c4-4139-918c-f354f77ccf9c\",\r\n\t\t\"scopeName\": \"scopeMapping\",\r\n\t\t\"scopeDescription\": \"scopeMapping description\",\r\n\t\t\"audience\": \"audienceName\",\r\n\t\t\"apiScopes\": [\r\n\t\t\t\"911c700d-1344-4d3e-9495-4f4e93cc8cce\"\r\n\t\t],\r\n\t\t\"requiredAuthScopes\": [\r\n\t\t\t{\r\n\t\t\t\t\"authServerAlias\": \"local\",\r\n\t\t\t\t\"scopeName\": \"scope1\"\r\n\t\t\t}\r\n\t\t]\r\n\t}\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code indicates that the input values given in the request body is wrong."
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          }
+        }
+      }
+    },
+    "/scopes/{oauthScopeId}": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "This method retrieves the requested OAuth scope mapping. OAuth scope mappings map the authorization server scope with APIs or API scopes",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getOAuthScope",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The path parameter specifies the id of an OAuth scope mapping that is to be retrieved from API Gateway.",
+            "name": "oauthScopeId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This status code indicates that the details of the specified OAuth scope are retrieved successfully.",
+            "schema": {
+              "$ref": "#/definitions/GatewayScope"
+            },
+            "examples": {
+              "application/json": "{\r\n\t\"scope\": {\r\n\t\t\"id\": \"51143fe6-7790-4c58-aa66-e4f2f0f2e3cd\",\r\n\t\t\"scopeName\": \"scopeMapping1\",\r\n\t\t\"scopeDescription\": \"scopeMapping1\",\r\n\t\t\"audience\": \"\",\r\n\t\t\"apiScopes\": [\r\n\t\t\t\"911c700d-1344-4d3e-9495-4f4e93cc8cce\"\r\n\t\t],\r\n\t\t\"requiredAuthScopes\": [\r\n\t\t\t{\r\n\t\t\t\t\"authServerAlias\": \"local\",\r\n\t\t\t\t\"scopeName\": \"scope1\"\r\n\t\t\t}\r\n\t\t]\r\n\t}\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that an OAuth scope with the given ID could not be found in API Gateway."
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Use this method to update an OAuth scope mapping",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "updateOAuthScope",
+        "parameters": [
+          {
+            "x-examples": {
+              "application/json": "{\r\n\t\"scopeName\": \"scopeMapping1\",\r\n\t\"scopeDescription\": \"scopeMapping1 description\",\r\n\t\"apiScopes\": [\r\n\t\t\"911c700d-1344-4d3e-9495-4f4e93cc8cce\"\r\n\t],\r\n\t\"requiredAuthScopes\": [\r\n\t\t{\r\n\t\t\t\"authServerAlias\": \"local\",\r\n\t\t\t\"scopeName\": \"scope1\"\r\n\t\t}\r\n\t],\r\n\t\"audience\": \"\"\r\n}"
+            },
+            "description": "This parameter describes the request payload of an OAuth scope that is to be updated in API Gateway.",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GatewayScope"
+            }
+          },
+          {
+            "type": "string",
+            "description": "The path parameter specifies the id of an OAuth scope mapping that is to be updated in API Gateway.",
+            "name": "oauthScopeId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "This status code indicates that the OAuth scope has been successfully updated in API Gateway.",
+            "schema": {
+              "$ref": "#/definitions/GatewayScope"
+            },
+            "examples": {
+              "application/json": "{\r\n\t\"scope\": {\r\n\t\t\"id\": \"51143fe6-7790-4c58-aa66-e4f2f0f2e3cd\",\r\n\t\t\"scopeName\": \"scopeMapping1\",\r\n\t\t\"scopeDescription\": \"scopeMapping1\",\r\n\t\t\"audience\": \"\",\r\n\t\t\"apiScopes\": [\r\n\t\t\t\"911c700d-1344-4d3e-9495-4f4e93cc8cce\"\r\n\t\t],\r\n\t\t\"requiredAuthScopes\": [\r\n\t\t\t{\r\n\t\t\t\t\"authServerAlias\": \"local\",\r\n\t\t\t\t\"scopeName\": \"scope1\"\r\n\t\t\t}\r\n\t\t]\r\n\t}\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code indicates that the input values given in the request body is wrong."
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "This method deletes the requested OAuth scope mapping.",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "deleteOAuthScope",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The path parameter specifies the id of an OAuth scope mapping that is to be deleted from API Gateway.",
+            "name": "oauthScopeId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "This status code indicates that the specified OAuth scope has been successfully deleted from API Gateway."
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that an OAuth scope with the given ID could not be found in API Gateway."
+          }
+        }
+      }
+    },
+    "/serviceRegistry/publish": {
+      "get": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Retrieve the service registry publish information for the API",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "getServiceRegistryPublishInfo",
+        "parameters": [
+          {
+            "type": "string",
+            "x-example": "353bd366-47d4-4703-aecf-9cb40cdcc864",
+            "description": "API Id of the API for which ServiceRegistryPublishInfo is to be fetched",
+            "name": "apiId",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the service registry publish info for the API",
+            "schema": {
+              "$ref": "#/definitions/ServiceRegistryPublishGetResponse"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"publishInfo\": {\r\n    \"apiId\": \"afe8b72e-e1a5-47c6-9b43-e7f12858c091\",\r\n    \"serviceRegistryPublishInfo\": [\r\n      {\r\n        \"serviceRegistryId\": \"aec973cd-1e4c-4a93-93a4-950e32d39156\",\r\n        \"status\": \"PUBLISHED\",\r\n        \"name\": \"MyServiceConsul\",\r\n        \"gatewayEndpoints\": [\r\n          {\r\n            \"gatewayEndpoint\": \"http://localhost:5555/ws/calc/1\",\r\n            \"status\": \"PUBLISHED\"\r\n          },\r\n          {\r\n            \"gatewayEndpoint\": \"http://localhost:1111/ws/calc/1\",\r\n            \"status\": \"NEW\"\r\n          }\r\n        ]\r\n      }\r\n    ]\r\n  }\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that Publish Info for the apiId specified is not found in API Gateway"
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Publish one or more APIs to one or more service registries",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "publishToServiceRegistry",
+        "parameters": [
+          {
+            "x-examples": {
+              "application/json": "{\r\n  \"publishInfo\": {\r\n    \"serviceRegistryPublishInfo\": [\r\n      {\r\n        \"gatewayEndpoints\": [\r\n          {\r\n            \"gatewayEndpoint\": \"http://localhost:5555/ws/calc/1\"\r\n          }\r\n        ],\r\n        \"serviceRegistryId\": \"aec973cd-1e4c-4a93-93a4-950e32d39156\"\r\n      }\r\n    ],\r\n    \"apiId\": \"afe8b72e-e1a5-47c6-9b43-e7f12858c091\"\r\n  }\r\n}"
+            },
+            "description": "Service registry publish payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InputServiceRegistryPublish"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the status of the publish operations given in the request.",
+            "schema": {
+              "$ref": "#/definitions/ServiceRegistryPublishPutResponse"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"publishResponse\": {\r\n    \"apiId\": \"afe8b72e-e1a5-47c6-9b43-e7f12858c091\",\r\n    \"apiName\": \"CalcService\",\r\n    \"apiVersion\": \"10.3\",\r\n    \"serviceRegistryPublishResponses\": [\r\n      {\r\n        \"serviceRegistryId\": \"aec973cd-1e4c-4a93-93a4-950e32d39156\",\r\n        \"serviceRegistryName\": \"MyServiceConsul\",\r\n        \"status\": \"PUBLISHED\",\r\n        \"gatewayEndpoints\": [\r\n          {\r\n            \"gatewayEndpoint\": \"http://localhost:5555/ws/calc/1\",\r\n            \"status\": \"PUBLISHED\",\r\n          }\r\n        ],\r\n        \"success\": true,\r\n        \"description\": \"Publish successful\"\r\n      }\r\n    ]\r\n  }\r\n}"
+            }
+          },
+          "400": {
+            "description": "This status code indicates an invalid request body"
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          },
+          "404": {
+            "description": "This status code indicates that API with given apiId is not found in API Gateway"
+          }
+        }
+      }
+    },
+    "/serviceRegistry/unpublish": {
+      "put": {
+        "security": [
+          {
+            "Basic": []
+          }
+        ],
+        "description": "Unpublish one or more APIs from one or more service registries",
+        "produces": [
+          "application/json"
+        ],
+        "operationId": "unpublishFromServiceRegistry",
+        "parameters": [
+          {
+            "x-examples": {
+              "application/json": "{\r\n  \"unpublishInfo\": {\r\n    \"serviceRegistryIds\": [\r\n      \"aec973cd-1e4c-4a93-93a4-950e32d39156\"\r\n    ],\r\n    \"apiId\": \"afe8b72e-e1a5-47c6-9b43-e7f12858c091\"\r\n  },\r\n  \"forceUnpublish\": false\r\n}ds"
+            },
+            "description": "Service registry unpublish payload",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InputServiceRegistryUnpublish"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the service registry unpublish response",
+            "schema": {
+              "$ref": "#/definitions/ServiceRegistryUnpublishPutResponse"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"unpublishResponse\": {\r\n    \"apiId\": \"afe8b72e-e1a5-47c6-9b43-e7f12858c091\",\r\n    \"apiName\": \"CalcService\",\r\n    \"apiVersion\": \"10.3\",\r\n    \"serviceRegistryUnpublishResponses\": [\r\n      {\r\n        \"serviceRegistryId\": \"aec973cd-1e4c-4a93-93a4-950e32d39156\",\r\n        \"serviceRegistryName\": \"MyServiceConsul\",\r\n        \"success\": true,\r\n        \"description\": \" Unpublish successful\"\r\n      }\r\n    ]\r\n  }\r\n}"
+            }
+          },
+          "401": {
+            "description": "This status code indicates that either user didn't provide right credentials or user doesn't have required privileges to access this API."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "API": {
+      "type": "object",
+      "properties": {
+        "apiTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": "string"
+        },
+        "serviceRegistryDisplayName": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "discriminator": "type"
+    },
+    "APIAccessKey": {
+      "type": "object",
+      "properties": {
+        "apiAccessKey": {
+          "description": "API access key",
+          "type": "string"
+        },
+        "expirationDate": {
+          "description": "expiration date of the api key",
+          "type": "string"
+        },
+        "expirationInterval": {
+          "description": "expiration interval of the api key",
+          "type": "string"
+        }
+      }
+    },
+    "APIResponse": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "$ref": "#/definitions/GatewayAPI"
+        },
+        "apiId": {
+          "type": "string"
+        },
+        "errorReason": {
+          "type": "string"
+        },
+        "gatewayEndPointList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/APIResponseGatewayEndpoint"
+          }
+        },
+        "gatewayEndPoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "microgatewayEndPoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "portalGatewayDataEntries": {
+          "type": "object"
+        },
+        "pubSOAPFlavor": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "object"
+        },
+        "responseStatus": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "ERROR",
+            "NOT_FOUND",
+            "BAD_REQUEST",
+            "PARTIAL_SUCCESS"
+          ]
+        },
+        "restrictViewAsset": {
+          "type": "boolean"
+        },
+        "rootFileLocation": {
+          "type": "string"
+        },
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Team"
+          }
+        }
+      }
+    },
+    "APIResponseCreate": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "$ref": "#/definitions/GatewayAPI"
+        },
+        "apiId": {
+          "type": "string"
+        },
+        "errorReason": {
+          "type": "string"
+        },
+        "responseStatus": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "ERROR",
+            "NOT_FOUND",
+            "BAD_REQUEST",
+            "PARTIAL_SUCCESS"
+          ]
+        }
+      }
+    },
+    "APIResponseDelete": {
+      "type": "object",
+      "properties": {
+        "apiId": {
+          "type": "string"
+        },
+        "errorReason": {
+          "type": "string"
+        },
+        "responseStatus": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "ERROR",
+            "NOT_FOUND",
+            "BAD_REQUEST",
+            "PARTIAL_SUCCESS"
+          ]
+        }
+      }
+    },
+    "APIResponseGatewayEndpoint": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "endpointDisplayName": {
+          "type": "string"
+        },
+        "endpointName": {
+          "type": "string"
+        },
+        "endpointType": {
+          "type": "string",
+          "enum": [
+            "DEFAULT",
+            "GLOBAL",
+            "API_LEVEL",
+            "MICRO_GATEWAY"
+          ]
+        },
+        "endpointUrls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "APIResponseGetAPI": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "$ref": "#/definitions/GatewayAPI"
+        },
+        "apiId": {
+          "type": "string"
+        },
+        "errorReason": {
+          "type": "string"
+        },
+        "gatewayEndPoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "responseStatus": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "ERROR",
+            "NOT_FOUND",
+            "BAD_REQUEST",
+            "PARTIAL_SUCCESS"
+          ]
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          }
+        }
+      }
+    },
+    "APIResponseGetAPIs": {
+      "description": "This model contains the basics details of an API.",
+      "type": "object",
+      "properties": {
+        "active": {
+          "type": "boolean"
+        },
+        "apiId": {
+          "type": "string"
+        },
+        "apiName": {
+          "description": "API Name",
+          "type": "string"
+        },
+        "apiVersion": {
+          "description": "API Version",
+          "type": "string"
+        },
+        "errorReason": {
+          "type": "string"
+        },
+        "id": {
+          "description": "API Id",
+          "type": "string"
+        },
+        "publishedPortals": {
+          "description": "Published portals of an API",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "responseStatus": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "ERROR",
+            "NOT_FOUND",
+            "BAD_REQUEST",
+            "PARTIAL_SUCCESS"
+          ]
+        },
+        "systemVersion": {
+          "description": "System version of an API",
+          "type": "integer",
+          "format": "int32"
+        },
+        "teams": {
+          "description": "Contains teams belonging to an API.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Team"
+          }
+        },
+        "type": {
+          "description": "API Type",
+          "type": "string"
+        }
+      }
+    },
+    "APIResponseGetGlobalPolicies": {
+      "type": "object",
+      "properties": {
+        "globalPolicies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "APIResponseModel": {
+      "description": "This model contains the basics details of an API.",
+      "type": "object",
+      "properties": {
+        "api": {
+          "$ref": "#/definitions/APIResponseGetAPIs"
+        },
+        "responseStatus": {
+          "description": "Response status",
+          "type": "string",
+          "enum": [
+            "CREATED",
+            "SUCCESS",
+            "ERROR",
+            "UNEXPECTED_ERROR",
+            "NOT_FOUND",
+            "NO_CONTENT",
+            "LOCKED",
+            "UPDATED",
+            "ACTIVATED",
+            "DEACTIVATED",
+            "PUBLISHED",
+            "UNPUBLISHED"
+          ]
+        }
+      }
+    },
+    "APIResponsesModel": {
+      "description": "This model contains the basics details of all APIs.",
+      "type": "object",
+      "properties": {
+        "apiResponse": {
+          "description": "API Response",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/APIResponseModel"
+          }
+        }
+      }
+    },
+    "AbstractParameter": {
+      "type": "object",
+      "properties": {
+        "allowEmptyValue": {
+          "description": "Sets the ability to pass empty-valued parameters. This is valid only for query parameters and allows sending a parameter with an empty value",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "A brief description of the parameter. This could contain examples of use",
+          "type": "string"
+        },
+        "get$ref": {
+          "description": "The available paths and operations for the API",
+          "type": "string"
+        },
+        "in": {
+          "description": "The location of the parameter. Possible values are \"query\", \"header\", \"path\" or \"cookie\"",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the parameter. Parameter names are case sensitive",
+          "type": "string"
+        },
+        "required": {
+          "description": "Determines whether this parameter is mandatory. If the parameter location is \"path\", this property is REQUIRED and its value MUST be true. Otherwise, the property MAY be included and its default value is false",
+          "type": "boolean"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ActionImport": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Application": {
+      "type": "object",
+      "properties": {
+        "accessTokens": {
+          "$ref": "#/definitions/ApplicationToken"
+        },
+        "applicationID": {
+          "description": "unique identifier of an application",
+          "type": "string"
+        },
+        "authStrategyIds": {
+          "description": "Contains a list of JWT/Oauth/OpenID authentication strategy ids associated to the application",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "contactEmails": {
+          "description": "list of email contacts",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creationDate": {
+          "description": "application creation time",
+          "type": "string"
+        },
+        "description": {
+          "description": "description of the application",
+          "type": "string"
+        },
+        "iconbyteArray": {
+          "description": "application icon byte array",
+          "type": "string"
+        },
+        "identifiers": {
+          "description": "list of all application identifiers",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationIdentifier"
+          }
+        },
+        "isSuspended": {
+          "description": "holds the suspended state of an application",
+          "type": "boolean"
+        },
+        "jsOrigins": {
+          "description": "list of all javascript origins",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "lastModified": {
+          "description": "last modified time of the application",
+          "type": "string"
+        },
+        "lastUpdated": {
+          "description": "last modified time of the application in milliseconds",
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "description": "name of the application",
+          "type": "string"
+        },
+        "owner": {
+          "description": "owner of the application",
+          "type": "string"
+        },
+        "primaryNode": {
+          "$ref": "#/definitions/Node"
+        },
+        "shell": {
+          "type": "boolean"
+        },
+        "siteURLs": {
+          "description": "list of all site URLs",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscription": {
+          "type": "boolean"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "ApplicationIdentifier": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "unique identifier of the application identifier",
+          "type": "string"
+        },
+        "key": {
+          "description": "identifier type",
+          "type": "string"
+        },
+        "name": {
+          "description": "name of the identifier",
+          "type": "string"
+        },
+        "value": {
+          "description": "list of identifier values",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ApplicationToken": {
+      "type": "object",
+      "properties": {
+        "apiAccessKey": {
+          "$ref": "#/definitions/APIAccessKey"
+        },
+        "oauth2Token": {
+          "$ref": "#/definitions/OAuth2Token"
+        }
+      }
+    },
+    "ArrayModel": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Model"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "items": {
+              "$ref": "#/definitions/Property"
+            },
+            "maxItems": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "minItems": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      ]
+    },
+    "ArrayProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "items": {
+              "$ref": "#/definitions/Property"
+            },
+            "maxItems": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "minItems": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "uniqueItems": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "ArraySchema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "items": {
+              "$ref": "#/definitions/Schema"
+            }
+          }
+        }
+      ]
+    },
+    "AuthServerScope": {
+      "description": "Represents the oauth scope from an authorization server",
+      "type": "object",
+      "properties": {
+        "authServerAlias": {
+          "description": "Name of the authorization server",
+          "type": "string"
+        },
+        "scopeName": {
+          "description": "OAuth scope name from authorization server definition",
+          "type": "string"
+        }
+      }
+    },
+    "AuthorizationValue": {
+      "type": "object",
+      "properties": {
+        "keyName": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "BaseIntegerProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exclusiveMaximum": {
+              "type": "boolean"
+            },
+            "exclusiveMinimum": {
+              "type": "boolean"
+            },
+            "maximum": {
+              "type": "number"
+            },
+            "minimum": {
+              "type": "number"
+            },
+            "multipleOf": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    },
+    "BodyParameter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Parameter"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Model"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "BooleanProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "BooleanSchema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "Callback": {
+      "type": "object",
+      "properties": {
+        "callbacksMap": {
+          "description": "A Path Item Object used to define a callback request and expected responses",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Path"
+          }
+        },
+        "get$ref": {
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "CommandInfo": {
+      "type": "object",
+      "properties": {
+        "commandClass": {
+          "type": "string"
+        },
+        "commandName": {
+          "type": "string"
+        }
+      }
+    },
+    "Components": {
+      "type": "object",
+      "properties": {
+        "callbacks": {
+          "description": "An object to hold reusable callback objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Callback"
+          }
+        },
+        "examples": {
+          "description": "An object to hold reusable example objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Example"
+          }
+        },
+        "headers": {
+          "description": "An object to hold reusable header objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Header"
+          }
+        },
+        "links": {
+          "description": "An object to hold reusable link objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "parameters": {
+          "description": "An object to hold reusable parameter objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Parameter"
+          }
+        },
+        "requestBodies": {
+          "description": "An object to hold reusable requestBody objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/RequestBody"
+          }
+        },
+        "responses": {
+          "description": "An object to hold reusable response objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Response"
+          }
+        },
+        "schemas": {
+          "description": "An object to hold reusable schema objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "securitySchemes": {
+          "description": "An object to hold reusable securityScheme objects",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SecurityScheme"
+          }
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ComposedModel": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Model"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "allOf": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Model"
+              }
+            },
+            "anyOf": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Model"
+              }
+            },
+            "child": {
+              "$ref": "#/definitions/Model"
+            },
+            "interfaces": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Model"
+              }
+            },
+            "oneOf": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Model"
+              }
+            },
+            "parent": {
+              "$ref": "#/definitions/Model"
+            }
+          }
+        }
+      ]
+    },
+    "ComposedProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "allOf": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Property"
+              }
+            },
+            "anyOf": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Property"
+              }
+            },
+            "oneOf": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Property"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ComposedSchema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "allOf": {
+              "description": "Must be valid against all of the subschemas",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Schema"
+              }
+            },
+            "anyOf": {
+              "description": "Must be valid against any of the subschemas",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Schema"
+              }
+            },
+            "oneOf": {
+              "description": "Must be valid against exactly one of the subschemas",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Schema"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Contact": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "description": "The email address of the contact person/organization",
+          "type": "string"
+        },
+        "name": {
+          "description": "The identifying name of the contact person/organization",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL pointing to the contact information",
+          "type": "string"
+        }
+      }
+    },
+    "CookieParameter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Parameter"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "DataFlavor": {
+      "type": "object",
+      "properties": {
+        "defaultRepresentationClassAsString": {
+          "type": "string"
+        },
+        "flavorJavaFileListType": {
+          "type": "boolean"
+        },
+        "flavorRemoteObjectType": {
+          "type": "boolean"
+        },
+        "flavorSerializedObjectType": {
+          "type": "boolean"
+        },
+        "flavorTextType": {
+          "type": "boolean"
+        },
+        "humanPresentableName": {
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string"
+        },
+        "mimeTypeSerializedObject": {
+          "type": "boolean"
+        },
+        "primaryType": {
+          "type": "string"
+        },
+        "representationClassByteBuffer": {
+          "type": "boolean"
+        },
+        "representationClassCharBuffer": {
+          "type": "boolean"
+        },
+        "representationClassInputStream": {
+          "type": "boolean"
+        },
+        "representationClassReader": {
+          "type": "boolean"
+        },
+        "representationClassRemote": {
+          "type": "boolean"
+        },
+        "representationClassSerializable": {
+          "type": "boolean"
+        },
+        "subType": {
+          "type": "string"
+        }
+      }
+    },
+    "DataHandler": {
+      "type": "object",
+      "properties": {
+        "allCommands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CommandInfo"
+          }
+        },
+        "content": {
+          "type": "object"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "dataSource": {
+          "$ref": "#/definitions/DataSource"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "name": {
+          "type": "string"
+        },
+        "outputStream": {
+          "$ref": "#/definitions/OutputStream"
+        },
+        "preferredCommands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CommandInfo"
+          }
+        },
+        "transferDataFlavors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataFlavor"
+          }
+        }
+      }
+    },
+    "DataSource": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "name": {
+          "type": "string"
+        },
+        "outputStream": {
+          "$ref": "#/definitions/OutputStream"
+        }
+      }
+    },
+    "DateTimeProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "DecimalProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exclusiveMaximum": {
+              "type": "boolean"
+            },
+            "exclusiveMinimum": {
+              "type": "boolean"
+            },
+            "maximum": {
+              "type": "number"
+            },
+            "minimum": {
+              "type": "number"
+            },
+            "multipleOf": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    },
+    "Endpoint": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": "boolean"
+        },
+        "connectionTimeoutDuration": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "optimizationTechnique": {
+          "type": "string"
+        },
+        "passSecurityHeaders": {
+          "type": "boolean"
+        },
+        "uri": {
+          "type": "string"
+        }
+      }
+    },
+    "Endpoints": {
+      "description": "This defines the service registry publish information for API Gateway's API endpoints",
+      "type": "object",
+      "properties": {
+        "gatewayEndpoint": {
+          "description": "API's access endpoint exposed in API Gateway.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the API endpoint. Shows whether this endpoint is published to the service registry.Possible values are NEW, PUBLISHED and SUSPENDED. NEW represents the endpoint is not published to the service registry. PUBLISHED represents the endpoint is published to the service registry. SUSPENDED represents the endpoint is published to service registry, but is not currently active (for example: during deactivation of API or shutdown of API Gateway or disabling ports).",
+          "type": "string",
+          "enum": [
+            "NEW",
+            "PUBLISHED",
+            "SUSPENDED"
+          ]
+        }
+      }
+    },
+    "EntitySet": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "entityType": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "EntityType": {
+      "type": "object",
+      "properties": {
+        "methods": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MethodParameters"
+          }
+        },
+        "navigationProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/EntitySet"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Enumeration": {
+      "type": "object"
+    },
+    "Example": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Long description for the example",
+          "type": "string"
+        },
+        "externalValue": {
+          "description": "A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents. The value field and externalValue field are mutually exclusive",
+          "type": "string"
+        },
+        "get$ref": {
+          "type": "string"
+        },
+        "summary": {
+          "description": "Short description for the example",
+          "type": "string"
+        },
+        "value": {
+          "description": "Embedded literal example. The value field and externalValue field are mutually exclusive. To represent examples of media types that cannot naturally represented in JSON or YAML, use a string value to contain the example, escaping where necessary",
+          "type": "object"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ExternalDocs": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "A short description of the target documentation",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL for the target documentation",
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "FormParameter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Parameter"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "FunctionImport": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "function": {
+          "type": "string"
+        }
+      }
+    },
+    "GatewayAPI": {
+      "type": "object",
+      "properties": {
+        "apiDefinition": {
+          "$ref": "#/definitions/API"
+        },
+        "apiDescription": {
+          "type": "string"
+        },
+        "apiDocuments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "apiEndpointPrefix": {
+          "type": "string"
+        },
+        "apiGroups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "apiName": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "centraSiteURL": {
+          "type": "string",
+          "readOnly": true
+        },
+        "creationDate": {
+          "type": "string",
+          "readOnly": true
+        },
+        "gatewayEndpoints": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "id": {
+          "type": "string"
+        },
+        "isActive": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "lastModified": {
+          "type": "string",
+          "readOnly": true
+        },
+        "maturityState": {
+          "type": "string"
+        },
+        "mockService": {
+          "$ref": "#/definitions/MockService"
+        },
+        "nativeEndpoint": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/Endpoint"
+          },
+          "readOnly": true
+        },
+        "nextVersion": {
+          "type": "string",
+          "readOnly": true
+        },
+        "oauth2ScopeName": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string",
+          "readOnly": true
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "portalApiItemIdentifier": {
+          "type": "string",
+          "readOnly": true
+        },
+        "prevVersion": {
+          "type": "string",
+          "readOnly": true
+        },
+        "provider": {
+          "type": "string",
+          "readOnly": true
+        },
+        "publishedPortals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "publishedToRegistry": {
+          "type": "boolean"
+        },
+        "rootFileName": {
+          "type": "string",
+          "readOnly": true
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Scope"
+          }
+        },
+        "systemVersion": {
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true
+        },
+        "tracingEnabled": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "GatewaySchema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "GatewayScope": {
+      "description": "Maps the authorization server scope with APIs or API scopes",
+      "type": "object",
+      "properties": {
+        "apiScopes": {
+          "description": "List of API IDs (or API Scope IDs) mapped the auth server scope",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "audience": {
+          "description": "This field is optional. This value will be used in scope level audience matching",
+          "type": "string"
+        },
+        "id": {
+          "description": "A unique ID for the OAuth scope mapping",
+          "type": "string"
+        },
+        "requiredAuthScopes": {
+          "description": "List of oauth scope entries from the authorization server definition",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuthServerScope"
+          }
+        },
+        "scopeDescription": {
+          "description": "Description for the OAuth scope mapping",
+          "type": "string"
+        },
+        "scopeName": {
+          "description": "Name of the OAuth scope mapping",
+          "type": "string"
+        }
+      }
+    },
+    "Header": {
+      "type": "object",
+      "properties": {
+        "_enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowEmptyValue": {
+          "description": "Sets the ability to pass empty-valued parameters. This is valid only for query parameters and allows sending a parameter with an empty value",
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "description": "Determines whether the parameter value SHOULD allow reserved characters, as defined by RFC3986 :/?#[]@!$\u0026'()*+,;= to be included without percent-encoding. This property only applies to parameters with an in value of query. The default value is false",
+          "type": "boolean"
+        },
+        "content": {
+          "description": "A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "default": {
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Determines whether this parameter is mandatory. If the parameter location is \"path\", this property is REQUIRED and its value MUST be true. Otherwise, the property MAY be included and its default value is false",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "A brief description of the parameter. This could contain examples of use",
+          "type": "string"
+        },
+        "examples": {
+          "description": "Examples of the media type. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The examples field is mutually exclusive of the example field. Furthermore, if referencing a schema which contains an example, the examples value SHALL override the example provided by the schema",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Example"
+          }
+        },
+        "explode": {
+          "description": "When this is true, parameter values of type array or object generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When style is form, the default value is true. For all other styles, the default value is false",
+          "type": "boolean"
+        },
+        "extendedExample": {
+          "description": "Example of the media type. The example SHOULD match the specified schema and encoding properties if present. The example field is mutually exclusive of the examples field. Furthermore, if referencing a schema which contains an example, the example value SHALL override the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary",
+          "type": "object"
+        },
+        "get$ref": {
+          "description": "The available paths and operations for the API",
+          "type": "string"
+        },
+        "in": {
+          "description": "The location of the parameter. Possible values are \"query\", \"header\", \"path\" or \"cookie\"",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the parameter. Parameter names are case sensitive",
+          "type": "string"
+        },
+        "parameterSchema": {
+          "$ref": "#/definitions/Schema"
+        },
+        "required": {
+          "description": "Determines whether this parameter is mandatory. If the parameter location is \"path\", this property is REQUIRED and its value MUST be true. Otherwise, the property MAY be included and its default value is false",
+          "type": "boolean"
+        },
+        "style": {
+          "description": "Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of in): for query - form; for path - simple; for header - simple; for cookie - form",
+          "type": "string",
+          "enum": [
+            "MATRIX",
+            "LABEL",
+            "FORM",
+            "SIMPLE",
+            "SPACEDELIMITED",
+            "PIPEDELIMITED",
+            "DEEPOBJECT"
+          ]
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "xpath": {
+          "$ref": "#/definitions/Xpath"
+        }
+      }
+    },
+    "HeaderParameter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Parameter"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "Info": {
+      "type": "object",
+      "properties": {
+        "contact": {
+          "$ref": "#/definitions/Contact"
+        },
+        "description": {
+          "description": "A short description of the application",
+          "type": "string"
+        },
+        "license": {
+          "$ref": "#/definitions/Licence"
+        },
+        "termsOfService": {
+          "description": "A URL to the Terms of Service for the API",
+          "type": "string"
+        },
+        "title": {
+          "description": "The title of the application",
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "version": {
+          "description": "Version of the API",
+          "type": "string"
+        }
+      }
+    },
+    "InputAPI": {
+      "type": "object",
+      "required": [
+        "apiName",
+        "type"
+      ],
+      "properties": {
+        "apiDefinition": {
+          "$ref": "#/definitions/API"
+        },
+        "apiDescription": {
+          "type": "string"
+        },
+        "apiName": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "authorizationValue": {
+          "$ref": "#/definitions/AuthorizationValue"
+        },
+        "maturityState": {
+          "type": "string"
+        },
+        "rootFileName": {
+          "description": "Required when creating an API by importing protected URL",
+          "type": "string"
+        },
+        "teams": {
+          "description": "Contains teams to which the API must be assigned.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Team"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "description": "Required when creating an API by importing URL",
+          "type": "string"
+        }
+      }
+    },
+    "InputAPIImplementation": {
+      "type": "object",
+      "properties": {
+        "maturityState": {
+          "type": "string"
+        },
+        "nativeBaseURLs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "InputForAddGatewayEndpoint": {
+      "description": "To add a new Gateway endpoint of this API",
+      "type": "object",
+      "properties": {
+        "endpointName": {
+          "description": "Name of the endpoint",
+          "type": "string"
+        },
+        "gatewayEndpoint": {
+          "description": "Gateway endpoint value",
+          "type": "string"
+        }
+      }
+    },
+    "InputForGatewayEndpoints": {
+      "description": "To manage gateway endpoints of an API",
+      "type": "object",
+      "properties": {
+        "add": {
+          "$ref": "#/definitions/InputForAddGatewayEndpoint"
+        },
+        "remove": {
+          "$ref": "#/definitions/InputForRemoveGatewayEndpoint"
+        },
+        "update": {
+          "$ref": "#/definitions/InputForUpdateGatewayEndpoint"
+        }
+      }
+    },
+    "InputForRemoveGatewayEndpoint": {
+      "description": "To remove an existing Gateway endpoint of this API",
+      "type": "object",
+      "properties": {
+        "endpointName": {
+          "description": "Name of the endpoint",
+          "type": "string"
+        }
+      }
+    },
+    "InputForUpdateGatewayEndpoint": {
+      "description": "To update an existing Gateway endpoint of this API",
+      "type": "object",
+      "properties": {
+        "gatewayEndpoint": {
+          "description": "Gateway endpoint value to be updated",
+          "type": "string"
+        },
+        "newEndpointName": {
+          "description": "New name of the endpoint",
+          "type": "string"
+        },
+        "oldEndpointName": {
+          "description": "Existing name of the endpoint",
+          "type": "string"
+        }
+      }
+    },
+    "InputGatewayEndpoints": {
+      "type": "object",
+      "properties": {
+        "gatewayEndpoints": {
+          "$ref": "#/definitions/InputForGatewayEndpoints"
+        }
+      }
+    },
+    "InputIntegrationServerPublish": {
+      "type": "object",
+      "properties": {
+        "publishInfo": {
+          "$ref": "#/definitions/PublishPayload"
+        },
+        "publishInfos": {
+          "description": "This contains the publish information for multiple APIs. Required when publishing more than one API to one or more integration servers.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublishPayload"
+          }
+        }
+      }
+    },
+    "InputPublish": {
+      "type": "object",
+      "properties": {
+        "communities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "endpoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "portalGatewayId": {
+          "type": "string"
+        }
+      }
+    },
+    "InputServiceRegistryPublish": {
+      "type": "object",
+      "properties": {
+        "publishInfo": {
+          "$ref": "#/definitions/PublishPayload"
+        },
+        "publishInfos": {
+          "description": "This contains the publish information for multiple APIs. Required when publishing more than one API to one or more service registries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublishPayload"
+          }
+        }
+      }
+    },
+    "InputServiceRegistryUnpublish": {
+      "type": "object",
+      "properties": {
+        "unpublishInfo": {
+          "$ref": "#/definitions/UnpublishInfo"
+        },
+        "unpublishInfos": {
+          "description": "This contains the unpublish information for multiple APIs. Required when publishing more than one API from one or more service registries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UnpublishInfo"
+          }
+        }
+      }
+    },
+    "InputStream": {
+      "type": "object"
+    },
+    "InputVersion": {
+      "type": "object",
+      "required": [
+        "newApiVersion"
+      ],
+      "properties": {
+        "newApiVersion": {
+          "type": "string"
+        },
+        "retainApplications": {
+          "type": "boolean"
+        }
+      }
+    },
+    "IntegerSchema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "IntegrationServerPublishInfo": {
+      "type": "object",
+      "properties": {
+        "apiName": {
+          "type": "string"
+        },
+        "contentModelComplianceForWSDL": {
+          "type": "string"
+        },
+        "enableMTOM": {
+          "type": "boolean"
+        },
+        "enforceWSICompliance": {
+          "type": "boolean"
+        },
+        "folderName": {
+          "description": "Name of the folder under the package (mentioned on 'packageName' property) in which the API to be published. This field is required.",
+          "type": "string"
+        },
+        "importSwaggerBasedOnTags": {
+          "type": "boolean"
+        },
+        "integrationServerId": {
+          "description": "Uddi key of the integration server created in API Gateway. This field is required.",
+          "type": "string"
+        },
+        "integrationServerName": {
+          "type": "string"
+        },
+        "packageAndFolders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PackageFolderPair"
+          }
+        },
+        "packageName": {
+          "description": "Name of the package in the integration server in which the API to be published. This field is required.",
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NEW",
+            "PUBLISHED",
+            "SUSPENDED"
+          ]
+        },
+        "updateNativeEndpointsOfAPI": {
+          "type": "boolean"
+        },
+        "validateSchemaWithXerces": {
+          "type": "boolean"
+        }
+      }
+    },
+    "IntegrationServerPublishResponse": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Represents the status of the publish operation of the API to the service registry eg: Publish successful, Publish failed, etc",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "Provides the reason for the failure when the publish operation is not successful",
+          "type": "string"
+        },
+        "integrationServerId": {
+          "description": "Id i.e, UDDI key of the service registry",
+          "type": "string"
+        },
+        "integrationServerName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NEW",
+            "PUBLISHED",
+            "SUSPENDED"
+          ]
+        },
+        "success": {
+          "description": "Represents whether the publish of API to the service registry is success. Possible values: true/false",
+          "type": "boolean"
+        }
+      }
+    },
+    "Licence": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The license name used for the API",
+          "type": "string"
+        },
+        "url": {
+          "description": "A URL to the license used for the API",
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "A description of the link",
+          "type": "string"
+        },
+        "get$ref": {
+          "type": "string"
+        },
+        "operationId": {
+          "description": "The name of an existing, resolvable OAS operation, as defined with a unique operationId. This field is mutually exclusive of the operationRef field",
+          "type": "string"
+        },
+        "operationRef": {
+          "description": "A relative or absolute reference to an OAS operation. This field is mutually exclusive of the operationId field, and MUST point to an Operation Object. Relative operationRef values MAY be used to locate an existing Operation Object in the API definition",
+          "type": "string"
+        },
+        "parameters": {
+          "description": "A map representing parameters to pass to an operation as specified with operationId or identified via operationRef. The key is the parameter name to be used, whereas the value can be a constant or an expression to be evaluated and passed to the linked operation. The parameter name can be qualified using the parameter location [{in}.]{name} for operations that use the same parameter name in different locations (e.g. path.id)",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "requestBody": {
+          "description": "A literal value or {expression} to use as a request body when calling the target operation",
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "MapProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/definitions/Property"
+            },
+            "maxProperties": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "minProperties": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      ]
+    },
+    "MediaType": {
+      "type": "object",
+      "properties": {
+        "example": {
+          "description": "Example of the media type. The example object SHOULD be in the correct format as specified by the media type. The example field is mutually exclusive of the examples field. Furthermore, if referencing a schema which contains an example, the example value SHALL override the example provided by the schema",
+          "type": "object"
+        },
+        "examples": {
+          "description": "Examples of the media type. Each example object SHOULD match the media type and specified schema if present. The examples field is mutually exclusive of the example field. Furthermore, if referencing a schema which contains an example, the examples value SHALL override the example provided by the schema",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Example"
+          }
+        },
+        "schema": {
+          "$ref": "#/definitions/Schema"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "MessageFrame": {
+      "type": "object",
+      "properties": {
+        "messageDescription": {
+          "type": "string"
+        },
+        "messagePayload": {
+          "type": "string"
+        },
+        "origin": {
+          "type": "string",
+          "enum": [
+            "Server",
+            "Client"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Binary",
+            "Text"
+          ]
+        }
+      }
+    },
+    "MethodParameters": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "returnType": {
+          "type": "string"
+        }
+      }
+    },
+    "MockService": {
+      "type": "object",
+      "properties": {
+        "enableMock": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "string"
+        },
+        "service": {
+          "type": "string"
+        }
+      }
+    },
+    "MockedCondition": {
+      "type": "object",
+      "properties": {
+        "conditionName": {
+          "type": "string"
+        },
+        "mockedConditionParameter": {
+          "type": "string",
+          "enum": [
+            "Body",
+            "Header",
+            "QueryParameter"
+          ]
+        },
+        "mockedLevel1Operator": {
+          "type": "string",
+          "enum": [
+            "Equals",
+            "NotEquals",
+            "ContainsKey",
+            "ContainsKeyValue"
+          ]
+        },
+        "mockedLevel2Operator": {
+          "type": "string",
+          "enum": [
+            "Equals",
+            "NotEquals",
+            "Contains",
+            "StartsWith",
+            "EndsWith"
+          ]
+        },
+        "value1": {
+          "type": "string"
+        },
+        "value2": {
+          "type": "string"
+        }
+      }
+    },
+    "MockedConditionsBasedCustomResponse": {
+      "type": "object",
+      "properties": {
+        "mockedConditionList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MockedCondition"
+          }
+        },
+        "mockedResponse": {
+          "$ref": "#/definitions/MockedResponse"
+        }
+      }
+    },
+    "MockedResponse": {
+      "type": "object",
+      "properties": {
+        "responseBody": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "responseHeaders": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "statusCode": {
+          "type": "string"
+        }
+      }
+    },
+    "Model": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "example": {
+          "type": "object"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocs"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reference": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      },
+      "discriminator": "type"
+    },
+    "ModelImpl": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Model"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "allowEmptyValue": {
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "type": "object"
+            },
+            "discriminator": {
+              "type": "string"
+            },
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "format": {
+              "type": "string"
+            },
+            "maximum": {
+              "type": "number"
+            },
+            "minimum": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            },
+            "required": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "uniqueItems": {
+              "type": "boolean"
+            },
+            "xml": {
+              "$ref": "#/definitions/Xml"
+            }
+          }
+        }
+      ]
+    },
+    "Multipart": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "parent": {
+          "$ref": "#/definitions/Part"
+        }
+      }
+    },
+    "Namespaces": {
+      "type": "object",
+      "properties": {
+        "prefix": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        }
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "hostId": {
+          "type": "string"
+        },
+        "replica": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "Number": {
+      "type": "object"
+    },
+    "NumberSchema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "OAuth2Definition": {
+      "type": "object",
+      "properties": {
+        "authorizationGrants": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authorizationUrl": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "flow": {
+          "type": "string"
+        },
+        "refreshUrl": {
+          "type": "string"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "securitySchemeDescriptor": {
+          "$ref": "#/definitions/SecuritySchemeDescriptor"
+        },
+        "tokenUrl": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "OAuth2Token": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "description": "unique identifier of the oauth2 client",
+          "type": "string"
+        },
+        "clientName": {
+          "description": "the name of the client",
+          "type": "string"
+        },
+        "clientSecret": {
+          "description": "the client secret",
+          "type": "string"
+        },
+        "expirationInterval": {
+          "description": "the expiration interval",
+          "type": "string"
+        },
+        "redirectUris": {
+          "description": "list of redirect uris",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "refreshCount": {
+          "description": "number of times an access token can be refreshed",
+          "type": "string"
+        },
+        "scopes": {
+          "description": "the scopes associated with the client",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "description": "type of the oauth2 client",
+          "type": "string"
+        }
+      }
+    },
+    "OAuthFlows": {
+      "type": "object",
+      "properties": {
+        "authorizationCode": {
+          "$ref": "#/definitions/OAuth2Definition"
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/OAuth2Definition"
+        },
+        "implicit": {
+          "$ref": "#/definitions/OAuth2Definition"
+        },
+        "password": {
+          "$ref": "#/definitions/OAuth2Definition"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ODataAPI": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/API"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "actionImports": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/ActionImport"
+              }
+            },
+            "actions": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/EntityType"
+              }
+            },
+            "entitySets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/EntitySet"
+              }
+            },
+            "entityTypes": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/EntityType"
+              }
+            },
+            "functionImports": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/FunctionImport"
+              }
+            },
+            "functions": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/EntityType"
+              }
+            },
+            "metaDataDocument": {
+              "type": "string"
+            },
+            "odataVersion": {
+              "type": "string"
+            },
+            "serviceDocument": {
+              "type": "string"
+            },
+            "serviceRoot": {
+              "type": "string"
+            },
+            "singletons": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/EntitySet"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ObjectProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Property"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ObjectSchema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "Operation": {
+      "type": "object",
+      "properties": {
+        "callbacks": {
+          "description": "An optional, string description, intended to apply to all operations in this path",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Callback"
+          }
+        },
+        "deprecated": {
+          "description": "Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation. Default value is false",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "A verbose explanation of the operation behavior",
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocs"
+        },
+        "mockedConditionsBasedCustomResponsesList": {
+          "description": "The list of mocked conditions and it's applicable only for mocked APIs",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MockedConditionsBasedCustomResponse"
+          }
+        },
+        "mockedResponses": {
+          "description": "The list of possible mocked responses as they are returned from executing this operation and it's applicable only for mocked APIs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MockedResponse"
+          }
+        },
+        "operationId": {
+          "description": "Unique string used to identify the operation. The id MUST be unique among all operations described in the API. The operationId value is case-sensitive",
+          "type": "string"
+        },
+        "parameters": {
+          "description": "A list of parameters that are applicable for this operation. If a parameter is already defined at the Path Item, the new definition will override it but can never remove it",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Parameter"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/definitions/RequestBody"
+        },
+        "responses": {
+          "description": "The list of possible responses as they are returned from executing this operation",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Response"
+          }
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "description": "A short summary of what the operation does",
+          "type": "string"
+        },
+        "tags": {
+          "description": "A list of tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "OutputStream": {
+      "type": "object"
+    },
+    "PackageFolderPair": {
+      "type": "object",
+      "properties": {
+        "apiDescriptorNSNameMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "folderName": {
+          "type": "string"
+        },
+        "markedAsDeleted": {
+          "type": "boolean"
+        },
+        "packageName": {
+          "type": "string"
+        }
+      }
+    },
+    "Parameter": {
+      "type": "object",
+      "properties": {
+        "_enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowEmptyValue": {
+          "description": "Sets the ability to pass empty-valued parameters. This is valid only for query parameters and allows sending a parameter with an empty value",
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "description": "Determines whether the parameter value SHOULD allow reserved characters, as defined by RFC3986 :/?#[]@!$\u0026'()*+,;= to be included without percent-encoding. This property only applies to parameters with an in value of query. The default value is false",
+          "type": "boolean"
+        },
+        "content": {
+          "description": "A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "default": {
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Determines whether this parameter is mandatory. If the parameter location is \"path\", this property is REQUIRED and its value MUST be true. Otherwise, the property MAY be included and its default value is false",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "A brief description of the parameter. This could contain examples of use",
+          "type": "string"
+        },
+        "examples": {
+          "description": "Examples of the media type. Each example SHOULD contain a value in the correct format as specified in the parameter encoding. The examples field is mutually exclusive of the example field. Furthermore, if referencing a schema which contains an example, the examples value SHALL override the example provided by the schema",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Example"
+          }
+        },
+        "explode": {
+          "description": "When this is true, parameter values of type array or object generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters this property has no effect. When style is form, the default value is true. For all other styles, the default value is false",
+          "type": "boolean"
+        },
+        "extendedExample": {
+          "description": "Example of the media type. The example SHOULD match the specified schema and encoding properties if present. The example field is mutually exclusive of the examples field. Furthermore, if referencing a schema which contains an example, the example value SHALL override the example provided by the schema. To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary",
+          "type": "object"
+        },
+        "get$ref": {
+          "description": "The available paths and operations for the API",
+          "type": "string"
+        },
+        "in": {
+          "description": "The location of the parameter. Possible values are \"query\", \"header\", \"path\" or \"cookie\"",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the parameter. Parameter names are case sensitive",
+          "type": "string"
+        },
+        "parameterSchema": {
+          "$ref": "#/definitions/Schema"
+        },
+        "required": {
+          "description": "Determines whether this parameter is mandatory. If the parameter location is \"path\", this property is REQUIRED and its value MUST be true. Otherwise, the property MAY be included and its default value is false",
+          "type": "boolean"
+        },
+        "style": {
+          "description": "Describes how the parameter value will be serialized depending on the type of the parameter value. Default values (based on value of in): for query - form; for path - simple; for header - simple; for cookie - form",
+          "type": "string",
+          "enum": [
+            "MATRIX",
+            "LABEL",
+            "FORM",
+            "SIMPLE",
+            "SPACEDELIMITED",
+            "PIPEDELIMITED",
+            "DEEPOBJECT"
+          ]
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "xpath": {
+          "$ref": "#/definitions/Xpath"
+        }
+      }
+    },
+    "Part": {
+      "type": "object",
+      "properties": {
+        "allHeaders": {
+          "$ref": "#/definitions/Enumeration"
+        },
+        "content": {
+          "type": "object"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "dataHandler": {
+          "$ref": "#/definitions/DataHandler"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disposition": {
+          "type": "string"
+        },
+        "fileName": {
+          "type": "string"
+        },
+        "inputStream": {
+          "$ref": "#/definitions/InputStream"
+        },
+        "lineCount": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "Path": {
+      "type": "object",
+      "properties": {
+        "delete": {
+          "$ref": "#/definitions/Operation"
+        },
+        "description": {
+          "description": "An optional, string description, intended to apply to all operations in this path",
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "get": {
+          "$ref": "#/definitions/Operation"
+        },
+        "get$ref": {
+          "description": "Allows for an external definition of this path item",
+          "type": "string"
+        },
+        "head": {
+          "$ref": "#/definitions/Operation"
+        },
+        "options": {
+          "$ref": "#/definitions/Operation"
+        },
+        "parameters": {
+          "description": "A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "patch": {
+          "$ref": "#/definitions/Operation"
+        },
+        "post": {
+          "$ref": "#/definitions/Operation"
+        },
+        "put": {
+          "$ref": "#/definitions/Operation"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "description": "An optional, string summary, intended to apply to all operations in this path",
+          "type": "string"
+        },
+        "tags": {
+          "description": "A list of path level tags for API documentation control. Tags can be used for logical grouping of operations by resources or any other qualifier",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trace": {
+          "$ref": "#/definitions/Operation"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "PathParameter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Parameter"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "Property": {
+      "type": "object",
+      "properties": {
+        "access": {
+          "type": "string"
+        },
+        "allowEmptyValue": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "example": {
+          "type": "object"
+        },
+        "format": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "position": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "xml": {
+          "$ref": "#/definitions/Xml"
+        }
+      },
+      "discriminator": "type"
+    },
+    "PublishPayload": {
+      "type": "object",
+      "properties": {
+        "apiId": {
+          "description": "API id for the API to be published. This field is required. The API will be published to the service registry with the value configured in 'Service registry display name' field of the API",
+          "type": "string"
+        },
+        "integrationServerPublishInfo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IntegrationServerPublishInfo"
+          }
+        },
+        "serviceRegistryPublishInfo": {
+          "description": "List of service registry publish information for the API. Each element of the list contains the publish information of the API for one service registry.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceRegistryPublishInfo"
+          }
+        }
+      }
+    },
+    "PublishResponse": {
+      "type": "object",
+      "properties": {
+        "apiId": {
+          "description": "API id of the API published.",
+          "type": "string"
+        },
+        "apiName": {
+          "description": "API name of the API published.",
+          "type": "string"
+        },
+        "apiVersion": {
+          "description": "API version of the API published.",
+          "type": "string"
+        },
+        "integrationServerPublishResponses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IntegrationServerPublishResponse"
+          }
+        },
+        "serviceRegistryPublishResponses": {
+          "description": "Contains publish status of the API for each service registry in the request.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceRegistryPublishResponse"
+          }
+        }
+      }
+    },
+    "QueryParameter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Parameter"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "RefModel": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Model"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "get$ref": {
+              "type": "string"
+            },
+            "refFormat": {
+              "type": "string",
+              "enum": [
+                "URL",
+                "RELATIVE",
+                "INTERNAL"
+              ]
+            },
+            "simpleRef": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "RefParameter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Parameter"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "RefProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "get$ref": {
+              "type": "string"
+            },
+            "refFormat": {
+              "type": "string",
+              "enum": [
+                "URL",
+                "RELATIVE",
+                "INTERNAL"
+              ]
+            },
+            "simpleRef": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "RequestBody": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "description": "The content of the request body. The key is a media type or media type range and the value describes it",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "description": {
+          "description": "A brief description of the request body. This could contain examples of use",
+          "type": "string"
+        },
+        "get$ref": {
+          "type": "string"
+        },
+        "required": {
+          "description": "Determines if the request body is required in the request. Defaults to false",
+          "type": "boolean"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Response": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "description": "A map containing descriptions of potential response payloads. The key is a media type or media type range and the value describes it",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "description": {
+          "description": "A short description of the response",
+          "type": "string"
+        },
+        "get$ref": {
+          "type": "string"
+        },
+        "headersV3": {
+          "description": "Maps a header name to its definition. RFC7230 states header names are case insensitive. If a response header is defined with the name \"Content-Type\", it SHALL be ignored",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Header"
+          }
+        },
+        "links": {
+          "description": "A map of operations links that can be followed from the response. The key of the map is a short name for the link, following the naming constraints of the names for Component Objects.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Link"
+          }
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "RestAPI": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/API"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "components": {
+              "$ref": "#/definitions/Components"
+            },
+            "externalDocs": {
+              "description": "Additional external documentation",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExternalDocs"
+              }
+            },
+            "info": {
+              "$ref": "#/definitions/Info"
+            },
+            "paths": {
+              "description": "The available paths and operations for the API",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Path"
+              }
+            },
+            "servers": {
+              "description": "An array of Server Objects, which provide connectivity information to a target server",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Server"
+              }
+            },
+            "vendorExtensions": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "RestEnabledPath": {
+      "type": "object",
+      "properties": {
+        "delete": {
+          "$ref": "#/definitions/Operation"
+        },
+        "description": {
+          "description": "An optional, string description, intended to apply to all operations in this path",
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "get": {
+          "$ref": "#/definitions/Operation"
+        },
+        "get$ref": {
+          "description": "Allows for an external definition of this path item",
+          "type": "string"
+        },
+        "head": {
+          "$ref": "#/definitions/Operation"
+        },
+        "invokePath": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/Operation"
+        },
+        "parameters": {
+          "description": "A list of parameters that are applicable for all the operations described under this path. These parameters can be overridden at the operation level, but cannot be removed there",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "patch": {
+          "$ref": "#/definitions/Operation"
+        },
+        "post": {
+          "$ref": "#/definitions/Operation"
+        },
+        "put": {
+          "$ref": "#/definitions/Operation"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "description": "An optional, string summary, intended to apply to all operations in this path",
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trace": {
+          "$ref": "#/definitions/Operation"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "SOAPAPI": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/API"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "baseWsdlUri": {
+              "type": "string"
+            },
+            "isRESTInvokeEnabled": {
+              "type": "boolean"
+            },
+            "nativeUri": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "operationPolicies": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "operationsInfo": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/definitions/SOAPOperation"
+              }
+            },
+            "primaryEndpoint": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "boolean"
+              }
+            },
+            "rootFileFolder": {
+              "type": "string"
+            },
+            "serviceName": {
+              "type": "string"
+            },
+            "wsdl": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "SOAPBinding": {
+      "type": "object",
+      "properties": {
+        "faultMessages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "inputMessage": {
+          "type": "string"
+        },
+        "interFace": {
+          "$ref": "#/definitions/SOAPInterface"
+        },
+        "name": {
+          "type": "string"
+        },
+        "outputMessage": {
+          "type": "string"
+        },
+        "specifier": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "SOAPInterface": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SOAPOperation"
+          }
+        }
+      }
+    },
+    "SOAPOperation": {
+      "type": "object",
+      "properties": {
+        "bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SOAPBinding"
+          }
+        },
+        "defined": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "isRESTInvokeEnabled": {
+          "type": "boolean"
+        },
+        "mockedConditionsBasedCustomResponsesList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MockedConditionsBasedCustomResponse"
+          }
+        },
+        "mockedResponses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MockedResponse"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "restEnabledPath": {
+          "$ref": "#/definitions/RestEnabledPath"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "soapAction": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Schema": {
+      "type": "object",
+      "properties": {
+        "additionalProperties": {
+          "$ref": "#/definitions/Schema"
+        },
+        "default": {
+          "description": "The default value represents what would be assumed by the consumer of the input as the value of the schema if one is not provided. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if type is string, then default can be \"foo\" but cannot be 1",
+          "type": "object"
+        },
+        "deprecated": {
+          "description": "Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is false",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "Provide a more lengthy explanation about the purpose of the data described by the schema",
+          "type": "string"
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "example": {
+          "description": "A free-form property to include an example of an instance for this schema. To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary",
+          "type": "object"
+        },
+        "exclusiveMaximum": {
+          "description": "Indicate whether maximum are exclusive of the value",
+          "type": "boolean"
+        },
+        "exclusiveMinimum": {
+          "description": "Indicate whether minimum are exclusive of the value",
+          "type": "boolean"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocs"
+        },
+        "format": {
+          "description": "The format keyword allows for basic semantic validation on certain kinds of string values that are commonly used",
+          "type": "string"
+        },
+        "get$ref": {
+          "type": "string"
+        },
+        "maxItems": {
+          "description": "The maximum length of the array can be specified",
+          "type": "integer",
+          "format": "int32"
+        },
+        "maxLength": {
+          "description": "The maximum length of a string can be constrained using the minLength",
+          "type": "integer",
+          "format": "int32"
+        },
+        "maxProperties": {
+          "description": "The maximum number of properties on an object can be restricted",
+          "type": "integer",
+          "format": "int32"
+        },
+        "maximum": {
+          "description": "Upper limit in the ranges of numbers, (or exclusiveMinimum and exclusiveMaximum for expressing exclusive range)",
+          "type": "number"
+        },
+        "minItems": {
+          "description": "The minimum length of the array can be specified",
+          "type": "integer",
+          "format": "int32"
+        },
+        "minLength": {
+          "description": "The minimum length of a string can be constrained using the minLength",
+          "type": "integer",
+          "format": "int32"
+        },
+        "minProperties": {
+          "description": "The minimum number of properties on an object can be restricted",
+          "type": "integer",
+          "format": "int32"
+        },
+        "minimum": {
+          "description": "Lower limit in the ranges of numbers",
+          "type": "number"
+        },
+        "multipleOf": {
+          "description": "Numbers can be restricted to a multiple of a given number, using the multipleOf keyword. It may be set to any positive number.",
+          "type": "number"
+        },
+        "name": {
+          "description": "User defined name for the property",
+          "type": "string"
+        },
+        "not": {
+          "$ref": "#/definitions/Schema"
+        },
+        "nullable": {
+          "description": "Allows sending a null value for the defined schema. Default value is false",
+          "type": "boolean"
+        },
+        "pattern": {
+          "description": "The pattern keyword is used to restrict a string to a particular regular expression. The regular expression syntax is the one defined in JavaScript (ECMA 262 specifically)",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties (key-value pairs) on an object are defined using the properties keyword. The value of properties is an object, where each key is the name of a property and each value is of type schema used to validate that property",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "readOnly": {
+          "description": "Relevant only for Schema \"properties\" definitions. Declares the property as \"read only\". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If the property is marked as readOnly being true and is in the required list, the required will take effect on the response only. A property MUST NOT be marked as both readOnly and writeOnly being true. Default value is false",
+          "type": "boolean"
+        },
+        "required": {
+          "description": "By default, the properties defined by the properties keyword are not required. However, one can provide a list of required properties using the required keyword.\nThe required keyword takes an array of zero or more strings. Each of these strings must be unique.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "description": "User defined title for the property",
+          "type": "string"
+        },
+        "type": {
+          "description": "It specifies the data type for a schema",
+          "type": "string"
+        },
+        "uniqueItems": {
+          "description": "A schema can ensure that each of the items in an array is unique. Simply set the uniqueItems keyword to true",
+          "type": "boolean"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "writeOnly": {
+          "description": "Relevant only for Schema \"properties\" definitions. Declares the property as \"write only\". Therefore, it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If the property is marked as writeOnly being true and is in the required list, the required will take effect on the request only. A property MUST NOT be marked as both readOnly and writeOnly being true. Default value is false",
+          "type": "boolean"
+        },
+        "xml": {
+          "$ref": "#/definitions/Xml"
+        }
+      },
+      "discriminator": "type"
+    },
+    "Scope": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "getoAuth2ScopeName": {
+          "type": "string"
+        },
+        "mashedUpAPI": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ScopeInformation": {
+      "type": "object",
+      "properties": {
+        "resourcePath": {
+          "type": "string"
+        },
+        "supportedOperations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ScopeResourceIndex": {
+      "type": "object",
+      "properties": {
+        "references": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScopeInformation"
+          }
+        },
+        "scope": {
+          "$ref": "#/definitions/Scope"
+        }
+      }
+    },
+    "SecurityScheme": {
+      "type": "object",
+      "properties": {
+        "bearerFormat": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "flows": {
+          "$ref": "#/definitions/OAuthFlows"
+        },
+        "get$ref": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "COOKIE",
+            "HEADER",
+            "QUERY"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "openIdConnectUrl": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "APIKEY",
+            "HTTP",
+            "OAUTH2",
+            "OPENIDCONNECT"
+          ]
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "SecuritySchemeDescriptor": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "queryParameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Server": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "An optional string describing the host designated by the URL",
+          "type": "string"
+        },
+        "url": {
+          "description": "A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in {brackets}",
+          "type": "string"
+        },
+        "variables": {
+          "description": "A map between a variable name and its value. The value is used for substitution in the server's URL template",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ServerVariable"
+          }
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ServerVariable": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "description": "An optional description for the server variable",
+          "type": "string"
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ServiceRegistryPublishGetResponse": {
+      "type": "object",
+      "properties": {
+        "publishInfo": {
+          "$ref": "#/definitions/PublishPayload"
+        }
+      }
+    },
+    "ServiceRegistryPublishInfo": {
+      "type": "object",
+      "properties": {
+        "gatewayEndpoints": {
+          "description": "List of API endpoints of the API. Each element contains an endpoint and the information about the publish status of that endpoint for the current service registry.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/Endpoints"
+          }
+        },
+        "name": {
+          "description": "Name of the service registry. This field is shown only in response and should not be sent by clients in requests. Only the serviceRegistryId is considered for uniquely identifying the registry.",
+          "type": "string"
+        },
+        "serviceRegistryId": {
+          "description": "Uddi key of the service registry created in API Gateway. This field is required.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Publish Status of the API for this service registry. This field is shown only in response and should not be sent by clients in requests. Possible values are NEW, PUBLISHED and SUSPENDED. NEW represents the API is not published to the service registry. PUBLISHED represents the API is published to the service registry. SUSPENDED represents the API is published to service registry, but is not currently active (during deactivation of API or shutdown of API Gateway).",
+          "type": "string",
+          "enum": [
+            "NEW",
+            "PUBLISHED",
+            "SUSPENDED"
+          ]
+        }
+      }
+    },
+    "ServiceRegistryPublishPutResponse": {
+      "type": "object",
+      "properties": {
+        "publishResponse": {
+          "$ref": "#/definitions/PublishResponse"
+        },
+        "publishResponses": {
+          "description": "This contains the service registry publish status for requests publishing more than one API to one or more service registries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublishResponse"
+          }
+        }
+      }
+    },
+    "ServiceRegistryPublishResponse": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Represents the status of the publish operation of the API to the service registry eg: Publish successful, Publish failed, etc",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "Provides the reason for the failure when the publish operation is not successful",
+          "type": "string"
+        },
+        "gatewayEndpoints": {
+          "description": "List of API endpoints of the API. Each element contains an endpoint and the information about the publish status of that endpoint for the current service registry.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/Endpoints"
+          }
+        },
+        "serviceRegistryId": {
+          "description": "Id i.e, UDDI key of the service registry",
+          "type": "string"
+        },
+        "serviceRegistryName": {
+          "description": "Name of the service registry",
+          "type": "string"
+        },
+        "status": {
+          "description": "Publish Status of the API for this service registry. Possible values are NEW, PUBLISHED and SUSPENDED. NEW represents the API is not published to the service registry. PUBLISHED represents the API is published to the service registry. SUSPENDED represents the API is published to service registry, but is not currently active (during deactivation of API or shutdown of API Gateway).",
+          "type": "string",
+          "enum": [
+            "NEW",
+            "PUBLISHED",
+            "SUSPENDED"
+          ]
+        },
+        "success": {
+          "description": "Represents whether the publish of API to the service registry is success. Possible values: true/false",
+          "type": "boolean"
+        }
+      }
+    },
+    "ServiceRegistryUnpublishPutResponse": {
+      "type": "object",
+      "properties": {
+        "unpublishResponse": {
+          "$ref": "#/definitions/UnpublishResponse"
+        },
+        "unpublishResponses": {
+          "description": "This contains the service registry unpublish status for requests unpublishing more than one API from one or more service registries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UnpublishResponse"
+          }
+        }
+      }
+    },
+    "ServiceRegistryUnpublishResponse": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Represents the status of the unpublish operation of the API from the service registry eg: Unpublish successful, Unpublish failed, etc",
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "Provides the reason for the failure when the unpublish operation is not successful",
+          "type": "string"
+        },
+        "serviceRegistryId": {
+          "description": "Id i.e, UDDI key of the service registry",
+          "type": "string"
+        },
+        "serviceRegistryName": {
+          "description": "Name of the service registry",
+          "type": "string"
+        },
+        "success": {
+          "description": "Represents whether the unpublish operation of API from the service registry is success. Possible values: true/false",
+          "type": "boolean"
+        }
+      }
+    },
+    "StringProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "string"
+            },
+            "enum": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "maxLength": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "minLength": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "pattern": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "StringSchema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Schema"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "StringSchemaModel": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Model"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "StringSchemaProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "Tag": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "A short description for the tag",
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocs"
+        },
+        "name": {
+          "description": "The name of the tag",
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Team": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Team id",
+          "type": "string"
+        },
+        "name": {
+          "description": "Team name",
+          "type": "string"
+        },
+        "source": {
+          "description": "The value is to identify whether the team is created from global team assignment or from user or by system",
+          "type": "string",
+          "enum": [
+            "USER",
+            "GLOBAL_ASSIGNMENT",
+            "SYSTEM"
+          ]
+        }
+      }
+    },
+    "UnpublishInfo": {
+      "type": "object",
+      "properties": {
+        "apiId": {
+          "description": "API id for the API to be unpublished. This field is required.",
+          "type": "string"
+        },
+        "serviceRegistryIds": {
+          "description": "List of ids of the service registries from which the API has to be unpublished. This field is required.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "UnpublishResponse": {
+      "type": "object",
+      "properties": {
+        "apiId": {
+          "description": "API id of the API published.",
+          "type": "string"
+        },
+        "apiName": {
+          "description": "API name of the API published.",
+          "type": "string"
+        },
+        "apiVersion": {
+          "description": "API version of the API published.",
+          "type": "string"
+        },
+        "serviceRegistryUnpublishResponses": {
+          "description": "Contains unpublish status of the API for each service registry in the request.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceRegistryUnpublishResponse"
+          }
+        }
+      }
+    },
+    "Version": {
+      "type": "object",
+      "properties": {
+        "apiId": {
+          "type": "string"
+        },
+        "versionNumber": {
+          "type": "string"
+        }
+      }
+    },
+    "WebsocketAPI": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/API"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "externalDocs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExternalDocs"
+              }
+            },
+            "messages": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MessageFrame"
+              }
+            },
+            "nativeUri": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "parameters": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/AbstractParameter"
+              }
+            },
+            "supportedSubProtocols": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Xml": {
+      "type": "object",
+      "properties": {
+        "attribute": {
+          "description": "Declares whether the property definition translates to an attribute instead of an element. Default value is false",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Replaces the name of the element/attribute used for the described schema property. When defined within items, it will affect the name of the individual XML elements within the list. When defined alongside type being array (outside the items), it will affect the wrapping element and only if wrapped is true. If wrapped is false, it will be ignored",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The URI of the namespace definition",
+          "type": "string"
+        },
+        "prefix": {
+          "description": "The prefix to be used for the name",
+          "type": "string"
+        },
+        "vendorExtensions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "wrapped": {
+          "description": "MAY be used only for an array definition. Signifies whether the array is wrapped (for example, \u003cbooks\u003e\u003cbook/\u003e\u003cbook/\u003e\u003c/books\u003e) or unwrapped (\u003cbook/\u003e\u003cbook/\u003e). Default value is false",
+          "type": "boolean"
+        }
+      }
+    },
+    "Xpath": {
+      "type": "object",
+      "properties": {
+        "namespaces": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Namespaces"
+          }
+        },
+        "xpath": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "Basic": {
+      "description": "API Gateway Administrator and API Gateway provider",
+      "type": "basic"
+    }
+  }
+}

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -2664,6 +2664,17 @@ func TestGenerateModels(t *testing.T) {
 					assert.False(t, fileExists(target, "restapi"))
 				},
 			},
+			"mangleNames": {
+				spec:   "../fixtures/bugs/2821/ServiceManagementBody.json",
+				target: "../fixtures/bugs/2821",
+				verify: func(t testing.TB, target string) {
+					target = filepath.Join(target, defaultModelsTarget)
+					require.True(t, fileExists(target, "schema.go"))
+					content, err := os.ReadFile(filepath.Join(target, "schema.go"))
+					require.NoError(t, err)
+					assert.Contains(t, string(content), "getDollarRefField string")
+				},
+			},
 		}
 		for k, cas := range cases {
 			name := k

--- a/generator/template_repo_test.go
+++ b/generator/template_repo_test.go
@@ -672,3 +672,25 @@ func TestGt0(t *testing.T) {
 	require.False(t, gt0(swag.Int64(0)))
 	require.False(t, gt0(nil))
 }
+
+func TestIssue2821(t *testing.T) {
+	tpl := `
+Pascalize={{ pascalize . }}
+Camelize={{ camelize . }}
+`
+
+	require.NoError(t,
+		templates.AddFile("functpl", tpl),
+	)
+
+	compiled, err := templates.Get("functpl")
+	require.NoError(t, err)
+
+	rendered := bytes.NewBuffer(nil)
+	require.NoError(t,
+		compiled.Execute(rendered, "get$ref"),
+	)
+
+	assert.Contains(t, rendered.String(), "Pascalize=GetDollarRef\n")
+	assert.Contains(t, rendered.String(), "Camelize=getDollarRef\n")
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/spec v0.20.13
 	github.com/go-openapi/strfmt v0.21.10
-	github.com/go-openapi/swag v0.22.6
+	github.com/go-openapi/swag v0.22.7
 	github.com/go-openapi/validate v0.22.6
 	github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013
 	github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/go-openapi/spec v0.20.13 h1:XJDIN+dLH6vqXgafnl5SUIMnzaChQ6QTo0/UPMbkI
 github.com/go-openapi/spec v0.20.13/go.mod h1:8EOhTpBoFiask8rrgwbLC3zmJfz4zsCUueRuPM6GNkw=
 github.com/go-openapi/strfmt v0.21.10 h1:JIsly3KXZB/Qf4UzvzJpg4OELH/0ASDQsyk//TTBDDk=
 github.com/go-openapi/strfmt v0.21.10/go.mod h1:vNDMwbilnl7xKiO/Ve/8H8Bb2JIInBnH+lqiw6QWgis=
-github.com/go-openapi/swag v0.22.6 h1:dnqg1XfHXL9aBxSbktBqFR5CxVyVI+7fYWhAf1JOeTw=
-github.com/go-openapi/swag v0.22.6/go.mod h1:Gl91UqO+btAM0plGGxHqJcQZ1ZTy6jbmridBTsDy8A0=
+github.com/go-openapi/swag v0.22.7 h1:JWrc1uc/P9cSomxfnsFSVWoE1FW6bNbrVPmpQYpCcR8=
+github.com/go-openapi/swag v0.22.7/go.mod h1:Gl91UqO+btAM0plGGxHqJcQZ1ZTy6jbmridBTsDy8A0=
 github.com/go-openapi/validate v0.22.6 h1:+NhuwcEYpWdO5Nm4bmvhGLW0rt1Fcc532Mu3wpypXfo=
 github.com/go-openapi/validate v0.22.6/go.mod h1:eaddXSqKeTg5XpSmj1dYyFTK/95n/XHwcOY+BMxKMyM=
 github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013 h1:l9rI6sNaZgNC0LnF3MiE+qTmyBA/tZAg1rtyrGbUMK0=


### PR DESCRIPTION
This PR fixes a special case when a "$" is inside a name AND we generate polymorphic types.

In this case the unexported name was not properly generated (included a blank space). More generally, swag mangling functions fail to properly handle this extra blank space. Fortunately, ToGoName wasn't affected and this is why this failure occurs in such rare circumstances.

* requires go-openapi/swag#78
* fixes #2821