### PR TITLE
fixed client generation test re sensitiveness to GOPATH

### DIFF
--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -224,8 +224,10 @@ func TestClient(t *testing.T) {
 	defer discardOutput()()
 
 	base := os.Getenv("GOPATH")
+	var importBase string
 	if base == "" {
 		base = "."
+		importBase = "github.com/go-swagger/go-swagger/generator/"
 	} else {
 		base = filepath.Join(base, "src")
 		err := os.MkdirAll(base, 0o755)
@@ -302,8 +304,8 @@ func TestClient(t *testing.T) {
 
 				// assert client import, with deconfliction
 				code := string(buf)
-				baseImport := `github.com/go-swagger/go-swagger/generator/swagger_nogo\d+/packages_mangling/client`
-				assertImports(t, baseImport, code)
+				importRegexp := importBase + `swagger_nogo\d+/packages_mangling/client`
+				assertImports(t, importRegexp, code)
 
 				assertInCode(t, `cli.Strfmt = strfmtops.New(transport, formats)`, code)
 				assertInCode(t, `cli.API = apiops.New(transport, formats)`, code)


### PR DESCRIPTION
Testing client codegen depends somehow on GOPATH.
One test wants to assert how imported packages are generated.

Currently, this works just fine when GOPATH is unset, but on some
older environments, this environment might be set.

This PR makes tests work in both situations (generation is carried out
in different target locations).

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>