### PR TITLE
feat(validation): added --rooted-error-path to generate models

### DIFF
--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -29,6 +29,7 @@ type modelOptions struct {
 	KeepSpecOrder              bool     `long:"keep-spec-order" description:"keep schema properties order identical to spec file"`
 	AllDefinitions             bool     `long:"all-definitions" description:"generate all model definitions regardless of usage in operations" hidden:"deprecated"`
 	StructTags                 []string `long:"struct-tags" description:"the struct tags to generate, repeat for multiple (defaults to json)"`
+	RootedErrorPath            bool     `long:"rooted-error-path" description:"extends validation errors with the type name instead of an empty path, in the case of arrays and maps"`
 }
 
 func (mo modelOptions) apply(opts *generator.GenOpts) {
@@ -39,6 +40,7 @@ func (mo modelOptions) apply(opts *generator.GenOpts) {
 	opts.PropertiesSpecOrder = mo.KeepSpecOrder
 	opts.IgnoreOperations = mo.AllDefinitions
 	opts.StructTags = mo.StructTags
+	opts.WantsRootedErrorPath = mo.RootedErrorPath
 }
 
 // WithModels adds the model options group.

--- a/docs/generate/model.md
+++ b/docs/generate/model.md
@@ -40,6 +40,7 @@ Help Options:
           --strict-additional-properties                                          disallow extra properties when additionalProperties is set to false
           --keep-spec-order                                                       keep schema properties order identical to spec file
           --struct-tags=                                                          the struct tags to generate, repeat for multiple (defaults to json)
+          --rooted-error-path                                                     extends validation errors with the type name instead of an empty path, in the case of arrays and maps
 ```
 
 Schema generation rules are detailed [here](../use/model.md).

--- a/fixtures/bugs/2597/2597.yaml
+++ b/fixtures/bugs/2597/2597.yaml
@@ -1,0 +1,81 @@
+swagger: "2.0"
+info:
+  description: 'repro issue #2597'
+  title: minitems
+  version: "0.0.0"
+paths:
+  /v1/blah:
+    patch:
+      produces:
+        - application/json
+      parameters:
+        - name: newArray
+          in: body
+          schema:
+            $ref: '#/definitions/BlahArray'
+      responses:
+        200:
+          description: ok
+          schema:
+    post:
+      produces:
+        - application/json
+      parameters:
+        - name: newArray
+          in: body
+          schema:
+            $ref: '#/definitions/BlahStruct'
+      responses:
+        200:
+          description: ok
+          schema:
+
+definitions:
+  BlahArray:
+    description: The array of blah numbers
+    type: array
+    items:
+      type: integer
+    minItems: 1
+    uniqueItems: true
+  BlahComplexArray:
+    description: The array of blah numbers
+    type: array
+    items:
+      type: object
+      properties:
+        a:
+          type: string
+    minItems: 1
+  BlahStruct:
+    description: The struct containing an array of blah numbers
+    type: object
+    required: [b]
+    properties:
+      list:
+        type: array
+        items:
+          type: integer
+        minItems: 1
+      unique:
+        type: array
+        items:
+          type: integer
+        uniqueItems: true
+      b:
+        type: string
+        maxLength: 10
+  BlahMap:
+    description: this is a map[string]string
+    type: object
+    additionalProperties:
+      type: string
+    maxProperties: 10
+  BlahComplexMap:
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        x:
+          type: string
+    maxProperties: 12

--- a/generator/model.go
+++ b/generator/model.go
@@ -254,6 +254,7 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 		StrictAdditionalProperties: opts.StrictAdditionalProperties,
 		WithXML:                    opts.WithXML,
 		StructTags:                 opts.StructTags,
+		WantsRootedErrorPath:       opts.WantsRootedErrorPath,
 	}
 	if err := pg.makeGenSchema(); err != nil {
 		return nil, fmt.Errorf("could not generate schema for %s: %w", name, err)
@@ -446,6 +447,7 @@ type schemaGenContext struct {
 	IncludeValidator           bool
 	IncludeModel               bool
 	StrictAdditionalProperties bool
+	WantsRootedErrorPath       bool
 	WithXML                    bool
 	Index                      int
 
@@ -1980,6 +1982,7 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	sg.GenSchema.Default = sg.Schema.Default
 	sg.GenSchema.StructTags = sg.StructTags
 	sg.GenSchema.ExtraImports = make(map[string]string)
+	sg.GenSchema.WantsRootedErrorPath = sg.WantsRootedErrorPath
 
 	var err error
 	returns, err := sg.shortCircuitNamedRef()

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -342,6 +342,7 @@ type GenOptsCommon struct {
 	AllowEnumCI            bool
 	StrictResponders       bool
 	AcceptDefinitionsOnly  bool
+	WantsRootedErrorPath   bool
 
 	templates *Repository // a shallow clone of the global template repository
 }

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -20,6 +20,7 @@ import (
 type GenCommon struct {
 	Copyright        string
 	TargetImportPath string
+	RootedErrorPath  bool // wants array and map types to have a path corresponding to their type in reported errors
 }
 
 // GenDefinition contains all the properties to generate a
@@ -96,6 +97,7 @@ type GenSchema struct {
 	StructTags                 []string
 	ExtraImports               map[string]string // non-standard imports detected when using external types
 	ExternalDocs               *spec.ExternalDocumentation
+	WantsRootedErrorPath       bool
 }
 
 func (g GenSchema) renderMarshalTag() string {

--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -1,6 +1,6 @@
 {{ define "primitivefieldcontextvalidator" }}
   {{ if .ReadOnly }}
-    if err := validate.ReadOnly(ctx, {{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil{
+    if err := validate.ReadOnly(ctx, {{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil{
       return err
     }
   {{ end }}
@@ -8,25 +8,25 @@
 {{ define "primitivefieldvalidator" }}
   {{ if .Required }}
     {{- if and (eq .GoType "string") (not .IsNullable) }}
-  if err := validate.RequiredString({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsAliased }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if .IsAliased }}){{ end }}); err != nil {
+  if err := validate.RequiredString({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsAliased }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if .IsAliased }}){{ end }}); err != nil {
     {{- else }}
-  if err := validate.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+  if err := validate.Required({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
     {{- end }}
     return err
   }
   {{- end }}
   {{ if .MinLength }}
-    if err := validate.MinLength({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ToString }}, {{.MinLength }}); err != nil {
+    if err := validate.MinLength({{ path . }}, {{ printf "%q" .Location }}, {{ .ToString }}, {{.MinLength }}); err != nil {
     return err
   }
   {{- end }}
   {{ if .MaxLength }}
-  if err := validate.MaxLength({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ToString }}, {{.MaxLength }}); err != nil {
+  if err := validate.MaxLength({{ path . }}, {{ printf "%q" .Location }}, {{ .ToString }}, {{.MaxLength }}); err != nil {
     return err
   }
   {{ end }}
   {{ if .Pattern }}
-  if err := validate.Pattern({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ToString }}, `{{ escapeBackticks .Pattern }}`); err != nil {
+  if err := validate.Pattern({{ path . }}, {{ printf "%q" .Location }}, {{ .ToString }}, `{{ escapeBackticks .Pattern }}`); err != nil {
     return err
   }
   {{- end }}
@@ -41,7 +41,7 @@
   {{ end }}
   {{ if .Enum }}
   // value enum
-  if err := {{.ReceiverName }}.validate{{ pascalize .Name }}{{ .Suffix }}Enum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}); err != nil {
+  if err := {{.ReceiverName }}.validate{{ pascalize .Name }}{{ .Suffix }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}); err != nil {
     return err
   }
   {{- end }}
@@ -52,7 +52,7 @@
 
 {{ define "slicecontextvalidator" }}
   {{ if .ReadOnly }}
-    if err := validate.ReadOnly(ctx, {{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil{
+    if err := validate.ReadOnly(ctx, {{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil{
       return err
     }
   {{ end }}
@@ -71,9 +71,9 @@
       {{- end }}
       if err := {{.ValueExpression }}.ContextValidate(ctx, formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
-          return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+          return ve.ValidateName({{ path . }})
         } else if ce, ok := err.(*errors.CompositeError); ok {
-          return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+          return ce.ValidateName({{ path . }})
         }
         return err
       }
@@ -86,7 +86,7 @@
 
 {{define "slicevalidator" }}
   {{ if .Required }}
-    if err := validate.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ValueExpression }}); err != nil {
+    if err := validate.Required({{ path . }}, {{ printf "%q" .Location }}, {{ .ValueExpression }}); err != nil {
       return err
     }
   {{ end }}
@@ -94,23 +94,23 @@
     {{ .IndexVar }}{{ pascalize .Name }}Size := int64(len({{.ValueExpression }}))
   {{ end }}
   {{ if .MinItems }}
-    if err := validate.MinItems({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .IndexVar }}{{ pascalize .Name }}Size, {{.MinItems }}); err != nil {
+    if err := validate.MinItems({{ path . }}, {{ printf "%q" .Location }}, {{ .IndexVar }}{{ pascalize .Name }}Size, {{.MinItems }}); err != nil {
       return err
     }
   {{ end }}
   {{ if .MaxItems }}
-    if err := validate.MaxItems({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .IndexVar }}{{ pascalize .Name }}Size, {{.MaxItems }}); err != nil {
+    if err := validate.MaxItems({{ path . }}, {{ printf "%q" .Location }}, {{ .IndexVar }}{{ pascalize .Name }}Size, {{.MaxItems }}); err != nil {
       return err
     }
   {{ end }}
   {{ if .UniqueItems }}
-    if err := validate.UniqueItems({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
+    if err := validate.UniqueItems({{ path . }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
       return err
     }
   {{ end }}
   {{ if .Enum }}
     // for slice
-    if err := {{.ReceiverName }}.validate{{ pascalize .Name }}Enum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
+    if err := {{.ReceiverName }}.validate{{ pascalize .Name }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
       return err
     }
   {{ end }}
@@ -138,9 +138,9 @@
       {{- end }}
       if err := {{.ValueExpression }}.Validate(formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
-          return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+          return ve.ValidateName({{ path . }})
         } else if ce, ok := err.(*errors.CompositeError); ok {
-          return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+          return ce.ValidateName({{ path . }})
         }
         return err
       }
@@ -154,10 +154,10 @@
   {{- if and .Required }}
     {{- if or .IsNullable .IsInterface }}
     if {{ .ReceiverName }}.{{ pascalize .Name }} == nil {
-      return errors.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, nil)
+      return errors.Required({{ path . }}, {{ printf "%q" .Location }}, nil)
     }
     {{- else }}
-    if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{ .ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+    if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{ .ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
       return err
     }
     {{- end }}
@@ -213,7 +213,7 @@
           {{ template "mapcontextvalidator" . }}
         {{- else if and .IsMap .IsInterface }}
           {{ if .Enum }}
-      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
+      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
         return err
       }
           {{- end }}
@@ -278,10 +278,10 @@
   {{- if and .Required }}
     {{- if or .IsNullable .IsInterface }}
     if {{ .ReceiverName }}.{{ pascalize .Name }} == nil {
-      return errors.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, nil)
+      return errors.Required({{ path . }}, {{ printf "%q" .Location }}, nil)
     }
     {{- else }}
-    if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{ .ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+    if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{ .ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
       return err
     }
     {{- end }}
@@ -300,7 +300,7 @@
         continue
       }
         {{- else if and (.Required) (not .IsArray) }}{{/* Required slice is processed below */}}
-      if err := validate.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
+      if err := validate.Required({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
         return err
       }
         {{- end }}
@@ -313,9 +313,9 @@
               {{- end }}
           if err := val.Validate(formats); err != nil {
               if ve, ok := err.(*errors.Validation); ok {
-                  return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+                  return ve.ValidateName({{ path . }})
               } else if ce, ok := err.(*errors.CompositeError); ok {
-                  return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+                  return ce.ValidateName({{ path . }})
               }
               return err
           }
@@ -342,7 +342,7 @@
           {{- end }}
         {{- else if and .IsCustomFormatter (or .HasValidations .Required) }}{{/* custom format not captured as primitive */}}
           {{- if .Required }}
-      if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+      if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
         return err
       }
           {{- end }}
@@ -354,13 +354,13 @@
         {{- else if and .IsMap (not .IsInterface) }}
           {{ template "mapvalidator" . }}
           {{ if .Enum }}
-      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
+      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
         return err
       }
           {{- end }}
         {{- else if and .IsMap .IsInterface }}
           {{ if .Enum }}
-      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
+      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
         return err
       }
           {{- end }}
@@ -372,9 +372,9 @@
             {{- end }}
           if err := val.Validate(formats); err != nil {
               if ve, ok := err.(*errors.Validation); ok {
-                  return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+                  return ve.ValidateName({{ path . }})
               } else if ce, ok := err.(*errors.CompositeError); ok {
-                  return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+                  return ce.ValidateName({{ path . }})
               }
               return err
           }
@@ -402,7 +402,7 @@
     {{ end }}
     {{ if .Enum }}
     // from map
-    if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}Enum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ValueExpression }}); err != nil {
+    if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{ .ValueExpression }}); err != nil {
       return err
     }
     {{ end }}
@@ -462,9 +462,9 @@
       {{ end }}
       if err := {{.ValueExpression }}.ContextValidate(ctx, formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
-          return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+          return ve.ValidateName({{ path . }})
         } else if ce, ok := err.(*errors.CompositeError); ok {
-          return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+          return ce.ValidateName({{ path . }})
         }
         return err
       }
@@ -497,7 +497,7 @@
 
     // short circuits minProperties > 0
     if {{ .ReceiverName }} == nil {
-      return errors.TooFewProperties({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ .MinProperties }})
+      return errors.TooFewProperties({{ path . }}, {{ printf "%q" .Location }}, {{ .MinProperties }})
     }
         {{- end }}
       {{- end }}
@@ -517,13 +517,13 @@
     {{ if .MinProperties }}
     // minProperties: {{ .MinProperties }}
     if nprops < {{ .MinProperties }} {
-      return errors.TooFewProperties({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ .MinProperties }})
+      return errors.TooFewProperties({{ path . }}, {{ printf "%q" .Location }}, {{ .MinProperties }})
     }
     {{- end }}
     {{ if .MaxProperties }}
     // maxProperties: {{ .MaxProperties }}
     if nprops > {{ .MaxProperties }} {
-      return errors.TooManyProperties({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ .MaxProperties }})
+      return errors.TooManyProperties({{ path . }}, {{ printf "%q" .Location }}, {{ .MaxProperties }})
     }
     {{- end }}
   {{- end }}
@@ -548,7 +548,7 @@
   */}}
   {{- if not .IsAnonymous }}
     {{- if and .Required (or .IsNullable .IsBaseType .IsMap) }}
-      if err := validate.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
+      if err := validate.Required({{ path . }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
         return err
       }
       {{- if and (not .Required) .IsBaseType }}
@@ -563,9 +563,9 @@
       {{- end }}
       if err := {{.ValueExpression }}.Validate(formats); err != nil {
         if ve, ok := err.(*errors.Validation); ok {
-          return ve.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+          return ve.ValidateName({{ path . }})
         } else if ce, ok := err.(*errors.CompositeError); ok {
-          return ce.ValidateName({{ if .Path }}{{ .Path }}{{ else }}""{{ end }})
+          return ce.ValidateName({{ path . }})
         }
         return err
       }
@@ -602,7 +602,7 @@
     // at https://github.com/go-swagger/go-swagger/issues
     {{- if .ReadOnly }}
 
-  if err := validate.ReadOnly{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+  if err := validate.ReadOnly{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
     return err
   }
     {{- end }}
@@ -625,7 +625,7 @@
   {{- if .IsPrimitive }}
     {{- if .IsAliased }}
       {{- if and .Required (not .IsAnonymous) }}
-  if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+  if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
     return err
   }
       {{- end }}
@@ -635,7 +635,7 @@
     {{- end }}
   {{- else if and .IsCustomFormatter (or .HasValidations .Required) }}{{/* custom format not captured as primitive */}}
     {{- if .Required }}
-  if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+  if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
     return err
   }
     {{- end }}
@@ -651,10 +651,10 @@
     {{- if and .IsAdditionalProperties .Required (not .IsAliased) }}
       {{- if or .IsNullable .IsInterface }}
       if {{ .ValueExpression }} == nil {
-        return errors.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ValueExpression }})
+        return errors.Required({{ path . }}, {{ printf "%q" .Location }}, {{ .ValueExpression }})
       }
       {{- else }}
-      if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+      if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
         return err
       }
       {{- end }}
@@ -663,10 +663,10 @@
   {{- else if and .IsExternal .Required }}
     {{- if or .IsNullable .IsInterface }}
       if {{ .ValueExpression }} == nil {
-        return errors.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ValueExpression }})
+        return errors.Required({{ path . }}, {{ printf "%q" .Location }}, {{ .ValueExpression }})
       }
     {{- else }}
-      if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+      if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
         return err
       }
     {{- end }}
@@ -697,7 +697,7 @@
     {{ template "primitivefieldvalidator" . }}
   {{- else if and .IsCustomFormatter (or .HasValidations .Required) }}{{/* custom format not captured as primitive */}}
     {{- if .Required }}
-  if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
+  if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{ if not (or .IsAnonymous .IsNullable) }}{{ .GoType }}({{ end }}{{.ValueExpression }}{{ if not (or .IsAnonymous .IsNullable) }}){{ end }}); err != nil {
     return err
   }
     {{- end }}
@@ -1034,11 +1034,11 @@ func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else i
         {{- if and $.IsTuple .IsMap .Required }}
           {{- if .IsInterface }}
   if {{ .ValueExpression }} == nil {
-    return errors.Required({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ValueExpression }})
+    return errors.Required({{ path . }}, {{ printf "%q" .Location }}, {{ .ValueExpression }})
   }
           {{- else }}
   if err := validate.Required{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}(
-            {{- if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }},
+            {{ path . }}, {{ printf "%q" .Location }},
             {{- if and (eq .GoType "string") (not (or .IsAnonymous .IsNullable)) }}{{ .GoType }}({{ end }}
             {{- .ValueExpression }}
             {{- if and (eq .GoType "string") (not (or .IsAnonymous .IsNullable)) }}){{ end }}); err != nil {

--- a/generator/templates/validation/customformat.gotmpl
+++ b/generator/templates/validation/customformat.gotmpl
@@ -1,3 +1,3 @@
-if err := validate.FormatOf({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ printf "%q" .SwaggerFormat }}, {{ .ToString }}, formats); err != nil {
+if err := validate.FormatOf({{ path . }}, {{ printf "%q" .Location }}, {{ printf "%q" .SwaggerFormat }}, {{ .ToString }}, formats); err != nil {
   return err
 }

--- a/generator/templates/validation/maximum.gotmpl
+++ b/generator/templates/validation/maximum.gotmpl
@@ -1,21 +1,21 @@
 {{- if or (hasPrefix .UnderlyingType "int") }}
   {{- if and (hasPrefix .UnderlyingType "int64") (not .IsAliased) }}
-if err := validate.MaximumInt({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
+if err := validate.MaximumInt({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
   {{- else }}
-if err := validate.MaximumInt({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, int64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
+if err := validate.MaximumInt({{ path . }}, {{ printf "%q" .Location }}, int64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
   {{- end }}
 {{- else }}
   {{- if hasPrefix .UnderlyingType "uint" }}
     {{- if and (hasPrefix .UnderlyingType "uint64") (not .IsAliased) }}
-if err := validate.MaximumUint({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
+if err := validate.MaximumUint({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
     {{- else }}
-if err := validate.MaximumUint({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, uint64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
+if err := validate.MaximumUint({{ path . }}, {{ printf "%q" .Location }}, uint64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
     {{- end }}
   {{- else }}
     {{- if and (eq .UnderlyingType "float64") (not .IsAliased) }}
-if err := validate.Maximum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
+if err := validate.Maximum({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
     {{- else }}
-if err := validate.Maximum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, float64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
+if err := validate.Maximum({{ path . }}, {{ printf "%q" .Location }}, float64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Maximum }}, {{.ExclusiveMaximum }}); err != nil {
     {{- end }}
   {{- end }}
 {{- end }}

--- a/generator/templates/validation/minimum.gotmpl
+++ b/generator/templates/validation/minimum.gotmpl
@@ -1,21 +1,21 @@
 {{- if hasPrefix .UnderlyingType "int" }}
   {{- if and (hasPrefix .UnderlyingType "int64") (not .IsAliased) }}
-if err := validate.MinimumInt({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
+if err := validate.MinimumInt({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
   {{- else }}
-if err := validate.MinimumInt({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, int64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
+if err := validate.MinimumInt({{ path . }}, {{ printf "%q" .Location }}, int64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
   {{- end }}
 {{- else }}
   {{- if hasPrefix .UnderlyingType "uint" }}
     {{- if and (hasPrefix .UnderlyingType "uint64") (not .IsAliased) }}
-if err := validate.MinimumUint({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
+if err := validate.MinimumUint({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
     {{- else }}
-if err := validate.MinimumUint({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, uint64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
+if err := validate.MinimumUint({{ path . }}, {{ printf "%q" .Location }}, uint64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
     {{- end }}
   {{- else }}
     {{- if and (eq .UnderlyingType "float64") (not .IsAliased) }}
-if err := validate.Minimum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
+if err := validate.Minimum({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
     {{- else }}
-if err := validate.Minimum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, float64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
+if err := validate.Minimum({{ path . }}, {{ printf "%q" .Location }}, float64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.Minimum }}, {{.ExclusiveMinimum }}); err != nil {
     {{- end }}
   {{- end }}
 {{- end }}

--- a/generator/templates/validation/multipleOf.gotmpl
+++ b/generator/templates/validation/multipleOf.gotmpl
@@ -1,21 +1,21 @@
 {{- if and (hasPrefix .UnderlyingType "int") (isInteger .MultipleOf) }}{{/* if the type is an integer, but the multiple factor is not, fall back to the float64 version of the validator */}}
   {{- if and (hasPrefix .UnderlyingType "int64") (not .IsAliased) }}
-if err := validate.MultipleOfInt({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.MultipleOf }}); err != nil {
+if err := validate.MultipleOfInt({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.MultipleOf }}); err != nil {
   {{- else }}
-if err := validate.MultipleOfInt({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, int64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.MultipleOf }}); err != nil {
+if err := validate.MultipleOfInt({{ path . }}, {{ printf "%q" .Location }}, int64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.MultipleOf }}); err != nil {
   {{- end }}
 {{- else }}
   {{- if and (hasPrefix .UnderlyingType "uint") (isInteger .MultipleOf) }}
     {{- if and (hasPrefix .UnderlyingType "uint64") (not .IsAliased) }}
-if err := validate.MultipleOfUint({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.MultipleOf }}); err != nil {
+if err := validate.MultipleOfUint({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.MultipleOf }}); err != nil {
     {{- else }}
-if err := validate.MultipleOfUint({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, uint64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.MultipleOf }}); err != nil {
+if err := validate.MultipleOfUint({{ path . }}, {{ printf "%q" .Location }}, uint64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.MultipleOf }}); err != nil {
     {{- end }}
   {{- else }}
     {{- if and (eq .UnderlyingType "float64") (not .IsAliased) }}
-if err := validate.MultipleOf({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.MultipleOf }}); err != nil {
+if err := validate.MultipleOf({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}, {{.MultipleOf }}); err != nil {
     {{- else }}
-if err := validate.MultipleOf({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, float64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.MultipleOf }}); err != nil {
+if err := validate.MultipleOf({{ path . }}, {{ printf "%q" .Location }}, float64({{ if .IsNullable }}*{{ end }}{{.ValueExpression }}), {{.MultipleOf }}); err != nil {
     {{- end }}
   {{- end }}
 {{- end }}

--- a/generator/templates/validation/primitive.gotmpl
+++ b/generator/templates/validation/primitive.gotmpl
@@ -1,15 +1,15 @@
 {{if .MinLength}}
-if err := validate.MinLength({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ .ToString }}, {{.MinLength}}); err != nil {
+if err := validate.MinLength({{ path . }}, {{ printf "%q" .Location }}, {{ .ToString }}, {{.MinLength}}); err != nil {
   return err
 }
 {{end}}
 {{if .MaxLength}}
-if err := validate.MaxLength({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ .ToString }}, {{.MaxLength}}); err != nil {
+if err := validate.MaxLength({{ path . }}, {{ printf "%q" .Location }}, {{ .ToString }}, {{.MaxLength}}); err != nil {
   return err
 }
 {{end}}
 {{if .Pattern}}
-if err := validate.Pattern({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ .ToString }}, `{{escapeBackticks .Pattern}}`); err != nil {
+if err := validate.Pattern({{ path . }}, {{ printf "%q" .Location }}, {{ .ToString }}, `{{escapeBackticks .Pattern}}`); err != nil {
   return err
 }
 {{end}}
@@ -23,7 +23,7 @@ if err := validate.Pattern({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf
   {{ template "validationMultipleOf" . }}
 {{end}}
 {{if .Enum}}
-if err := validate.EnumCase({{ if .Path }}{{ .Path }}{{else}}""{{end}}, {{ printf "%q" .Location }}, {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) .IsNullable }}*{{ end }}{{.ValueExpression}}{{ if .IsCustomFormatter }}.String(){{ end }}, {{ printf "%#v" .Enum}}, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+if err := validate.EnumCase({{ path . }}, {{ printf "%q" .Location }}, {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) .IsNullable }}*{{ end }}{{.ValueExpression}}{{ if .IsCustomFormatter }}.String(){{ end }}, {{ printf "%#v" .Enum}}, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
   return err
 }
 {{end}}

--- a/generator/utils_test.go
+++ b/generator/utils_test.go
@@ -34,6 +34,10 @@ func assertNotInCode(t testing.TB, expr, code string) bool {
 	return assert.NotRegexp(t, reqm(expr), code)
 }
 
+func assertRegexpNotInCode(t testing.TB, expr, code string) bool {
+	return assert.NotRegexp(t, reqOri(expr), code)
+}
+
 // Unused
 // func assertRegexpNotInCode(t testing.TB, expr, code string) bool {
 // 	return assert.NotRegexp(t, reqOri(expr), code)


### PR DESCRIPTION
This new option to generate models allows to report more context
in validation errors for arrays and maps.

Validation errors used for those types used to be reported with an
empty path (e.g. " in body should have at least 1 items").

With this option enabled, generated models for arrays and maps
report the type (e.g. "[myArray] in body should have at least 1 items").

This flag acts as a feature flag: it is disabled by default with no
alteration of the existing generated code.

* fixes https://github.com/go-swagger/go-swagger/issues/2597

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>