### PR TITLE
chore(test): reduced the verbosity of tests

### DIFF
--- a/generator/build_test.go
+++ b/generator/build_test.go
@@ -1,18 +1,15 @@
 package generator_test
 
 import (
-	"io"
-	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-swagger/go-swagger/cmd/swagger/commands/generate"
+	"github.com/go-swagger/go-swagger/generator/internal/gentest"
 )
 
 const (
@@ -30,7 +27,7 @@ func TestGenerateAndBuild(t *testing.T) {
 	//
 	// NOTE: test cases are randomized (map)
 	t.Parallel()
-	defer discardOutput()()
+	defer gentest.DiscardOutput()()
 
 	cases := map[string]struct {
 		spec string
@@ -59,23 +56,23 @@ func TestGenerateAndBuild(t *testing.T) {
 	}
 
 	t.Run("build client", func(t *testing.T) {
-		for name, cas := range cases {
-			cas := cas
+		for name, toPin := range cases {
+			cas := toPin
+
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 				spec := filepath.FromSlash(cas.spec)
 
 				generated, err := os.MkdirTemp(filepath.Dir(spec), "generated")
 				require.NoErrorf(t, err, "TempDir()=%s", generated)
-				defer func() { _ = os.RemoveAll(generated) }()
+				t.Cleanup(func() { _ = os.RemoveAll(generated) })
 
 				require.NoErrorf(t, newTestClient(spec, generated).Execute(nil), "Execute()=%s", err)
 
 				packages := filepath.Join(generated, "...")
 
-				goExecInDir(t, "", "get")
-
-				goExecInDir(t, "", "build", packages)
+				t.Run("should go get imports", gentest.GoExecInDir("", "get"))
+				t.Run("should build client", gentest.GoExecInDir("", "build", packages))
 			})
 		}
 	})
@@ -91,35 +88,4 @@ func newTestClient(input, output string) *generate.Client {
 	c.Models.ModelPackage = defaultModelPackage
 	c.ClientPackage = defaultClientPackage
 	return c
-}
-
-func goExecInDir(t testing.TB, target string, args ...string) {
-	cmd := exec.Command("go", args...)
-	cmd.Dir = target
-	p, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "unexpected error: %s: %v\n%s", cmd.String(), err, string(p))
-}
-
-var lockLogger sync.Mutex
-
-func discardOutput(w ...io.Writer) func() {
-	var out io.Writer
-	if len(w) == 0 {
-		out = io.Discard
-	} else {
-		out = w[0]
-	}
-
-	lockLogger.Lock()
-	defer lockLogger.Unlock()
-
-	original := log.Writer()
-	// discards log output then sends a function to set it back to its original value
-	log.SetOutput(out)
-
-	return func() {
-		lockLogger.Lock()
-		log.SetOutput(original)
-		lockLogger.Unlock()
-	}
 }

--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -15,7 +15,6 @@
 package generator
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -236,10 +235,9 @@ func TestClient(t *testing.T) {
 	targetdir, err := os.MkdirTemp(base, "swagger_nogo")
 	require.NoError(t, err, "Failed to create a test target directory: %v", err)
 
-	defer func() {
+	t.Cleanup(func() {
 		_ = os.RemoveAll(targetdir)
-		log.SetOutput(os.Stdout)
-	}()
+	})
 
 	tests := []struct {
 		name      string

--- a/generator/debug_test.go
+++ b/generator/debug_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// mutex for -race because this test alters a global
 var logMutex = &sync.Mutex{}
 
-func TestDebug(t *testing.T) {
-	// test debugLog()
+func TestDebugLog(t *testing.T) {
 	tmpFile, _ := os.CreateTemp("", "debug-test")
 	tmpName := tmpFile.Name()
 	logMutex.Lock()
@@ -80,7 +80,7 @@ func TestDebug(t *testing.T) {
 	assert.Contains(t, string(buf2), `"content"`)
 }
 
-func TestDebugAsJSON(t *testing.T) {
+func TestDebugLogAsJSON(t *testing.T) {
 	t.SkipNow()
 
 	var body struct {

--- a/generator/discriminators_test.go
+++ b/generator/discriminators_test.go
@@ -49,6 +49,8 @@ func TestGenerateModel_DiscriminatorSlices(t *testing.T) {
 }
 
 func TestGenerateModel_Discriminators(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, e := loads.Spec("../fixtures/codegen/todolist.discriminators.yml")
 	require.NoError(t, e)
 
@@ -141,6 +143,8 @@ func TestGenerateModel_Discriminators(t *testing.T) {
 }
 
 func TestGenerateModel_UsesDiscriminator(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/codegen/todolist.discriminators.yml")
 	require.NoError(t, err)
 
@@ -168,6 +172,8 @@ func TestGenerateModel_UsesDiscriminator(t *testing.T) {
 }
 
 func TestGenerateClient_OKResponseWithDiscriminator(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/codegen/todolist.discriminators.yml")
 	require.NoError(t, err)
 
@@ -207,6 +213,8 @@ func TestGenerateClient_OKResponseWithDiscriminator(t *testing.T) {
 }
 
 func TestGenerateServer_Parameters(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/codegen/todolist.discriminators.yml")
 	require.NoError(t, err)
 
@@ -245,6 +253,8 @@ func TestGenerateServer_Parameters(t *testing.T) {
 }
 
 func TestGenerateModel_Discriminator_Billforward(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/codegen/billforward.discriminators.yml")
 	require.NoError(t, err)
 
@@ -268,6 +278,8 @@ func TestGenerateModel_Discriminator_Billforward(t *testing.T) {
 }
 
 func TestGenerateModel_Bitbucket_Repository(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/codegen/bitbucket.json")
 	require.NoError(t, err)
 
@@ -300,6 +312,8 @@ func TestGenerateModel_Bitbucket_Repository(t *testing.T) {
 }
 
 func TestGenerateModel_Bitbucket_WebhookSubscription(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/codegen/bitbucket.json")
 	require.NoError(t, err)
 
@@ -323,6 +337,8 @@ func TestGenerateModel_Bitbucket_WebhookSubscription(t *testing.T) {
 }
 
 func TestGenerateModel_Issue319(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/bugs/319/swagger.yml")
 	require.NoError(t, err)
 
@@ -346,6 +362,8 @@ func TestGenerateModel_Issue319(t *testing.T) {
 }
 
 func TestGenerateModel_Issue541(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/bugs/541/swagger.json")
 	require.NoError(t, err)
 
@@ -370,6 +388,8 @@ func TestGenerateModel_Issue541(t *testing.T) {
 }
 
 func TestGenerateModel_Issue436(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/bugs/436/swagger.yml")
 	require.NoError(t, err)
 
@@ -397,6 +417,8 @@ func TestGenerateModel_Issue436(t *testing.T) {
 }
 
 func TestGenerateModel_Issue740(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/bugs/740/swagger.yml")
 	require.NoError(t, err)
 
@@ -421,6 +443,8 @@ func TestGenerateModel_Issue740(t *testing.T) {
 }
 
 func TestGenerateModel_Issue743(t *testing.T) {
+	defer discardOutput()()
+
 	specDoc, err := loads.Spec("../fixtures/bugs/743/swagger.yml")
 	require.NoError(t, err)
 

--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -161,7 +161,7 @@ func (f generateFixture) warnFailed(t testing.TB) func() {
 	}
 }
 
-func generateFixtures(t testing.TB) map[string]generateFixture {
+func generateFixtures(_ testing.TB) map[string]generateFixture {
 	return map[string]generateFixture{
 		"issue 1943": {
 			spec:   "../fixtures/bugs/1943/fixture-1943.yaml",

--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -2,8 +2,8 @@ package generator
 
 import (
 	"bytes"
+	"fmt"
 	"io"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -32,11 +32,8 @@ func TestGenerateAndTest(t *testing.T) {
 			t.Run(thisName, func(t *testing.T) {
 				t.Parallel()
 
-				log.SetOutput(io.Discard)
 				defer thisCas.warnFailed(t)
-
-				// default opts
-				opts := testGenOpts()
+				opts := testGenOpts() // default opts
 
 				// create directory layout, defer clean
 				defer thisCas.prepareTarget(t, thisName, "server_test", root, opts)()
@@ -46,19 +43,19 @@ func TestGenerateAndTest(t *testing.T) {
 					thisCas.prepare(t, opts)
 				}
 
-				t.Logf("generating test server at: %s, from %s", opts.Target, opts.Spec)
+				t.Run(fmt.Sprintf("generating test server from %s", opts.Spec), func(t *testing.T) {
+					err := GenerateServer("", nil, nil, opts)
+					if thisCas.wantError {
+						require.Errorf(t, err, "expected an error for server build fixture: %s", opts.Spec)
+					} else {
+						require.NoError(t, err, "unexpected error for server build fixture: %s", opts.Spec)
+					}
 
-				err := GenerateServer("", nil, nil, opts)
-				if thisCas.wantError {
-					require.Errorf(t, err, "expected an error for server build fixture: %s", opts.Spec)
-				} else {
-					require.NoError(t, err, "unexpected error for server build fixture: %s", opts.Spec)
-				}
-
-				// verify
-				if thisCas.verify != nil {
-					thisCas.verify(t, opts.Target)
-				}
+					// verify
+					if thisCas.verify != nil {
+						thisCas.verify(t, opts.Target)
+					}
+				})
 
 				// fixture-specific clean
 				if thisCas.clean != nil {
@@ -76,11 +73,8 @@ func TestGenerateAndTest(t *testing.T) {
 			t.Run(thisName, func(t *testing.T) {
 				t.Parallel()
 
-				log.SetOutput(io.Discard)
 				defer thisCas.warnFailed(t)
-
-				// default opts
-				opts := testClientGenOpts()
+				opts := testClientGenOpts() // default opts for client codegen
 
 				// create directory layout, defer clean
 				defer thisCas.prepareTarget(t, thisName, "server_test", root, opts)()
@@ -90,19 +84,19 @@ func TestGenerateAndTest(t *testing.T) {
 					thisCas.prepare(t, opts)
 				}
 
-				t.Logf("generating test client at: %s, from %s", opts.Target, opts.Spec)
+				t.Run(fmt.Sprintf("generating test client from %s", opts.Spec), func(t *testing.T) {
+					err := GenerateClient(thisName, nil, nil, opts)
+					if thisCas.wantError {
+						require.Errorf(t, err, "expected an error for client build fixture: %s", opts.Spec)
+					} else {
+						require.NoError(t, err, "unexpected error for client build fixture: %s", opts.Spec)
+					}
 
-				err := GenerateClient(thisName, nil, nil, opts)
-				if thisCas.wantError {
-					require.Errorf(t, err, "expected an error for client build fixture: %s", opts.Spec)
-				} else {
-					require.NoError(t, err, "unexpected error for client build fixture: %s", opts.Spec)
-				}
-
-				// verify
-				if thisCas.verify != nil {
-					thisCas.verify(t, opts.Target)
-				}
+					// verify
+					if thisCas.verify != nil {
+						thisCas.verify(t, opts.Target)
+					}
+				})
 
 				// fixture-specific clean
 				if thisCas.clean != nil {
@@ -118,8 +112,8 @@ type generateFixture struct {
 	spec      string
 	target    string
 	wantError bool
-	prepare   func(testing.TB, *GenOpts)
-	verify    func(testing.TB, string)
+	prepare   func(*testing.T, *GenOpts)
+	verify    func(*testing.T, string)
 	clean     func()
 }
 
@@ -172,7 +166,7 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 		"issue 1943": {
 			spec:   "../fixtures/bugs/1943/fixture-1943.yaml",
 			target: "../fixtures/bugs/1943",
-			prepare: func(t testing.TB, opts *GenOpts) {
+			prepare: func(t *testing.T, opts *GenOpts) {
 				input, err := os.ReadFile("../fixtures/bugs/1943/datarace_test.go")
 				require.NoError(t, err)
 
@@ -187,7 +181,7 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 				require.NoError(t, os.WriteFile(filepath.Join(opts.Target, "datarace_test.go"), rebased, 0o600))
 				opts.ExcludeSpec = false
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				if runtime.GOOS == "windows" {
 					// don't run race tests on Appveyor CI
 					t.Logf("warn: race test skipped on windows")
@@ -197,18 +191,18 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 				const packages = "./..."
 				testPrg := "datarace_test.go"
 
-				goExecInDir(t, target, "get", packages)
-
-				t.Log("running data race test on generated server")
-				goExecInDir(t, target, "test", "-v", "-race", testPrg)
+				t.Run("go get", goExecInDir(target, "get", packages))
+				t.Run("running data race test on generated server",
+					goExecInDir(target, "test", "-v", "-race", testPrg),
+				)
 			},
 		},
 		"packages_mangling": {
 			spec: "../fixtures/bugs/2111/fixture-2111.yaml",
-			prepare: func(_ testing.TB, opts *GenOpts) {
+			prepare: func(_ *testing.T, opts *GenOpts) {
 				opts.IncludeMain = true
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				require.True(t, fileExists(target, defaultServerTarget))
 				assert.True(t, fileExists(filepath.Join(target, "cmd", "unsafe-tag-names-server"), "main.go"))
 
@@ -280,10 +274,10 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 		},
 		"packages_flattening": {
 			spec: "../fixtures/bugs/2111/fixture-2111.yaml",
-			prepare: func(_ testing.TB, opts *GenOpts) {
+			prepare: func(_ *testing.T, opts *GenOpts) {
 				opts.SkipTagPackages = true
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				require.True(t, fileExists(target, defaultServerTarget))
 
 				srvTarget := filepath.Join(target, defaultServerTarget)
@@ -351,18 +345,18 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 		},
 		"main_package": {
 			spec: "../fixtures/bugs/2111/fixture-2111.yaml",
-			prepare: func(_ testing.TB, opts *GenOpts) {
+			prepare: func(_ *testing.T, opts *GenOpts) {
 				opts.IncludeMain = true
 				opts.MainPackage = "custom-api"
 				opts.SkipTagPackages = true
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				assert.True(t, fileExists(filepath.Join(target, "cmd", "custom-api"), "main.go"))
 			},
 		},
 		"external_model": {
 			spec: "../fixtures/bugs/1897/fixture-1897.yaml",
-			prepare: func(t testing.TB, opts *GenOpts) {
+			prepare: func(t *testing.T, opts *GenOpts) {
 				modelOpts := *opts
 				modelOpts.AcceptDefinitionsOnly = true
 				modelOpts.Spec = "../fixtures/bugs/1897/model.yaml"
@@ -371,18 +365,20 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 
 				require.NoError(t, GenerateModels(nil, &modelOpts))
 
-				t.Logf("generated external model")
-				require.True(t, fileExists(modelOpts.Target, "external"))
-				require.True(t, fileExists(modelOpts.Target, filepath.Join("external", "error.go")))
+				t.Run("external model should be available", func(t *testing.T) {
+					require.True(t, fileExists(modelOpts.Target, "external"))
+					require.True(t, fileExists(modelOpts.Target, filepath.Join("external", "error.go")))
+				})
 
 				opts.IncludeMain = true
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				location := filepath.Join(target, "cmd", "repro1897-server")
 				require.True(t, fileExists("", location))
 
-				t.Log("building generated server")
-				goExecInDir(t, location, "build")
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
 			},
 			clean: func() {
 				// remove generated external models
@@ -392,7 +388,7 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 		"external_models_hints": {
 			spec:   "../fixtures/enhancements/2224/fixture-2224.yaml",
 			target: "2224-hints",
-			prepare: func(t testing.TB, opts *GenOpts) {
+			prepare: func(t *testing.T, opts *GenOpts) {
 				modelOpts := *opts
 				modelOpts.AcceptDefinitionsOnly = true
 				modelOpts.Spec = "../fixtures/enhancements/2224/fixture-2224-models.yaml"
@@ -401,24 +397,25 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 
 				require.NoError(t, GenerateModels(nil, &modelOpts))
 
-				t.Logf("generated external model")
-				require.True(t, fileExists(modelOpts.Target, "external"))
+				t.Run("external models should be available", func(t *testing.T) {
+					require.True(t, fileExists(modelOpts.Target, "external"))
 
-				for _, model := range []string{
-					"access_point.go", "base.go",
-					"hotspot.go", "hotspot_type.go",
-					"incorrect.go", "json_message.go",
-					"json_object.go", "json_object_with_alias.go",
-					"object_with_embedded.go", "object_with_externals.go",
-					"raw.go", "request.go",
-					"request_pointer.go", "time_as_object.go", "time.go",
-				} {
-					require.True(t, fileExists(modelOpts.Target, filepath.Join("external", model)))
-				}
+					for _, model := range []string{
+						"access_point.go", "base.go",
+						"hotspot.go", "hotspot_type.go",
+						"incorrect.go", "json_message.go",
+						"json_object.go", "json_object_with_alias.go",
+						"object_with_embedded.go", "object_with_externals.go",
+						"raw.go", "request.go",
+						"request_pointer.go", "time_as_object.go", "time.go",
+					} {
+						require.True(t, fileExists(modelOpts.Target, filepath.Join("external", model)))
+					}
+				})
 
 				opts.IncludeMain = true
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				// generated models (not external)
 				require.True(t, fileExists(target, "models"))
 				for _, model := range []string{"error.go", "external_with_embed.go"} {
@@ -428,8 +425,9 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 				location := filepath.Join(target, "cmd", "external-types-with-hints-server")
 				require.True(t, fileExists("", location))
 
-				t.Log("building generated server")
-				goExecInDir(t, location, "build")
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
 			},
 			clean: func() {
 				// remove generated external models
@@ -439,53 +437,56 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 		"conflict_name_api_issue_2405_1": {
 			spec:   "../examples/todo-list/swagger.yml",
 			target: "2405-1",
-			prepare: func(_ testing.TB, opts *GenOpts) {
+			prepare: func(_ *testing.T, opts *GenOpts) {
 				opts.ServerPackage = "api"
 				opts.IncludeMain = true
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				location := filepath.Join(target, "cmd", "simple-to-do-list-api-server")
 				require.True(t, fileExists("", location))
 
-				t.Log("building generated server")
-				goExecInDir(t, location, "build")
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
 			},
 		},
 		"conflict_name_api_issue_2405_2": {
 			spec:   "../examples/todo-list/swagger.yml",
 			target: "2405-2",
-			prepare: func(_ testing.TB, opts *GenOpts) {
+			prepare: func(_ *testing.T, opts *GenOpts) {
 				opts.ServerPackage = "loads"
 				opts.IncludeMain = true
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				location := filepath.Join(target, "cmd", "simple-to-do-list-api-server")
 				require.True(t, fileExists("", location))
 
-				t.Log("building generated server")
-				goExecInDir(t, location, "build")
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
 			},
 		},
 		"conflict_name_api_issue_2405_3": {
 			spec:   "../fixtures/bugs/2405/fixture-2405.yaml",
 			target: "2405-3",
-			prepare: func(_ testing.TB, opts *GenOpts) {
+			prepare: func(_ *testing.T, opts *GenOpts) {
 				opts.ServerPackage = "server"
 				opts.APIPackage = "api"
 				opts.IncludeMain = true
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				location := filepath.Join(target, "cmd", "simple-to-do-list-api-server")
 				require.True(t, fileExists("", location))
 
-				t.Log("building generated server")
-				goExecInDir(t, location, "build")
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
 			},
 		},
 		"ext_types_issue_2385": {
 			spec:   "../fixtures/bugs/2385/fixture-2385.yaml",
 			target: "2385",
-			prepare: func(t testing.TB, opts *GenOpts) {
+			prepare: func(t *testing.T, opts *GenOpts) {
 				opts.MainPackage = "nrcodegen-server"
 				opts.IncludeMain = true
 				location := filepath.Join(opts.Target, "models")
@@ -493,23 +494,25 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 				// add some custom model to the generated models
 				addModelsToLocation(t, location, "my_type.go")
 			},
-			verify: func(_ testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				location := filepath.Join(target, "cmd", "nrcodegen-server")
 				require.True(t, fileExists("", location))
 
-				t.Log("building generated server")
-				goExecInDir(t, location, "build")
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
 
 				location = filepath.Join(target, "models")
 
-				t.Log("building generated models")
-				goExecInDir(t, location, "build")
+				t.Run("building generated models",
+					goExecInDir(location, "build"),
+				)
 			},
 		},
 		"ext_types_full_example": {
 			spec:   "../examples/external-types/example-external-types.yaml",
 			target: "external-full",
-			prepare: func(_ testing.TB, opts *GenOpts) {
+			prepare: func(t *testing.T, opts *GenOpts) {
 				opts.MainPackage = "nrcodegen-server"
 				opts.IncludeMain = true
 				opts.ValidateSpec = false // the spec contains AdditionalItems
@@ -518,17 +521,19 @@ func generateFixtures(t testing.TB) map[string]generateFixture {
 				// add some custom model to the generated models
 				addModelsToLocation(t, location, "my_type.go")
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				location := filepath.Join(target, "cmd", "nrcodegen-server")
 				require.True(t, fileExists("", location))
 
-				t.Log("building generated server")
-				goExecInDir(t, location, "build")
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
 
 				location = filepath.Join(target, "models")
 
-				t.Log("building generated models")
-				goExecInDir(t, location, "build")
+				t.Run("building generated models",
+					goExecInDir(location, "build"),
+				)
 			},
 		},
 	}
@@ -539,7 +544,7 @@ func generateClientFixtures(_ testing.TB) map[string]generateFixture {
 		"issue1083": {
 			spec:   "../fixtures/bugs/1083/petstore.yaml",
 			target: "../fixtures/bugs/1083/codegen",
-			prepare: func(t testing.TB, opts *GenOpts) {
+			prepare: func(t *testing.T, opts *GenOpts) {
 				input, err := os.ReadFile("../fixtures/bugs/1083/pathparam_test.go")
 				require.NoError(t, err)
 
@@ -568,18 +573,21 @@ func generateClientFixtures(_ testing.TB) map[string]generateFixture {
 				_, err = io.Copy(w, f)
 				require.NoError(t, err)
 			},
-			verify: func(t testing.TB, target string) {
+			verify: func(t *testing.T, target string) {
 				const packages = "./..."
 				testPrg := "pathparam_test.go"
 				testDir := filepath.Dir(target)
 
-				goExecInDir(t, testDir, "get", packages)
+				t.Run("go get",
+					goExecInDir(testDir, "get", packages),
+				)
 
-				t.Log("running runtime request test on generated client")
-				// This test runs a generated client against a untyped API server.
-				// It verifies that path parameters are properly escaped and unescaped.
-				// It exercises the full stack of runtime client and server.
-				goExecInDir(t, testDir, "test", "-v", testPrg)
+				t.Run("running runtime request test on generated client",
+					// This test runs a generated client against a untyped API server.
+					// It verifies that path parameters are properly escaped and unescaped.
+					// It exercises the full stack of runtime client and server.
+					goExecInDir(testDir, "test", "-v", testPrg),
+				)
 			},
 		},
 	}

--- a/generator/internal/gentest/doc.go
+++ b/generator/internal/gentest/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// for code generators.
+
+// Package gentest provides internal test utilities
+package gentest

--- a/generator/internal/gentest/testutils.go
+++ b/generator/internal/gentest/testutils.go
@@ -1,0 +1,78 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gentest
+
+import (
+	"io"
+	"log"
+	"os/exec"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var lockLogger sync.Mutex
+
+// DiscardOutput discards the standard logger and returns
+// a rollback function.
+//
+// Typical usage:
+//
+//	defer gentest.DiscardOutput()()
+func DiscardOutput() func() {
+	return setOutput(io.Discard)
+}
+
+// CaptureOutput captures the standard logger to the passed writer
+// and returns a rollback function.
+// Typical usage:
+//
+//	var buf bytes.Buffer
+//	defer gentest.CaptureOutput(&buf)()
+func CaptureOutput(w io.Writer) func() {
+	return setOutput(w)
+}
+
+func setOutput(w io.Writer) func() {
+	lockLogger.Lock()
+	defer lockLogger.Unlock()
+
+	original := log.Writer()
+	// discards log output then sends a function to set it back to its original value
+	log.SetOutput(w)
+
+	return func() {
+		lockLogger.Lock()
+		log.SetOutput(original)
+		lockLogger.Unlock()
+	}
+}
+
+// GoExecInDir executes a go commands from a target current directory.
+//
+// It returns a test runner func(*testing.T).
+//
+// Typical usage:
+//
+//	t.Run("should execute mycommand", gentest.GoExecInDir(folder, args))
+func GoExecInDir(target string, args ...string) func(*testing.T) {
+	return func(t *testing.T) {
+		cmd := exec.Command("go", args...)
+		cmd.Dir = target
+		p, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "unexpected error: %s: %v\n%s", cmd.String(), err, string(p))
+	}
+}

--- a/generator/model.go
+++ b/generator/model.go
@@ -687,7 +687,7 @@ func (sg *schemaGenContext) schemaValidations() sharedValidations {
 		// when readOnly or default is specified, this disables Required validation (Swagger-specific)
 		isRequired = false
 		if sg.Required {
-			log.Printf("warn: properties with a default value or readOnly should not be required [%s]", sg.Name)
+			log.Printf("warning: properties with a default value or readOnly should not be required [%s]", sg.Name)
 		}
 	}
 

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -2642,7 +2642,7 @@ func TestGenerateModels(t *testing.T) {
 			"allDefinitions": {
 				spec:   "../fixtures/bugs/1042/fixture-1042.yaml",
 				target: "../fixtures/bugs/1042",
-				verify: func(t testing.TB, target string) {
+				verify: func(t *testing.T, target string) {
 					target = filepath.Join(target, defaultModelsTarget)
 					require.True(t, fileExists(target, ""))
 					assert.True(t, fileExists(target, "a.go"))
@@ -2652,10 +2652,10 @@ func TestGenerateModels(t *testing.T) {
 			"acceptDefinitions": {
 				spec:   "../fixtures/enhancements/2333/fixture-definitions.yaml",
 				target: "../fixtures/enhancements/2333",
-				prepare: func(_ testing.TB, opts *GenOpts) {
+				prepare: func(_ *testing.T, opts *GenOpts) {
 					opts.AcceptDefinitionsOnly = true
 				},
-				verify: func(t testing.TB, target string) {
+				verify: func(t *testing.T, target string) {
 					target = filepath.Join(target, defaultModelsTarget)
 					require.True(t, fileExists(target, ""))
 					assert.True(t, fileExists(target, "model_interface.go"))
@@ -2667,7 +2667,7 @@ func TestGenerateModels(t *testing.T) {
 			"mangleNames": {
 				spec:   "../fixtures/bugs/2821/ServiceManagementBody.json",
 				target: "../fixtures/bugs/2821",
-				verify: func(t testing.TB, target string) {
+				verify: func(t *testing.T, target string) {
 					target = filepath.Join(target, defaultModelsTarget)
 					require.True(t, fileExists(target, "schema.go"))
 					content, err := os.ReadFile(filepath.Join(target, "schema.go"))
@@ -2692,18 +2692,18 @@ func TestGenerateModels(t *testing.T) {
 					thisCas.prepare(t, opts)
 				}
 
-				t.Logf("generating test models at: %s", opts.Target)
+				t.Run(fmt.Sprintf("generating test models from: %s", opts.Spec), func(t *testing.T) {
+					err := GenerateModels([]string{"", ""}, opts) // NOTE: generate all models, ignore ""
+					if thisCas.wantError {
+						require.Errorf(t, err, "expected an error for models build fixture: %s", opts.Spec)
+					} else {
+						require.NoError(t, err, "unexpected error for models build fixture: %s", opts.Spec)
+					}
 
-				err := GenerateModels([]string{"", ""}, opts) // NOTE: generate all models, ignore ""
-				if thisCas.wantError {
-					require.Errorf(t, err, "expected an error for models build fixture: %s", opts.Spec)
-				} else {
-					require.NoError(t, err, "unexpected error for models build fixture: %s", opts.Spec)
-				}
-
-				if thisCas.verify != nil {
-					thisCas.verify(t, opts.Target)
-				}
+					if thisCas.verify != nil {
+						thisCas.verify(t, opts.Target)
+					}
+				})
 			})
 		}
 	})

--- a/generator/moreschemavalidation_test.go
+++ b/generator/moreschemavalidation_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -326,17 +325,14 @@ func initTxxx() {
 
 func TestModelGenerateDefinition(t *testing.T) {
 	// exercise the top level model generation func
-	log.SetOutput(io.Discard)
-	defer func() {
-		log.SetOutput(os.Stdout)
-	}()
+	defer discardOutput()()
+
 	fixtureSpec := "../fixtures/bugs/1487/fixture-is-nullable.yaml"
-	assert := assert.New(t)
-	gendir, erd := os.MkdirTemp(".", "model-test")
+	gendir, err := os.MkdirTemp(".", "model-test")
+	require.NoError(t, err)
 	defer func() {
 		_ = os.RemoveAll(gendir)
 	}()
-	require.NoError(t, erd)
 
 	opts := &GenOpts{}
 	opts.IncludeValidator = true
@@ -345,43 +341,65 @@ func TestModelGenerateDefinition(t *testing.T) {
 	opts.Spec = fixtureSpec
 	opts.ModelPackage = "models"
 	opts.Target = gendir
-	if err := opts.EnsureDefaults(); err != nil {
-		panic(err)
-	}
-	// sets gen options (e.g. flatten vs expand) - flatten is the default setting
+	require.NoError(t, opts.EnsureDefaults())
+
+	// sets gen options (e.g. flatten vs expand) - minimal flatten is the default setting
 	opts.FlattenOpts.Minimal = false
 
-	err := GenerateDefinition([]string{"thingWithNullableDates"}, opts)
-	assert.NoErrorf(err, "Expected GenerateDefinition() to run without error")
+	t.Run("should generate definitions", func(t *testing.T) {
+		require.NoErrorf(t,
+			GenerateDefinition([]string{"thingWithNullableDates"}, opts),
+			"expected GenerateDefinition() to run without error",
+		)
 
-	err = GenerateDefinition(nil, opts)
-	assert.NoErrorf(err, "Expected GenerateDefinition() to run without error")
+		require.NoErrorf(t,
+			GenerateDefinition(nil, opts),
+			"expected GenerateDefinition() to run without error",
+		)
+	})
 
-	opts.TemplateDir = gendir
-	err = GenerateDefinition([]string{"thingWithNullableDates"}, opts)
-	assert.NoErrorf(err, "Expected GenerateDefinition() to run without error")
+	t.Run("should generate definitions with templates dir", func(t *testing.T) {
+		opts.TemplateDir = gendir
+		require.NoErrorf(t,
+			GenerateDefinition([]string{"thingWithNullableDates"}, opts),
+			"expected GenerateDefinition() to run without error",
+		)
+	})
 
-	err = GenerateDefinition([]string{"thingWithNullableDates"}, nil)
-	assert.Errorf(err, "Expected GenerateDefinition() return an error when no option is passed")
+	t.Run("should NOT generate definition when options is nil", func(t *testing.T) {
+		require.Errorf(t,
+			GenerateDefinition([]string{"thingWithNullableDates"}, nil),
+			"expected GenerateDefinition() return an error when no option is passed",
+		)
+	})
 
-	opts.TemplateDir = "templates"
-	err = GenerateDefinition([]string{"thingWithNullableDates"}, opts)
-	assert.Errorf(err, "Expected GenerateDefinition() to croak about protected templates")
+	t.Run("should NOT generate definition when overwriting protected templates", func(t *testing.T) {
+		opts.TemplateDir = "templates"
+		require.Errorf(t,
+			GenerateDefinition([]string{"thingWithNullableDates"}, opts),
+			"expected GenerateDefinition() to croak about protected templates",
+		)
+	})
 
-	opts.TemplateDir = ""
-	err = GenerateDefinition([]string{"myAbsentDefinition"}, opts)
-	assert.Errorf(err, "Expected GenerateDefinition() to return an error when the model is not in spec")
+	t.Run("should NOT generate definition when not in spec", func(t *testing.T) {
+		opts.TemplateDir = ""
+		require.Errorf(t,
+			GenerateDefinition([]string{"myAbsentDefinition"}, opts),
+			"expected GenerateDefinition() to return an error when the model is not in spec",
+		)
+	})
 
-	opts.Spec = "pathToNowhere"
-	err = GenerateDefinition([]string{"thingWithNullableDates"}, opts)
-	assert.Errorf(err, "Expected GenerateDefinition() to return an error when the spec is not reachable")
+	t.Run("should NOT generate definition when the spec is available", func(t *testing.T) {
+		opts.Spec = "pathToNowhere"
+		require.Errorf(t,
+			GenerateDefinition([]string{"thingWithNullableDates"}, opts),
+			"expected GenerateDefinition() to return an error when the spec is not reachable",
+		)
+	})
 }
 
 func TestMoreModelValidations(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer func() {
-		log.SetOutput(os.Stdout)
-	}()
+	defer discardOutput()()
 
 	initModelFixtures()
 
@@ -396,7 +414,6 @@ func TestMoreModelValidations(t *testing.T) {
 
 		t.Run(runTitle, func(t *testing.T) {
 			t.Parallel()
-			log.SetOutput(io.Discard)
 
 			for _, fixtureRun := range fixture.Runs {
 				opts := fixtureRun.FixtureOpts

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -1068,7 +1068,7 @@ func dumpData(data interface{}) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(os.Stdout, string(bb))
+	fmt.Fprintln(os.Stdout, string(bb)) // TODO(fred): not testable
 	return nil
 }
 

--- a/generator/shared_test.go
+++ b/generator/shared_test.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path"
@@ -79,10 +78,8 @@ func testGenOpts() *GenOpts {
 // Windows style path is difficult to test on unix
 // since the filepath pkg is platform dependent
 func TestShared_CheckOpts(t *testing.T) {
+	defer discardOutput()()
 	testPath := filepath.Join("a", "b", "b")
-
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
 
 	opts := new(GenOpts)
 	_ = opts.EnsureDefaults()
@@ -143,8 +140,7 @@ func TestShared_EnsureDefaults(t *testing.T) {
 // {{ .SpecPath }}, to construct the go generate
 // directive.
 func TestShared_TargetPath(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	cwd, _ := os.Getwd()
 
@@ -187,8 +183,7 @@ func TestShared_TargetPath(t *testing.T) {
 
 // NOTE: file://url is not supported
 func TestShared_SpecPath(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	cwd, _ := os.Getwd()
 
@@ -273,8 +268,7 @@ func TestShared_SpecPath(t *testing.T) {
 
 // Low level testing: templates not found (higher level calls raise panic(), see above)
 func TestShared_NotFoundTemplate(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	opts := testGenOpts()
 	tplOpts := TemplateOpts{
@@ -294,8 +288,7 @@ func TestShared_NotFoundTemplate(t *testing.T) {
 // Low level testing: invalid template => Get() returns not found (higher level calls raise panic(), see above)
 // TODO: better error discrimination between absent definition and non-parsing template
 func TestShared_GarbledTemplate(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	garbled := "func x {{;;; garbled"
 
@@ -324,8 +317,7 @@ func (*myTemplateData) MyFaultyMethod() (string, error) {
 }
 
 func TestShared_ExecTemplate(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	// Not a failure: no value data
 	execfailure1 := "func x {{ .NotInData }}"
@@ -368,14 +360,14 @@ func TestShared_ExecTemplate(t *testing.T) {
 
 // Test correctly parsed templates, with bad formatting
 func TestShared_BadFormatTemplate(t *testing.T) {
-	log.SetOutput(io.Discard)
+	// TODO: fred refact
+	defer discardOutput()()
 
-	defer func() {
+	t.Cleanup(func() {
 		_ = os.Remove("test_badformat.gol")
 		_ = os.Remove("test_badformat2.gol")
-		log.SetOutput(os.Stdout)
 		Debug = false
-	}()
+	})
 
 	// Not skipping format
 	badFormat := "func x {;;; garbled"
@@ -438,12 +430,11 @@ func TestShared_BadFormatTemplate(t *testing.T) {
 
 // Test dir creation
 func TestShared_DirectoryTemplate(t *testing.T) {
-	log.SetOutput(io.Discard)
+	defer discardOutput()()
 
-	defer func() {
+	t.Cleanup(func() {
 		_ = os.RemoveAll("TestGenDir")
-		log.SetOutput(os.Stdout)
-	}()
+	})
 
 	// Not skipping format
 	content := "func x {}"
@@ -480,8 +471,7 @@ func TestShared_DirectoryTemplate(t *testing.T) {
 // Test templates which are not assets (open in file)
 // Low level testing: templates loaded from file
 func TestShared_LoadTemplate(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	opts := testGenOpts()
 	tplOpts := TemplateOpts{
@@ -565,29 +555,35 @@ func TestShared_GatherModel(t *testing.T) {
 }
 
 func TestShared_DumpWrongData(t *testing.T) {
-	assert.Error(t, dumpData(struct {
-		A func() string
-		B string
-	}{
-		A: func() string { return "" },
-		B: "xyz",
-	}))
+	defer discardOutput()()
 
-	assert.NoError(t, dumpData(struct {
-		A func() string `json:"-"`
-		B string
-	}{
-		A: func() string { return "" },
-		B: "xyz",
-	}))
+	t.Run("should not be able to dump things that don't marshal as JSON", func(t *testing.T) {
+		require.Error(t, dumpData(struct {
+			A func() string
+			B string
+		}{
+			A: func() string { return "" },
+			B: "xyz",
+		}))
+	})
 
-	assert.NoError(t, dumpData(struct {
-		a func() string
-		B string
-	}{
-		a: func() string { return "" },
-		B: "xyz",
-	}))
+	t.Run("should dump any data, with unmarshallable fields exlicitly excluded", func(t *testing.T) {
+		require.NoError(t, dumpData(struct {
+			A func() string `json:"-"`
+			B string
+		}{
+			A: func() string { return "" },
+			B: "xyz",
+		}))
+
+		require.NoError(t, dumpData(struct {
+			a func() string
+			B string
+		}{
+			a: func() string { return "" },
+			B: "xyz",
+		}))
+	})
 }
 
 func TestResolvePrincipal(t *testing.T) {
@@ -780,8 +776,7 @@ func TestDefaultImports(t *testing.T) {
 }
 
 func TestShared_Issue2113(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	// acknowledge fix in go-openapi/spec
 	specPath := filepath.Join("..", "fixtures", "bugs", "2113", "base.yaml")

--- a/generator/spec_test.go
+++ b/generator/spec_test.go
@@ -1,9 +1,6 @@
 package generator
 
 import (
-	"io"
-	"log"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,8 +11,7 @@ import (
 )
 
 func TestSpec_Issue1429(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	// acknowledge fix in go-openapi/spec
 	specPath := filepath.Join("..", "fixtures", "bugs", "1429", "swagger-1429.yaml")
@@ -47,8 +43,7 @@ func TestSpec_Issue1429(t *testing.T) {
 }
 
 func TestSpec_Issue2527(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	t.Run("spec should be detected as invalid", func(t *testing.T) {
 		specPath := filepath.Join("..", "fixtures", "bugs", "2527", "swagger.yml")
@@ -84,8 +79,7 @@ func TestSpec_FindSwaggerSpec(t *testing.T) {
 }
 
 func TestSpec_Issue1621(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	// acknowledge fix in go-openapi/spec
 	specPath := filepath.Join("..", "fixtures", "bugs", "1621", "fixture-1621.yaml")
@@ -100,8 +94,7 @@ func TestSpec_Issue1621(t *testing.T) {
 }
 
 func TestShared_Issue1614(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+	defer discardOutput()()
 
 	// acknowledge fix in go-openapi/spec
 	specPath := filepath.Join("..", "fixtures", "bugs", "1614", "gitea.json")
@@ -115,9 +108,8 @@ func TestShared_Issue1614(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_analyzeSpec_Issue2216(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(os.Stdout)
+func Test_AnalyzeSpec_Issue2216(t *testing.T) {
+	defer discardOutput()()
 
 	t.Run("single-swagger-file", func(t *testing.T) {
 		specPath := filepath.Join("..", "fixtures", "bugs", "2216", "swagger-single.yml")

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -2,9 +2,6 @@ package generator
 
 import (
 	"encoding/json"
-	"io"
-	"log"
-	"os"
 	"strconv"
 	"testing"
 
@@ -468,10 +465,7 @@ func makeGuardValidationFixtures() []guardValidationsFixture {
 }
 
 func TestGuardValidations(t *testing.T) {
-	log.SetOutput(io.Discard)
-	defer func() {
-		log.SetOutput(os.Stdout)
-	}()
+	defer discardOutput()()
 
 	for _, toPin := range makeGuardValidationFixtures() {
 		testCase := toPin

--- a/generator/utils_test.go
+++ b/generator/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,11 +77,13 @@ func funcBody(code string, signature string) string {
 
 // testing utilities for codegen build
 
-func goExecInDir(t testing.TB, target string, args ...string) {
-	cmd := exec.Command("go", args...)
-	cmd.Dir = target
-	p, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "unexpected error: %s: %v\n%s", cmd.String(), err, string(p))
+func goExecInDir(target string, args ...string) func(*testing.T) {
+	return func(t *testing.T) {
+		cmd := exec.Command("go", args...)
+		cmd.Dir = target
+		p, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "unexpected error: %s: %v\n%s", cmd.String(), err, string(p))
+	}
 }
 
 func testCwd(t testing.TB) string {
@@ -89,11 +92,27 @@ func testCwd(t testing.TB) string {
 	return cwd
 }
 
+var lockLogger sync.Mutex
+
 func discardOutput() func() {
-	// discards log output then sends a function to set it back to stdout
-	log.SetOutput(io.Discard)
+	return setOutput(io.Discard)
+}
+
+func captureOutput(w io.Writer) func() {
+	return setOutput(w)
+}
+
+func setOutput(w io.Writer) func() {
+	lockLogger.Lock()
+	defer lockLogger.Unlock()
+
+	original := log.Writer()
+	// discards log output then sends a function to set it back to its original value
+	log.SetOutput(w)
 
 	return func() {
-		log.SetOutput(os.Stdout)
+		lockLogger.Lock()
+		log.SetOutput(original)
+		lockLogger.Unlock()
 	}
 }


### PR DESCRIPTION
This PR generalizes the discarding of log output.

A few rough edges remain (but were previously there), as it is still possible that the few tests that assert the logged output cross the way of a test that discards it.

At least, running tests now generates less clutter.