### PR TITLE
feat(gen client): added support to work with multiple mimes

### DIFF
--- a/fixtures/bugs/2773/2773.yaml
+++ b/fixtures/bugs/2773/2773.yaml
@@ -1,0 +1,32 @@
+swagger: "2.0"
+info:
+  description: Example server uploading a file
+  version: "1.0.0"
+  title: File Upload
+basePath: /
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/octet-stream
+  - application/json
+
+paths:
+  /upload:
+    post:
+      tags:
+      - uploads
+      summary: uploads
+      operationId: uploadFile
+      consumes:
+      - multipart/form-data
+      - application/x-www-form-urlencoded
+      parameters:
+      - name: file
+        in: formData
+        type: file
+        required: true
+      responses:
+        "200":
+          description: OK

--- a/generator/media.go
+++ b/generator/media.go
@@ -71,6 +71,10 @@ func mediaMime(orig string) string {
 	return strings.SplitN(orig, ";", 2)[0]
 }
 
+func mediaGoName(media string) string {
+	return pascalize(strings.ReplaceAll(media, "*", "Star"))
+}
+
 func mediaParameters(orig string) string {
 	parts := strings.SplitN(orig, ";", 2)
 	if len(parts) < 2 {

--- a/generator/media_test.go
+++ b/generator/media_test.go
@@ -37,6 +37,10 @@ func TestMediaMime(t *testing.T) {
 	assert.Equal(t, "", mediaParameters(runtime.JSONMime))
 }
 
+func TestMediaGoName(t *testing.T) {
+	assert.Equal(t, "StarStar", mediaGoName("*/*"))
+}
+
 func TestMediaMakeSerializers(t *testing.T) {
 	app := appGenerator{
 		Name:     "myapp",

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -428,10 +428,7 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	originalExtraSchemes := getExtraSchemes(operation.Extensions)
 
 	produces := producesOrDefault(operation.Produces, swsp.Produces, b.DefaultProduces)
-	sort.Strings(produces)
-
 	consumes := producesOrDefault(operation.Consumes, swsp.Consumes, b.DefaultConsumes)
-	sort.Strings(consumes)
 
 	var successResponse *GenResponse
 	for _, resp := range successResponses {

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -520,6 +520,8 @@ type GenOperationGroup struct {
 	RootPackage    string
 	GenOpts        *GenOpts
 	PackageAlias   string
+
+	ClientOptions *GenClientOptions
 }
 
 // GenOperationGroups is a sorted collection of operation groups
@@ -807,3 +809,10 @@ type GenSecurityRequirements []GenSecurityRequirement
 func (g GenSecurityRequirements) Len() int           { return len(g) }
 func (g GenSecurityRequirements) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 func (g GenSecurityRequirements) Less(i, j int) bool { return g[i].Name < g[j].Name }
+
+// GenClientOptions holds extra pieces of information
+// to generate a client.
+type GenClientOptions struct {
+	ProducesMediaTypes []string // filled with all producers if any method as more than 1
+	ConsumesMediaTypes []string // filled with all consumers if any method as more than 1
+}

--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -93,6 +93,7 @@ func DefaultFuncMap(lang *LanguageOpts) template.FuncMap {
 		"inspect":          pretty.Sprint,
 		"cleanPath":        path.Clean,
 		"mediaTypeName":    mediaMime,
+		"mediaGoName":      mediaGoName,
 		"arrayInitializer": lang.arrayInitializer,
 		"hasPrefix":        strings.HasPrefix,
 		"stringContains":   strings.Contains,

--- a/generator/templates/client/client.gotmpl
+++ b/generator/templates/client/client.gotmpl
@@ -68,7 +68,7 @@ type Client struct {
 // ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
-{{- with .ClientOptions }}
+{{- with .ClientOptions }}{{/* use ad'hoc function mediaGoName rather than pascalize because of patterns with * */}}
 
 // This client is generated with a few options you might find useful for your swagger spec.
 //
@@ -85,11 +85,13 @@ func WithContentType(mime string) ClientOption {
 	}
 }
     {{ range .ConsumesMediaTypes  }}
+      {{- if not ( eq (mediaGoName .) ""  ) }}{{/* guard: in case garbled input produces a (conflicting) empty name */}}
 
-// WithContentType{{ pascalize . }} sets the Content-Type header to {{ printf "%q" . }}.
-func WithContentType{{ pascalize . }}(r *runtime.ClientOperation) {
+// WithContentType{{ mediaGoName . }} sets the Content-Type header to {{ printf "%q" . }}.
+func WithContentType{{ mediaGoName . }}(r *runtime.ClientOperation) {
 	r.ConsumesMediaTypes = []string{ {{ printf "%q" . }} }
 }
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- if gt (len .ProducesMediaTypes) 1 }}
@@ -104,11 +106,13 @@ func WithAccept(mime string) ClientOption {
 	}
 }
     {{ range .ProducesMediaTypes  }}
+      {{- if not ( eq (mediaGoName .) ""  ) }}{{/* guard: in case garbled input produces a (conflicting) empty name */}}
 
-// WithAccept{{ pascalize . }} sets the Accept header to {{ printf "%q" . }}.
-func WithAccept{{ pascalize . }}(r *runtime.ClientOperation) {
+// WithAccept{{ mediaGoName . }} sets the Accept header to {{ printf "%q" . }}.
+func WithAccept{{ mediaGoName . }}(r *runtime.ClientOperation) {
 	r.ProducesMediaTypes = []string{ {{ printf "%q" . }} }
 }
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/generator/templates/client/client.gotmpl
+++ b/generator/templates/client/client.gotmpl
@@ -65,8 +65,53 @@ type Client struct {
   formats strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+{{- with .ClientOptions }}
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+  {{- if gt (len .ConsumesMediaTypes) 1 }}
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+    {{ range .ConsumesMediaTypes  }}
+
+// WithContentType{{ pascalize . }} sets the Content-Type header to {{ printf "%q" . }}.
+func WithContentType{{ pascalize . }}(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{ {{ printf "%q" . }} }
+}
+    {{- end }}
+  {{- end }}
+  {{- if gt (len .ProducesMediaTypes) 1 }}
+
+// WithAccept allows the client to force the Accept header
+// to negotiate a specific Producer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithAccept(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ProducesMediaTypes = []string{mime}
+	}
+}
+    {{ range .ProducesMediaTypes  }}
+
+// WithAccept{{ pascalize . }} sets the Accept header to {{ printf "%q" . }}.
+func WithAccept{{ pascalize . }}(r *runtime.ClientOperation) {
+	r.ProducesMediaTypes = []string{ {{ printf "%q" . }} }
+}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
 // ClientService is the interface for Client methods
 type ClientService interface {


### PR DESCRIPTION
* fixes https://github.com/go-swagger/go-swagger/issues/2773

1. fix: no longer sort producers and consumers
   The client runtime picks the first one, so the order is relevant.

2. feat: added extra options to set media type
   For client codegen only, AND whenever a single group of operations
   deals with more than one media for producers OR more than one media
   for consumers , THEN we generate an extra set of convenience ClientOption
   functions to switch media type.

   Generates generic options to set the mime as an arbitrary string
   (comes in handy to set mime extensions):

   WithContentType(string) (to negotiate consumers)
   WithAccept(string) (to negotiate producers)

   Generate shorthands with a mangled name such as:
	`WithContentTypeApplicationxWwwFormUrlencoded`
   to be used directly as an option.

* Simple APIs with a single producer and a single consumer are not
affected.
* Server codegen is not affected

* test: content type is not sorted
* test: asserted codegen

> NOTE: see https://github.com/go-swagger/go-swagger/issues/2773 on github issues for a complete analysis.
> The part of that issue relative to the runtime client not supporting
> file upload with application/x-www-form-urlencoded is obviously not
> fixed by this PR.

Signed-off-by: Frédéric BIDON <fredbi@yahoo.com>