### PR TITLE
fix(codegen): fixed operation package mangling when tag is v1

### DIFF
--- a/fixtures/bugs/2866/2866.yaml
+++ b/fixtures/bugs/2866/2866.yaml
@@ -1,0 +1,9547 @@
+swagger: '2.0'
+info:
+  version: '0.0.1'
+  title: Planting Service
+  description: Planting Service is the reference for all planting activities.
+  contact: {}
+host: www.example.com
+basePath: /
+securityDefinitions: {}
+schemes:
+- https
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /healthz:
+    get:
+      description: Service health check
+      summary: Service health check
+      tags:
+      - core
+      operationId: Servicehealthcheck
+      deprecated: false
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        default:
+          description: ''
+          headers: {}
+  /propertiez:
+    get:
+      description: Build/Runtime properties
+      summary: Build/Runtime properties
+      tags:
+      - core
+      operationId: Build/Runtimeproperties
+      deprecated: false
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        default:
+          description: ''
+          headers: {}
+  /hystrixz:
+    get:
+      description: Hystrix event stream
+      summary: Hystrix event stream
+      tags:
+      - core
+      operationId: Hystrixeventstream
+      deprecated: false
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        default:
+          description: ''
+          headers: {}
+  /prometheuz:
+    get:
+      description: Prometheus metrics
+      summary: Prometheus metrics
+      tags:
+      - core
+      operationId: Prometheusmetrics
+      deprecated: false
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        default:
+          description: ''
+          headers: {}
+  /legacy/nitro/api/data/v1/planting_activities/{activity-id}:
+    delete:
+      description: 'GONE: Nitro Planting Activities API V1'
+      summary: 'GONE: Delete a planting activity'
+      tags:
+      - legacy nitro
+      operationId: GONE:Deleteaplantingactivity
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-user-email
+        in: header
+        required: true
+        type: string
+        description: email
+      - name: user
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_groups
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: activity-id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        default:
+          description: ''
+          headers: {}
+    get:
+      description: 'GONE: Nitro Planting Activities API V1'
+      summary: 'GONE: Get a planting activity'
+      tags:
+      - legacy nitro
+      operationId: GONE:Getaplantingactivity
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-user-email
+        in: header
+        required: true
+        type: string
+        description: email
+      - name: activity-id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: user
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_groups
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        default:
+          description: ''
+          headers: {}
+    post:
+      description: 'GONE: Nitro Planting Activities API V1'
+      summary: 'GONE: Update a planting activity'
+      tags:
+      - legacy nitro
+      operationId: GONE:Updateaplantingactivity
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-user-email
+        in: header
+        required: true
+        type: string
+        description: email
+      - name: activity-id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: user
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_groups
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        default:
+          description: ''
+          headers: {}
+    put:
+      description: 'GONE: Nitro Planting Activities API V1'
+      summary: 'GONE: Update a planting activity1'
+      tags:
+      - legacy nitro
+      operationId: GONE:Updateaplantingactivity1
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-user-email
+        in: header
+        required: true
+        type: string
+        description: email
+      - name: activity-id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: user
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_groups
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        default:
+          description: ''
+          headers: {}
+  /legacy/nitro/api/data/v1/planting_activities:
+    get:
+      description: 'GONE: Nitro Planting Activities API V1'
+      summary: 'GONE: Get planting activites'
+      tags:
+      - legacy nitro
+      operationId: GONE:Getplantingactivites
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-user-email
+        in: header
+        required: true
+        type: string
+        description: email
+      - name: user
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_groups
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        default:
+          description: ''
+          headers: {}
+    post:
+      description: 'GONE: Nitro Planting Activities API V1'
+      summary: 'GONE: Create planting activities'
+      tags:
+      - legacy nitro
+      operationId: GONE:Createplantingactivities
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-user-email
+        in: header
+        required: true
+        type: string
+        description: email
+      - name: user
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_groups
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        default:
+          description: ''
+          headers: {}
+    put:
+      description: 'GONE: Nitro Planting Activities API V1'
+      summary: 'GONE: Update multiple planting activities'
+      tags:
+      - legacy nitro
+      operationId: GONE:Updatemultipleplantingactivities
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-user-email
+        in: header
+        required: true
+        type: string
+        description: email
+      - name: user
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_groups
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        default:
+          description: ''
+          headers: {}
+  /legacy/umber/v1/programs.json:
+    get:
+      description: Umber API V1
+      summary: (Deprecated) Get all planting programs associated with a user
+      tags:
+      - legacy umber
+      operationId: (Deprecated)Getallplantingprogramsassociatedwithauser
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/UmberPlantingProgramsResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    post:
+      description: Umber API V1
+      summary: 'GONE: Create a new planting program'
+      tags:
+      - legacy umber
+      operationId: GONE:Createanewplantingprogram
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        '201':
+          description: Created
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/programs/{id}.json:
+    delete:
+      description: Umber API V1
+      summary: 'GONE: Delete a program'
+      tags:
+      - legacy umber
+      operationId: GONE:Deleteaprogram
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: program id
+      - name: last-updated-at
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    get:
+      description: Umber API V1
+      summary: (Deprecated) Get a program
+      tags:
+      - legacy umber
+      operationId: (Deprecated)Getaprogram
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: program id
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/UmberPlantingProgramResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: Umber API V1
+      summary: 'GONE: Update a planting program'
+      tags:
+      - legacy umber
+      operationId: GONE:Updateaplantingprogram
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: program id
+      - name: last-updated-at
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: Umber API V1
+      summary: 'GONE: Update a planting program1'
+      tags:
+      - legacy umber
+      operationId: GONE:Updateaplantingprogram1
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: program id
+      - name: last-updated-at
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/programs/query.json:
+    post:
+      description: Umber API V1
+      summary: (Deprecated) Get programs by id
+      tags:
+      - legacy umber
+      operationId: (Deprecated)Getprogramsbyid
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: ProgramQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ProgramQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/UmberPlantingProgramsResponse'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/profiles/apply-program.json:
+    post:
+      description: Umber API V1
+      summary: 'GONE: Apply a program to a collection of field profiles'
+      tags:
+      - legacy umber
+      operationId: GONE:Applyaprogramtoacollectionoffieldprofiles
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/profiles/remove-program.json:
+    post:
+      description: Umber API V1
+      summary: 'GONE: Remove a program from a collection of profiles'
+      tags:
+      - legacy umber
+      operationId: GONE:Removeaprogramfromacollectionofprofiles
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/profiles/programs/{program-id}.json:
+    get:
+      description: Umber API V1
+      summary: (Deprecated) Retrieve all profiles for a program
+      tags:
+      - legacy umber
+      operationId: (Deprecated)Retrieveallprofilesforaprogram
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: program-id
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: program id
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/UmberProgramFieldsResponse'
+          headers: {}
+        '404':
+          description: NOT Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/profiles/fields/query.json:
+    post:
+      description: Umber API V1
+      summary: (Deprecated) Query for profile information by field IDs
+      tags:
+      - legacy umber
+      operationId: (Deprecated)QueryforprofileinformationbyfieldIDs
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: UmberFieldProfileQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/UmberFieldProfileQuery'
+      - name: full-profile
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/UmberFieldPlantingProfiles'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/profiles/fields/{field_id}/product-years/{product_year}.json:
+    delete:
+      description: Umber API V1
+      summary: 'GONE: Delete a field profile'
+      tags:
+      - legacy umber
+      operationId: GONE:Deleteafieldprofile
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product_year
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: last-updated-at
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    get:
+      description: Umber API V1
+      summary: (Deprecated) Get a field profile
+      tags:
+      - legacy umber
+      operationId: (Deprecated)Getafieldprofile
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product_year
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: full-profile
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/UmberFieldPlantingProfile'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: Umber API V1
+      summary: 'GONE: Create or update a field profile'
+      tags:
+      - legacy umber
+      operationId: GONE:Createorupdateafieldprofile
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product_year
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: last-updated-at
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/profiles/fields/{field_id}/fmz/{fmz_id}/zones/query.json:
+    post:
+      description: Umber API V1
+      summary: (Deprecated) Query for profile information by zone IDs
+      tags:
+      - legacy umber
+      operationId: (Deprecated)QueryforprofileinformationbyzoneIDs
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: fmz_id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: full-profile
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: UmberZoneProfilesQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/UmberZoneProfilesQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/UmberZoneProfileResponse'
+          headers: {}
+        '500':
+          description: Sever Error
+          headers: {}
+  /legacy/umber/v1/profiles/fields/{field_id}/fmz/{fmz_id}/zones/{zone_id}/product-years/{product_year}.json:
+    delete:
+      description: Umber API V1
+      summary: 'GONE: Delete a zone profile'
+      tags:
+      - legacy umber
+      operationId: GONE:Deleteazoneprofile
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: fmz_id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: zone_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product_year
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: last-updated-at
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    get:
+      description: Umber API V1
+      summary: (Deprecated) Get a zone profile
+      tags:
+      - legacy umber
+      operationId: (Deprecated)Getazoneprofile
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: fmz_id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: zone_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product_year
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: full-profile
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/UmberZoneProfile'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: Umber API V1
+      summary: 'GONE: Create or update a zone profile'
+      tags:
+      - legacy umber
+      operationId: GONE:Createorupdateazoneprofile
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: field_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: fmz_id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: zone_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product_year
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: last-updated-at
+        in: query
+        required: false
+        type: string
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /legacy/umber/v1/profiles/fields/{field_id}/fmz/{fmz_id}/zones/edit-planting.json:
+    post:
+      description: Umber API V1
+      summary: (Deprecated) Update planting information for a zone in a field
+      tags:
+      - legacy umber
+      operationId: (Deprecated)Updateplantinginformationforazoneinafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: x-http-caller-id
+        in: header
+        required: false
+        type: string
+        description: ''
+      - name: field_id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: fmz_id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: UmberPlantingEdits
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/UmberPlantingEdits'
+      responses:
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/validations/product-years/{product-year}:
+    get:
+      description: '**DEPRECATED - Please use GET /v3/validations**'
+      summary: (Deprecated) Get planting-specific validations for a given product year
+      tags:
+      - v1
+      operationId: (Deprecated)Getplanting-specificvalidationsforagivenproductyear
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: if-none-match
+        in: header
+        required: false
+        type: string
+        description: Etag identifier
+      - name: product-year
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        '304':
+          description: Not Modified
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/best/fields/{field-id}:
+    get:
+      description: '**DEPRECATED - Please use GET /v3/fields**'
+      summary: (Deprecated) Best-available planting estimate for a field
+      tags:
+      - v1
+      operationId: (Deprecated)Best-availableplantingestimateforafield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product-year
+        in: query
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: event-type
+        in: query
+        required: false
+        enum:
+        - planned
+        - recorded
+        - all
+        - actual
+        type: string
+      - name: include-plantings
+        in: query
+        required: false
+        type: boolean
+        description: If false, exclude "plantings" to save bandwidth
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/BestResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/best/fields/{field-id}/fmz/{fmz-id}:
+    get:
+      description: '**DEPRECATED - Please use GET /v3/fields/fmz/{fmz-id}**'
+      summary: (Deprecated) Best-available planting estimate for a field's FMZ zones
+      tags:
+      - v1
+      operationId: (Deprecated)Best-availableplantingestimateforafield'sFMZzones
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: fmz-id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: product-year
+        in: query
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: event-type
+        in: query
+        required: false
+        enum:
+        - planned
+        - recorded
+        - all
+        - actual
+        type: string
+      - name: include-plantings
+        in: query
+        required: false
+        type: boolean
+        description: If false, exclude "plantings" to save bandwidth
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/BestFmzResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/best/fields/query:
+    post:
+      description: '**DEPRECATED - Please use POST /v3/fields**'
+      summary: (Deprecated) Best-available planting estimate for a field
+      tags:
+      - v1
+      operationId: Post(Deprecated)Best-availableplantingestimateforafield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      - name: product-year
+        in: query
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: event-type
+        in: query
+        required: false
+        enum:
+        - planned
+        - recorded
+        - all
+        - actual
+        type: string
+      - name: include-plantings
+        in: query
+        required: false
+        type: boolean
+        description: If false, exclude "plantings" to save bandwidth
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/BestQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/best/fields/fmz/query:
+    post:
+      description: '**DEPRECATED - Please use POST /v3/fields/fmz/query**'
+      summary: (Deprecated) Best-available planting estimate for a field's FMZ zones
+      tags:
+      - v1
+      operationId: Post(Deprecated)Best-availableplantingestimateforafield'sFMZzones
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: FieldsFmzsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsFmzsQuery'
+      - name: product-year
+        in: query
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: event-type
+        in: query
+        required: false
+        enum:
+        - planned
+        - recorded
+        - all
+        - actual
+        type: string
+      - name: include-plantings
+        in: query
+        required: false
+        type: boolean
+        description: If false, exclude "plantings" to save bandwidth
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/BestFmzQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/programs:
+    get:
+      description: '**DEPRECATED - Please use GET /v3/programs**'
+      summary: (Deprecated) Get all planned planting programs
+      tags:
+      - v1
+      operationId: (Deprecated)Getallplannedplantingprograms
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-invisible
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    post:
+      description: (Deprecated) Create a planned planting event
+      summary: (Deprecated) Create a planned planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Createaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: NewProgram
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewProgram'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/programs/query:
+    post:
+      description: '**DEPRECATED - Please use POST /v3/programs/query**'
+      summary: (Deprecated) Get many planned planting programs by ID
+      tags:
+      - v1
+      operationId: (Deprecated)GetmanyplannedplantingprogramsbyID
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: ProgramsQueryRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ProgramsQueryRequest'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/programs/{id}:
+    get:
+      description: '**DEPRECATED - Please use GET /v3/programs/{id}**'
+      summary: (Deprecated) Get an individual planned planting program
+      tags:
+      - v1
+      operationId: (Deprecated)Getanindividualplannedplantingprogram
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    delete:
+      description: '**DEPRECATED - Please use DELETE /v3/programs**'
+      summary: (Deprecated) Remove a planned planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Removeaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/DeletedResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: (Deprecated) Patch a planned planting event
+      summary: (Deprecated) Patch a planned planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Patchaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: ProgramPatchInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ProgramPatchInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: (Deprecated) Update a planned planting event
+      summary: (Deprecated) Update a planned planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Updateaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: ProgramInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ProgramInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/programs/{id}/fields:
+    get:
+      description: (Deprecated) Get list of field associatd with a program
+      summary: (Deprecated) Get list of field associatd with a program
+      tags:
+      - v1
+      operationId: (Deprecated)Getlistoffieldassociatdwithaprogram
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramFieldsResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/fields/query:
+    post:
+      description: (Deprecated) Get planned planting events for many fields
+      summary: (Deprecated) Get planned planting events for many fields
+      tags:
+      - v1
+      operationId: (Deprecated)Getplannedplantingeventsformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FieldPlanQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/fields/{field-id}:
+    get:
+      description: (Deprecated) Get planned planting events for one field
+      summary: (Deprecated) Get planned planting events for one field
+      tags:
+      - v1
+      operationId: (Deprecated)Getplannedplantingeventsforonefield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FieldPlan'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/apply-program:
+    post:
+      description: (Deprecated) Apply a program to one or more fields
+      summary: (Deprecated) Apply a program to one or more fields
+      tags:
+      - v1
+      operationId: (Deprecated)Applyaprogramtooneormorefields
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: product-year
+        in: query
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: ApplyProgramRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ApplyProgramRequest'
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/remove-program:
+    post:
+      description: (Deprecated) Remove planting program from one or more fields
+      summary: (Deprecated) Remove planting program from one or more fields
+      tags:
+      - v1
+      operationId: (Deprecated)Removeplantingprogramfromoneormorefields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: product-year
+        in: query
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      - name: RemoveProgramRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/RemoveProgramRequest'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RemoveProgramResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/apply-prescription:
+    post:
+      description: '(Deprecated) GONE: Apply a prescription to a field'
+      summary: '(Deprecated) GONE: Apply a prescription to a field'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Applyaprescriptiontoafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: product-year
+        in: query
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/prescriptions/fields/query:
+    post:
+      description: '(Deprecated) GONE: Get all planned planting prescriptions for many fields'
+      summary: '(Deprecated) GONE: Get all planned planting prescriptions for many fields'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Getallplannedplantingprescriptionsformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/prescriptions/fields/{field-id}:
+    get:
+      description: '(Deprecated) GONE: Get all planned planting prescriptions for a field'
+      summary: '(Deprecated) GONE: Get all planned planting prescriptions for a field'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Getallplannedplantingprescriptionsforafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/prescriptions/query:
+    post:
+      description: '(Deprecated) GONE: Get many planned planting prescriptions by ID'
+      summary: '(Deprecated) GONE: Get many planned planting prescriptions by ID'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:GetmanyplannedplantingprescriptionsbyID
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/prescriptions/{id}:
+    get:
+      description: '(Deprecated) GONE: Get an individual planned planting prescription'
+      summary: '(Deprecated) GONE: Get an individual planned planting prescription'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Getanindividualplannedplantingprescription
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+    delete:
+      description: '(Deprecated) GONE: Remove a planned planting event'
+      summary: '(Deprecated) GONE: Remove a planned planting event'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Removeaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: '(Deprecated) GONE: Update or create a planned planting event'
+      summary: '(Deprecated) GONE: Update or create a planned planting event'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Updateorcreateaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/PrescriptionResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: '(Deprecated) GONE: Patch a planned planting event'
+      summary: '(Deprecated) GONE: Patch a planned planting event'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Patchaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/PrescriptionResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/prescriptions:
+    post:
+      description: '(Deprecated) GONE: Create a planting prescription'
+      summary: '(Deprecated) GONE: Create a planting prescription'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Createaplantingprescription
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/PrescriptionResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/fields/{field-id}/programs:
+    patch:
+      description: (Deprecated) Patch a planting program for a field
+      summary: (Deprecated) Patch a planting program for a field
+      tags:
+      - v1
+      operationId: (Deprecated)Patchaplantingprogramforafield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: NewProgramPatch
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewProgramPatch'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FieldPlan'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    post:
+      description: (Deprecated) Set a planting program for a field
+      summary: (Deprecated) Set a planting program for a field
+      tags:
+      - v1
+      operationId: (Deprecated)Setaplantingprogramforafield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: NewProgram
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewProgram'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FieldPlan'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/planned/fields/{field-id}/prescriptions:
+    patch:
+      description: '(Deprecated) GONE: Patch a prescription for a field'
+      summary: '(Deprecated) GONE: Patch a prescription for a field'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Patchaprescriptionforafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    post:
+      description: '(Deprecated) GONE: Set a prescription for a field'
+      summary: '(Deprecated) GONE: Set a prescription for a field'
+      tags:
+      - v1
+      operationId: (Deprecated)GONE:Setaprescriptionforafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/actual/events/query:
+    post:
+      description: '**DEPRECATED - Please use POST /v3**'
+      summary: (Deprecated) Get many machine-observed actual planting events by ID
+      tags:
+      - v1
+      operationId: (Deprecated)Getmanymachine-observedactualplantingeventsbyID
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-source
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: ActualEventQueryRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ActualEventQueryRequest'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/actual/events/{id}:
+    get:
+      description: '**DEPRECATED - Please use GET /v3**'
+      summary: (Deprecated) Get an individual machine-observed actual planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Getanindividualmachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-source
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    delete:
+      description: '**DEPRECATED - Please use DELETE /v3**'
+      summary: (Deprecated) Remove a machine-observed actual planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Removeamachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/DeletedResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: '**DEPRECATED - Please use PATCH /v3**'
+      summary: (Deprecated) Patch a machine-observed actual planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Patchamachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: ActualEventPatchInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ActualEventPatchInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: '**DEPRECATED - Please use PUT /v3**'
+      summary: (Deprecated) Update a machine-observed actual planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Updateamachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: ActualEventInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ActualEventInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/actual/events:
+    post:
+      description: '**DEPRECATED - Please use POST /v3**'
+      summary: (Deprecated) Create a machine-observed actual planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Createamachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: NewActualEvent
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewActualEvent'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/actual/fields/query:
+    post:
+      description: '**DEPRECATED - Please use POST /v3**'
+      summary: (Deprecated) Get machine-observed actual planting events for many fields
+      tags:
+      - v1
+      operationId: (Deprecated)Getmachine-observedactualplantingeventsformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-source
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventFieldsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/actual/fields/{field-id}:
+    get:
+      description: '**DEPRECATED - Please use GET /v3**'
+      summary: (Deprecated) Get machine-observed actual planting events for one field
+      tags:
+      - v1
+      operationId: (Deprecated)Getmachine-observedactualplantingeventsforonefield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-source
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventFieldResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/recorded/events/query:
+    post:
+      description: (Deprecated) Get many human-provided recorded planting events by ID
+      summary: (Deprecated) Get many human-provided recorded planting events by ID
+      tags:
+      - v1
+      operationId: (Deprecated)Getmanyhuman-providedrecordedplantingeventsbyID
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return events updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: RecordedEventQueryRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/RecordedEventQueryRequest'
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/recorded/events/{id}:
+    get:
+      description: (Deprecated) Get an individual human-provided recorded planting event
+      summary: (Deprecated) Get an individual human-provided recorded planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Getanindividualhuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    delete:
+      description: (Deprecated) Remove a human-provided recorded planting event
+      summary: (Deprecated) Remove a human-provided recorded planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Removeahuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/DeletedResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: (Deprecated) PATCH a human-provided recorded planting event
+      summary: (Deprecated) PATCH a human-provided recorded planting event
+      tags:
+      - v1
+      operationId: (Deprecated)PATCHahuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: RecordedEventPatchInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/RecordedEventPatchInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: (Deprecated) Update a human-provided recorded planting event
+      summary: (Deprecated) Update a human-provided recorded planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Updateahuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: RecordedEventInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/RecordedEventInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/recorded/events:
+    post:
+      description: (Deprecated) Create a human-provided recorded planting event
+      summary: (Deprecated) Create a human-provided recorded planting event
+      tags:
+      - v1
+      operationId: (Deprecated)Createahuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: NewRecordedEvent
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewRecordedEvent'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/recorded/fields/query:
+    post:
+      description: (Deprecated) Get human-provided recorded planting events for many fields
+      summary: (Deprecated) Get human-provided recorded planting events for many fields
+      tags:
+      - v1
+      operationId: (Deprecated)Gethuman-providedrecordedplantingeventsformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return events updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventFieldsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/recorded/fields/{field-id}:
+    get:
+      description: (Deprecated) Get human-provided recorded planting events for one field
+      summary: (Deprecated) Get human-provided recorded planting events for one field
+      tags:
+      - v1
+      operationId: (Deprecated)Gethuman-providedrecordedplantingeventsforonefield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return events updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventFieldResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/all-events/fields/query:
+    post:
+      description: '**DEPRECATED - Please use POST /v3/fields/query**'
+      summary: (Deprecated) Get all planting events of all types for many fields
+      tags:
+      - v1
+      operationId: (Deprecated)Getallplantingeventsofalltypesformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: user-agent
+        in: header
+        required: false
+        type: string
+        description: ''
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/AllEventsFieldsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v1/all-events/fields/{field-id}:
+    get:
+      description: '**DEPRECATED - Please use GET /v3/fields**'
+      summary: (Deprecated) Get all planting events of all types for one field
+      tags:
+      - v1
+      operationId: (Deprecated)Getallplantingeventsofalltypesforonefield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return events updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/AllEventsFieldResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v2/validations/product-years/{product-year}:
+    get:
+      description: (Deprecated) Get planting-specific validations for a given product year
+      summary: (Deprecated) Get planting-specific validations for a given product year
+      tags:
+      - v2-validations
+      - v2
+      operationId: Get(Deprecated)Getplanting-specificvalidationsforagivenproductyear
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: if-none-match
+        in: header
+        required: false
+        type: string
+        description: Etag identifier
+      - name: product-year
+        in: path
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        '304':
+          description: Not Modified
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/validations/seasons/{season}:
+    get:
+      description: (Deprecated) Get planting-specific validations for a given product year
+      summary: (Deprecated) Get planting-specific validations for a given product year
+      tags:
+      - v3-validations
+      - v3
+      operationId: Get(Deprecated)Getplanting-specificvalidationsforagivenproductyear1
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: if-none-match
+        in: header
+        required: false
+        type: string
+        description: Etag identifier
+      - name: season
+        in: path
+        required: true
+        type: string
+        description: ''
+      responses:
+        '304':
+          description: Not Modified
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/best/fields/{field-id}:
+    get:
+      description: '**DEPRECATED - There will be no further development work on /v3/best/fields/{field-id}**'
+      summary: (Deprecated) Best-available planting estimate for a field
+      tags:
+      - v3
+      - v3-best
+      operationId: Get(Deprecated)Best-availableplantingestimateforafield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: event-type
+        in: query
+        required: false
+        enum:
+        - planned
+        - recorded
+        - all
+        - actual
+        type: string
+      - name: include-plantings
+        in: query
+        required: false
+        type: boolean
+        description: If false, exclude "plantings" to save bandwidth
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/BestResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/best/fields/{field-id}/fmz/{fmz-id}:
+    get:
+      description: '**DEPRECATED - There will be no further work on /v3/best/fields/{fmz-id}**'
+      summary: (Deprecated) Best-available planting estimate for a field's FMZ zones
+      tags:
+      - v3
+      - v3-best
+      operationId: Get(Deprecated)Best-availableplantingestimateforafield'sFMZzones
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: fmz-id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: event-type
+        in: query
+        required: false
+        enum:
+        - planned
+        - recorded
+        - all
+        - actual
+        type: string
+      - name: include-plantings
+        in: query
+        required: false
+        type: boolean
+        description: If false, exclude "plantings" to save bandwidth
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/BestFmzResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/best/fields/query:
+    post:
+      description: '**DEPRECATED - There will be no further work on /fields/query**'
+      summary: (Deprecated) Best-available planting estimate for a field
+      tags:
+      - v3
+      - v3-best
+      operationId: Post(Deprecated)Best-availableplantingestimateforafield1
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: start-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: end-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: event-type
+        in: query
+        required: false
+        enum:
+        - planned
+        - recorded
+        - all
+        - actual
+        type: string
+      - name: include-plantings
+        in: query
+        required: false
+        type: boolean
+        description: If false, exclude "plantings" to save bandwidth
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/BestQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/best/fields/fmz/query:
+    post:
+      description: '**DEPRECATED - There will be no further work on /fields/fmz/query**'
+      summary: (Deprecated) Best-available planting estimate for a field's FMZ zones
+      tags:
+      - v3
+      - v3-best
+      operationId: Post(Deprecated)Best-availableplantingestimateforafield'sFMZzones1
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: FieldsFmzsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsFmzsQuery'
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: event-type
+        in: query
+        required: false
+        enum:
+        - planned
+        - recorded
+        - all
+        - actual
+        type: string
+      - name: include-plantings
+        in: query
+        required: false
+        type: boolean
+        description: If false, exclude "plantings" to save bandwidth
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/BestFmzQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/recorded/events/query:
+    post:
+      description: (Deprecated) Get many human-provided recorded planting events by ID
+      summary: (Deprecated) Get many human-provided recorded planting events by ID
+      tags:
+      - v3
+      - v3-recorded
+      operationId: Post(Deprecated)Getmanyhuman-providedrecordedplantingeventsbyID
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return events updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: RecordedEventQueryRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/RecordedEventQueryRequest'
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/recorded/events/{id}:
+    get:
+      description: (Deprecated) Get an individual human-provided recorded planting event
+      summary: (Deprecated) Get an individual human-provided recorded planting event
+      tags:
+      - v3
+      - v3-recorded
+      operationId: Get(Deprecated)Getanindividualhuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    delete:
+      description: (Deprecated) Remove a human-provided recorded planting event
+      summary: (Deprecated) Remove a human-provided recorded planting event
+      tags:
+      - v3
+      - v3-recorded
+      operationId: Delete(Deprecated)Removeahuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/DeletedResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: (Deprecated) PATCH a human-provided recorded planting event
+      summary: (Deprecated) PATCH a human-provided recorded planting event
+      tags:
+      - v3
+      - v3-recorded
+      operationId: Patch(Deprecated)PATCHahuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: RecordedEventPatchInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/RecordedEventPatchInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: (Deprecated) Update a human-provided recorded planting event
+      summary: (Deprecated) Update a human-provided recorded planting event
+      tags:
+      - v3
+      - v3-recorded
+      operationId: Put(Deprecated)Updateahuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: RecordedEventInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/RecordedEventInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/recorded/events:
+    post:
+      description: (Deprecated) Create a human-provided recorded planting event
+      summary: (Deprecated) Create a human-provided recorded planting event
+      tags:
+      - v3
+      - v3-recorded
+      operationId: Post(Deprecated)Createahuman-providedrecordedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: NewRecordedEvent
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewRecordedEvent'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/recorded/fields/query:
+    post:
+      description: (Deprecated) Get human-provided recorded planting events for many fields
+      summary: (Deprecated) Get human-provided recorded planting events for many fields
+      tags:
+      - v3
+      - v3-recorded
+      operationId: Post(Deprecated)Gethuman-providedrecordedplantingeventsformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return events updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventFieldsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/recorded/fields/{field-id}:
+    get:
+      description: (Deprecated) Get human-provided recorded planting events for one field
+      summary: (Deprecated) Get human-provided recorded planting events for one field
+      tags:
+      - v3
+      - v3-recorded
+      operationId: Get(Deprecated)Gethuman-providedrecordedplantingeventsforonefield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return events updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RecordedEventFieldResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/all-events/fields/query:
+    post:
+      description: (Deprecated) Get all planting events of all types for many fields
+      summary: (Deprecated) Get all planting events of all types for many fields
+      tags:
+      - v3
+      - v3-all-events
+      operationId: Post(Deprecated)Getallplantingeventsofalltypesformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: user-agent
+        in: header
+        required: false
+        type: string
+        description: ''
+      - name: start-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: end-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: season
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/AllEventsFieldsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/all-events/fields/{field-id}:
+    get:
+      description: (Deprecated) Get all planting events of all types for one field
+      summary: (Deprecated) Get all planting events of all types for one field
+      tags:
+      - v3
+      - v3-all-events
+      operationId: Get(Deprecated)Getallplantingeventsofalltypesforonefield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return events updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: start-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: end-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: season
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/AllEventsFieldResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/migrations/seasons/{command}:
+    get:
+      description: (Deprecated) Kick off season DB migration
+      summary: (Deprecated) Kick off season DB migration
+      tags:
+      - v3
+      - v3-migrations
+      operationId: (Deprecated)KickoffseasonDBmigration
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: if-none-match
+        in: header
+        required: false
+        type: string
+        description: Etag identifier
+      - name: init-uuid
+        in: header
+        required: false
+        type: string
+        description: UUID required to kick of migration
+      - name: command
+        in: path
+        required: true
+        enum:
+        - user-geo-table
+        - update-recorded
+        - season-table
+        - update-program
+        - geo-table
+        - program-season-table
+        - all
+        - update-actual
+        - update-profile
+        type: string
+      responses:
+        '304':
+          description: Not Modified
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/programs:
+    get:
+      description: (Deprecated) Get all planned planting programs
+      summary: (Deprecated) Get all planned planting programs
+      tags:
+      - v3-planned
+      - v3
+      operationId: Get(Deprecated)Getallplannedplantingprograms
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-invisible
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    post:
+      description: (Deprecated) Create a planned planting event
+      summary: (Deprecated) Create a planned planting event
+      tags:
+      - v3-planned
+      - v3
+      operationId: Post(Deprecated)Createaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: NewProgram
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewProgram'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/programs/query:
+    post:
+      description: (Deprecated) Get many planned planting programs by ID
+      summary: (Deprecated) Get many planned planting programs by ID
+      tags:
+      - v3-planned
+      - v3
+      operationId: Post(Deprecated)GetmanyplannedplantingprogramsbyID
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: ProgramsQueryRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ProgramsQueryRequest'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/programs/{id}:
+    get:
+      description: (Deprecated) Get an individual planned planting program
+      summary: (Deprecated) Get an individual planned planting program
+      tags:
+      - v3-planned
+      - v3
+      operationId: Get(Deprecated)Getanindividualplannedplantingprogram
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    delete:
+      description: (Deprecated) Remove a planned planting event
+      summary: (Deprecated) Remove a planned planting event
+      tags:
+      - v3-planned
+      - v3
+      operationId: Delete(Deprecated)Removeaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/DeletedResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: (Deprecated) Patch a planned planting event
+      summary: (Deprecated) Patch a planned planting event
+      tags:
+      - v3-planned
+      - v3
+      operationId: Patch(Deprecated)Patchaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: ProgramPatchInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ProgramPatchInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: (Deprecated) Update a planned planting event
+      summary: (Deprecated) Update a planned planting event
+      tags:
+      - v3-planned
+      - v3
+      operationId: Put(Deprecated)Updateaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: ProgramInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ProgramInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramResponse'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/programs/{id}/fields:
+    get:
+      description: (Deprecated) Get list of field associatd with a program
+      summary: (Deprecated) Get list of field associatd with a program
+      tags:
+      - v3-planned
+      - v3
+      operationId: Get(Deprecated)Getlistoffieldassociatdwithaprogram
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ProgramFieldsResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/fields/query:
+    post:
+      description: (Deprecated) Get planned planting events for many fields
+      summary: (Deprecated) Get planned planting events for many fields
+      tags:
+      - v3-planned
+      - v3
+      operationId: Post(Deprecated)Getplannedplantingeventsformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FieldPlanQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/fields/{field-id}:
+    get:
+      description: (Deprecated) Get planned planting events for one field
+      summary: (Deprecated) Get planned planting events for one field
+      tags:
+      - v3-planned
+      - v3
+      operationId: Get(Deprecated)Getplannedplantingeventsforonefield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: season
+        in: query
+        required: false
+        type: string
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FieldPlan'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/apply-program:
+    post:
+      description: (Deprecated) Apply a program to one or more fields
+      summary: (Deprecated) Apply a program to one or more fields
+      tags:
+      - v3-planned
+      - v3
+      operationId: Post(Deprecated)Applyaprogramtooneormorefields
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: season
+        in: query
+        required: true
+        type: string
+        description: ''
+      - name: ApplyProgramRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ApplyProgramRequest'
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/remove-program:
+    post:
+      description: (Deprecated) Remove planting program from one or more fields
+      summary: (Deprecated) Remove planting program from one or more fields
+      tags:
+      - v3-planned
+      - v3
+      operationId: Post(Deprecated)Removeplantingprogramfromoneormorefields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: season
+        in: query
+        required: true
+        type: string
+        description: ''
+      - name: RemoveProgramRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/RemoveProgramRequest'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/RemoveProgramResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/apply-prescription:
+    post:
+      description: 'GONE: Apply a prescription to a field'
+      summary: 'GONE: Apply a prescription to a field'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Applyaprescriptiontoafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: product-year
+        in: query
+        required: true
+        type: integer
+        format: int64
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/prescriptions/fields/query:
+    post:
+      description: 'GONE: Get all planned planting prescriptions for many fields'
+      summary: 'GONE: Get all planned planting prescriptions for many fields'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Getallplannedplantingprescriptionsformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/prescriptions/fields/{field-id}:
+    get:
+      description: 'GONE: Get all planned planting prescriptions for a field'
+      summary: 'GONE: Get all planned planting prescriptions for a field'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Getallplannedplantingprescriptionsforafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: product-year
+        in: query
+        required: false
+        type: integer
+        format: int64
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/prescriptions/query:
+    post:
+      description: 'GONE: Get many planned planting prescriptions by ID'
+      summary: 'GONE: Get many planned planting prescriptions by ID'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:GetmanyplannedplantingprescriptionsbyID
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/prescriptions/{id}:
+    get:
+      description: 'GONE: Get an individual planned planting prescription'
+      summary: 'GONE: Get an individual planned planting prescription'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Getanindividualplannedplantingprescription
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+    delete:
+      description: 'GONE: Remove a planned planting event'
+      summary: 'GONE: Remove a planned planting event'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Removeaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: 'GONE: Update or create a planned planting event'
+      summary: 'GONE: Update or create a planned planting event'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Updateorcreateaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/PrescriptionResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: 'GONE: Patch a planned planting event'
+      summary: 'GONE: Patch a planned planting event'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Patchaplannedplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/PrescriptionResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/prescriptions:
+    post:
+      description: 'GONE: Create a planting prescription'
+      summary: 'GONE: Create a planting prescription'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Createaplantingprescription
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/PrescriptionResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/fields/{field-id}/programs:
+    patch:
+      description: (Deprecated) Patch a planting program for a field
+      summary: (Deprecated) Patch a planting program for a field
+      tags:
+      - v3-planned
+      - v3
+      operationId: Patch(Deprecated)Patchaplantingprogramforafield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: NewProgramPatch
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewProgramPatch'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FieldPlan'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    post:
+      description: (Deprecated) Set a planting program for a field
+      summary: (Deprecated) Set a planting program for a field
+      tags:
+      - v3-planned
+      - v3
+      operationId: Post(Deprecated)Setaplantingprogramforafield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: NewProgram
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewProgram'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/FieldPlan'
+          headers: {}
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/planned/fields/{field-id}/prescriptions:
+    patch:
+      description: 'GONE: Patch a prescription for a field'
+      summary: 'GONE: Patch a prescription for a field'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Patchaprescriptionforafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    post:
+      description: 'GONE: Set a prescription for a field'
+      summary: 'GONE: Set a prescription for a field'
+      tags:
+      - v3-planned
+      - v3
+      operationId: GONE:Setaprescriptionforafield
+      deprecated: true
+      produces:
+      - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      responses:
+        '400':
+          description: Bad Request
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/actual/events/query:
+    post:
+      description: (Deprecated) Get many machine-observed actual planting events by ID
+      summary: (Deprecated) Get many machine-observed actual planting events by ID
+      tags:
+      - v3-actual
+      - v3
+      operationId: Post(Deprecated)Getmanymachine-observedactualplantingeventsbyID
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-source
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: ActualEventQueryRequest
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ActualEventQueryRequest'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/actual/events/{id}:
+    get:
+      description: (Deprecated) Get an individual machine-observed actual planting event
+      summary: (Deprecated) Get an individual machine-observed actual planting event
+      tags:
+      - v3-actual
+      - v3
+      operationId: Get(Deprecated)Getanindividualmachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-source
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    delete:
+      description: (Deprecated) Remove a machine-observed actual planting event
+      summary: (Deprecated) Remove a machine-observed actual planting event
+      tags:
+      - v3-actual
+      - v3
+      operationId: Delete(Deprecated)Removeamachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/DeletedResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    patch:
+      description: (Deprecated) Patch a machine-observed actual planting event
+      summary: (Deprecated) Patch a machine-observed actual planting event
+      tags:
+      - v3-actual
+      - v3
+      operationId: Patch(Deprecated)Patchamachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: ActualEventPatchInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ActualEventPatchInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '404':
+          description: Not Found
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+    put:
+      description: (Deprecated) Update a machine-observed actual planting event
+      summary: (Deprecated) Update a machine-observed actual planting event
+      tags:
+      - v3-actual
+      - v3
+      operationId: Put(Deprecated)Updateamachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: id
+        in: path
+        required: true
+        type: string
+        format: uuid
+        description: ''
+      - name: ActualEventInput
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/ActualEventInput'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/actual/events:
+    post:
+      description: (Deprecated) Create a machine-observed actual planting event
+      summary: (Deprecated) Create a machine-observed actual planting event
+      tags:
+      - v3-actual
+      - v3
+      operationId: Post(Deprecated)Createamachine-observedactualplantingevent
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: NewActualEvent
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/NewActualEvent'
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/actual/fields/query:
+    post:
+      description: (Deprecated) Get machine-observed actual planting events for many fields
+      summary: (Deprecated) Get machine-observed actual planting events for many fields
+      tags:
+      - v3-actual
+      - v3
+      operationId: Post(Deprecated)Getmachine-observedactualplantingeventsformanyfields
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: start-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: end-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-source
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: FieldsQuery
+        in: body
+        required: true
+        description: ''
+        schema:
+          $ref: '#/definitions/FieldsQuery'
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventFieldsQueryResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+  /v3/actual/fields/{field-id}:
+    get:
+      description: (Deprecated) Get machine-observed actual planting events for one field
+      summary: (Deprecated) Get machine-observed actual planting events for one field
+      tags:
+      - v3-actual
+      - v3
+      operationId: Get(Deprecated)Getmachine-observedactualplantingeventsforonefield
+      deprecated: true
+      produces:
+      - application/json
+      - application/x-yaml
+      - application/edn
+      - application/transit+json
+      - application/transit+msgpack
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        type: string
+        description: Base64-encoded JWT in the format "Bearer <token>"
+      - name: x-user-id
+        in: header
+        required: true
+        type: integer
+        format: int64
+        description: id
+      - name: x-http-caller-id
+        in: header
+        required: true
+        type: string
+        description: caller id
+      - name: x-http-request-id
+        in: header
+        required: false
+        type: string
+        description: request-id
+      - name: x-authenticated-user-id
+        in: header
+        required: false
+        type: integer
+        format: int64
+        description: user-id verified by auth service
+      - name: If-Modified-Since
+        in: header
+        required: false
+        type: string
+        description: Only return fields updated since this time http://www.freesoft.org/CIE/RFC/1945/58.htm
+      - name: field-id
+        in: path
+        required: true
+        type: string
+        description: ''
+      - name: start-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: end-time
+        in: query
+        required: false
+        type: string
+        description: Only return events with planting dates after this date
+      - name: include-deleted
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      - name: include-source
+        in: query
+        required: false
+        type: boolean
+        description: ''
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/ActualEventFieldResponse'
+          headers: {}
+        '500':
+          description: Server Error
+          headers: {}
+definitions:
+  ActualEventFieldResponse:
+    title: ActualEventFieldResponse
+    type: object
+    properties:
+      field-id:
+        type: string
+      field-uuid:
+        type: string
+        format: uuid
+      events:
+        type: array
+        items:
+          $ref: '#/definitions/ActualEventResponse'
+    required:
+    - field-id
+    - field-uuid
+    - events
+  ActualEventFieldsQueryResponse:
+    title: ActualEventFieldsQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/ActualEventFieldResponse'
+    required:
+    - results
+  ActualEventInput:
+    title: ActualEventInput
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      custom-crop-name:
+        type: string
+      updated-at:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      replant:
+        type: boolean
+      source-type:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      geometry:
+        $ref: '#/definitions/ActualEventInputGeometry'
+      planting-end-time:
+        type: string
+      season:
+        type: string
+      id:
+        type: string
+        format: uuid
+      population:
+        $ref: '#/definitions/Population'
+      area:
+        $ref: '#/definitions/Area'
+      source-id:
+        type: string
+      planting-start-time:
+        type: string
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+    required:
+    - seed-product
+    - planting-end-time
+    - id
+    - area
+    - planting-start-time
+    - field-id
+  ActualEventInputGeometry:
+    title: ActualEventInputGeometry
+    type: object
+    properties:
+      crs:
+        type: string
+      bbox:
+        type: array
+        items:
+          type: number
+          format: double
+      coordinates:
+        type: array
+        items:
+          type: number
+          format: double
+      type:
+        type: string
+    required:
+    - coordinates
+    - type
+  ActualEventPatchInput:
+    title: ActualEventPatchInput
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      custom-crop-name:
+        type: string
+      updated-at:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      replant:
+        type: boolean
+      source-type:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      geometry:
+        $ref: '#/definitions/ActualEventPatchInputGeometry'
+      planting-end-time:
+        type: string
+      season:
+        type: string
+      id:
+        type: string
+        format: uuid
+      population:
+        $ref: '#/definitions/Population'
+      area:
+        $ref: '#/definitions/Area'
+      source-id:
+        type: string
+      planting-start-time:
+        type: string
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+    required:
+    - id
+    - field-id
+  ActualEventPatchInputGeometry:
+    title: ActualEventPatchInputGeometry
+    type: object
+    properties:
+      crs:
+        type: string
+      bbox:
+        type: array
+        items:
+          type: number
+          format: double
+      coordinates:
+        type: array
+        items:
+          type: number
+          format: double
+      type:
+        type: string
+    required:
+    - coordinates
+    - type
+  ActualEventQueryRequest:
+    title: ActualEventQueryRequest
+    type: object
+    properties:
+      event-ids:
+        type: array
+        items:
+          type: string
+          format: uuid
+    required:
+    - event-ids
+  ActualEventQueryResponse:
+    title: ActualEventQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/ActualEventResponse'
+    required:
+    - results
+  ActualEventQueryResponseResultsGeometry:
+    title: ActualEventQueryResponseResultsGeometry
+    type: object
+    properties:
+      crs:
+        type: string
+      bbox:
+        type: array
+        items:
+          type: number
+          format: double
+      coordinates:
+        type: array
+        items:
+          type: number
+          format: double
+      type:
+        type: string
+    required:
+    - coordinates
+    - type
+  ActualEventResponse:
+    title: ActualEventResponse
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/SeedProduct'
+      updated-at:
+        type: string
+      deleted:
+        type: boolean
+      field-uuid:
+        type: string
+        format: uuid
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      replant:
+        type: boolean
+      source-type:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      geometry:
+        $ref: '#/definitions/ActualEventQueryResponseResultsGeometry'
+      planting-end-time:
+        type: string
+      cropping-year:
+        type: integer
+        format: int64
+      season:
+        type: string
+      updated-by:
+        type: integer
+        format: int64
+      created-by:
+        type: integer
+        format: int64
+      id:
+        type: string
+        format: uuid
+      population:
+        $ref: '#/definitions/Population'
+      area:
+        $ref: '#/definitions/Area'
+      source-id:
+        type: string
+      planting-start-time:
+        type: string
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+      created-at:
+        type: string
+    required:
+    - seed-product
+    - updated-at
+    - deleted
+    - field-uuid
+    - planting-end-time
+    - updated-by
+    - created-by
+    - id
+    - area
+    - planting-start-time
+    - field-id
+    - created-at
+  AllEventsFieldResponse:
+    title: AllEventsFieldResponse
+    type: object
+    properties:
+      field-id:
+        type: string
+      field-uuid:
+        type: string
+        format: uuid
+      planned:
+        $ref: '#/definitions/AllEventsFieldsQueryResponseResultsPlanned'
+      actual:
+        type: array
+        items:
+          $ref: '#/definitions/ActualEventResponse'
+      recorded:
+        type: array
+        items:
+          $ref: '#/definitions/RecordedEventResponse'
+    required:
+    - field-id
+    - field-uuid
+    - planned
+    - actual
+    - recorded
+  AllEventsFieldsQueryResponse:
+    title: AllEventsFieldsQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/AllEventsFieldResponse'
+    required:
+    - results
+  AllEventsFieldsQueryResponseResultsPlanned:
+    title: AllEventsFieldsQueryResponseResultsPlanned
+    type: object
+    properties:
+      program:
+        $ref: '#/definitions/ProgramResponse'
+      prescription:
+        $ref: '#/definitions/PrescriptionResponse'
+      created-at:
+        type: string
+      created-by:
+        type: integer
+        format: int64
+      updated-at:
+        type: string
+      updated-by:
+        type: integer
+        format: int64
+      deleted:
+        type: boolean
+  ApplyProgramRequest:
+    title: ApplyProgramRequest
+    type: object
+    properties:
+      program-id:
+        type: string
+        format: uuid
+      field-ids:
+        type: array
+        items:
+          type: string
+    required:
+    - program-id
+    - field-ids
+  Area:
+    title: Area
+    type: object
+    properties:
+      q:
+        type: number
+        format: double
+      u:
+        type: string
+        default: hectare
+    required:
+    - q
+    - u
+  BestFmzQueryResponse:
+    title: BestFmzQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/BestFmzResponse'
+    required:
+    - results
+  BestFmzResponse:
+    title: BestFmzResponse
+    type: object
+    properties:
+      field-id:
+        type: string
+      field-uuid:
+        type: string
+        format: uuid
+      fmz-id:
+        type: string
+        format: uuid
+      event-type:
+        $ref: '#/definitions/EventType'
+      product-year:
+        type: integer
+        format: int64
+      season:
+        type: string
+      zones:
+        type: array
+        items:
+          $ref: '#/definitions/BestFmzZoneResponse'
+    required:
+    - field-id
+    - field-uuid
+    - fmz-id
+    - event-type
+    - zones
+  BestFmzZoneResponse:
+    title: BestFmzZoneResponse
+    type: object
+    properties:
+      zone-id:
+        type: string
+      event-type:
+        $ref: '#/definitions/EventType'
+      dominant-planting:
+        $ref: '#/definitions/BestPlanting'
+    required:
+    - zone-id
+    - event-type
+    - dominant-planting
+  BestPlanting:
+    title: BestPlanting
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/SeedProduct'
+      target-yield:
+        $ref: '#/definitions/Yield'
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      replant:
+        type: boolean
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      fmz-id:
+        type: string
+        format: uuid
+      season:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      area:
+        $ref: '#/definitions/Area'
+  BestQueryResponse:
+    title: BestQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/BestResponse'
+    required:
+    - results
+  BestResponse:
+    title: BestResponse
+    type: object
+    properties:
+      field-id:
+        type: string
+      field-uuid:
+        type: string
+        format: uuid
+      updated-at:
+        type: string
+      event-type:
+        $ref: '#/definitions/EventType'
+      dominant-planting:
+        $ref: '#/definitions/BestPlanting'
+      product-year:
+        type: integer
+        format: int64
+      season:
+        type: string
+      plantings:
+        type: array
+        items:
+          $ref: '#/definitions/BestPlanting'
+    required:
+    - field-id
+    - field-uuid
+    - updated-at
+    - event-type
+    - dominant-planting
+  DeletedResponse:
+    title: DeletedResponse
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      deleted:
+        type: boolean
+    required:
+    - id
+    - deleted
+  FieldPlan:
+    title: FieldPlan
+    type: object
+    properties:
+      updated-at:
+        type: string
+      deleted:
+        type: boolean
+      field-uuid:
+        type: string
+        format: uuid
+      source-type:
+        type: string
+      updated-by:
+        type: integer
+        format: int64
+      created-by:
+        type: integer
+        format: int64
+      prescription:
+        $ref: '#/definitions/PrescriptionResponse'
+      field-area:
+        $ref: '#/definitions/Area'
+      source-id:
+        type: string
+      field-id:
+        type: string
+      created-at:
+        type: string
+      program:
+        $ref: '#/definitions/ProgramResponse'
+    required:
+    - field-uuid
+    - field-area
+    - field-id
+  FieldPlanQueryResponse:
+    title: FieldPlanQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/FieldPlan'
+    required:
+    - results
+  FieldsFmzsQuery:
+    title: FieldsFmzsQuery
+    type: object
+    properties:
+      field-fmz-ids:
+        type: array
+        items:
+          $ref: '#/definitions/FieldsFmzsQueryFieldFmzIds'
+    required:
+    - field-fmz-ids
+  FieldsFmzsQueryFieldFmzIds:
+    title: FieldsFmzsQueryFieldFmzIds
+    type: object
+    properties:
+      field-id:
+        type: string
+      fmz-id:
+        type: string
+        format: uuid
+    required:
+    - field-id
+    - fmz-id
+  FieldsQuery:
+    title: FieldsQuery
+    type: object
+    properties:
+      field-ids:
+        type: array
+        items:
+          type: string
+    required:
+    - field-ids
+  NewActualEvent:
+    title: NewActualEvent
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      custom-crop-name:
+        type: string
+      updated-at:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      replant:
+        type: boolean
+      source-type:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      geometry:
+        $ref: '#/definitions/NewActualEventGeometry'
+      planting-end-time:
+        type: string
+      season:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      area:
+        $ref: '#/definitions/Area'
+      source-id:
+        type: string
+      planting-start-time:
+        type: string
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+    required:
+    - seed-product
+    - planting-end-time
+    - area
+    - planting-start-time
+    - field-id
+  NewActualEventGeometry:
+    title: NewActualEventGeometry
+    type: object
+    properties:
+      crs:
+        type: string
+      bbox:
+        type: array
+        items:
+          type: number
+          format: double
+      coordinates:
+        type: array
+        items:
+          type: number
+          format: double
+      type:
+        type: string
+    required:
+    - coordinates
+    - type
+  NewProgram:
+    title: NewProgram
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      updated-at:
+        type: string
+      target-yield:
+        $ref: '#/definitions/Yield'
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      product-year:
+        type: integer
+        format: int64
+      visible:
+        type: boolean
+  NewProgramPatch:
+    title: NewProgramPatch
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      updated-at:
+        type: string
+      target-yield:
+        $ref: '#/definitions/Yield'
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      product-year:
+        type: integer
+        format: int64
+      visible:
+        type: boolean
+  NewRecordedEvent:
+    title: NewRecordedEvent
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      updated-at:
+        type: string
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      source-type:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      cropping-year:
+        type: integer
+        format: int64
+      fmz-id:
+        type: string
+        format: uuid
+      season:
+        type: string
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      zone-id:
+        type: string
+      area:
+        $ref: '#/definitions/Area'
+      source-id:
+        type: string
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+    required:
+    - field-id
+  Population:
+    title: Population
+    type: object
+    properties:
+      q:
+        type: number
+        format: double
+      u:
+        $ref: '#/definitions/U'
+    required:
+    - q
+    - u
+  PrescriptionResponse:
+    title: PrescriptionResponse
+    type: object
+    properties:
+      updated-at:
+        type: string
+      deleted:
+        type: boolean
+      field-uuid:
+        type: string
+        format: uuid
+      name:
+        type: string
+      fmz-id:
+        type: string
+        format: uuid
+      updated-by:
+        type: integer
+        format: int64
+      created-by:
+        type: integer
+        format: int64
+      id:
+        type: string
+        format: uuid
+      notes:
+        type: string
+      zones:
+        type: array
+        items:
+          $ref: '#/definitions/ZoneProgram'
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+      created-at:
+        type: string
+    required:
+    - field-uuid
+    - fmz-id
+    - id
+    - zones
+    - field-id
+    - product-year
+  ProgramFieldsResponse:
+    title: ProgramFieldsResponse
+    type: object
+    properties:
+      program-id:
+        type: string
+        format: uuid
+      field-ids:
+        type: array
+        items:
+          type: string
+    required:
+    - program-id
+    - field-ids
+  ProgramInput:
+    title: ProgramInput
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      updated-at:
+        type: string
+      target-yield:
+        $ref: '#/definitions/Yield'
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      id:
+        type: string
+        format: uuid
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      product-year:
+        type: integer
+        format: int64
+      visible:
+        type: boolean
+    required:
+    - id
+  ProgramPatchInput:
+    title: ProgramPatchInput
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      updated-at:
+        type: string
+      target-yield:
+        $ref: '#/definitions/Yield'
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      id:
+        type: string
+        format: uuid
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      product-year:
+        type: integer
+        format: int64
+      visible:
+        type: boolean
+    required:
+    - id
+  ProgramQuery:
+    title: ProgramQuery
+    type: object
+    properties:
+      field-ids:
+        type: array
+        items:
+          type: string
+      program-ids:
+        type: array
+        items:
+          type: integer
+          format: int64
+      product-year:
+        type: integer
+        format: int64
+      type:
+        $ref: '#/definitions/Type'
+      visible:
+        type: boolean
+      include-owned: {}
+      include-zones: {}
+  ProgramResponse:
+    title: ProgramResponse
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/SeedProduct'
+      updated-at:
+        type: string
+      deleted:
+        type: boolean
+      target-yield:
+        $ref: '#/definitions/Yield'
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      source-type:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      updated-by:
+        type: integer
+        format: int64
+      created-by:
+        type: integer
+        format: int64
+      id:
+        type: string
+        format: uuid
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      source-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+      visible:
+        type: boolean
+      created-at:
+        type: string
+    required:
+    - id
+  ProgramsQueryRequest:
+    title: ProgramsQueryRequest
+    type: object
+    properties:
+      program-ids:
+        type: array
+        items:
+          type: string
+          format: uuid
+    required:
+    - program-ids
+  ProgramsQueryResponse:
+    title: ProgramsQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/ProgramResponse'
+    required:
+    - results
+  RM:
+    title: RM
+    type: object
+    properties:
+      q:
+        type: string
+      u:
+        type: string
+    required:
+    - q
+    - u
+  RecordedEventFieldResponse:
+    title: RecordedEventFieldResponse
+    type: object
+    properties:
+      field-id:
+        type: string
+      field-uuid:
+        type: string
+        format: uuid
+      events:
+        type: array
+        items:
+          $ref: '#/definitions/RecordedEventResponse'
+    required:
+    - field-id
+    - field-uuid
+    - events
+  RecordedEventFieldsQueryResponse:
+    title: RecordedEventFieldsQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/RecordedEventFieldResponse'
+    required:
+    - results
+  RecordedEventInput:
+    title: RecordedEventInput
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      updated-at:
+        type: string
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      source-type:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      cropping-year:
+        type: integer
+        format: int64
+      fmz-id:
+        type: string
+        format: uuid
+      season:
+        type: string
+      id:
+        type: string
+        format: uuid
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      zone-id:
+        type: string
+      area:
+        $ref: '#/definitions/Area'
+      source-id:
+        type: string
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+    required:
+    - id
+    - field-id
+  RecordedEventPatchInput:
+    title: RecordedEventPatchInput
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/ValidatedSeedProduct'
+      updated-at:
+        type: string
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      source-type:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      cropping-year:
+        type: integer
+        format: int64
+      fmz-id:
+        type: string
+        format: uuid
+      season:
+        type: string
+      id:
+        type: string
+        format: uuid
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      zone-id:
+        type: string
+      area:
+        $ref: '#/definitions/Area'
+      source-id:
+        type: string
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+    required:
+    - id
+    - field-id
+  RecordedEventQueryRequest:
+    title: RecordedEventQueryRequest
+    type: object
+    properties:
+      event-ids:
+        type: array
+        items:
+          type: string
+          format: uuid
+    required:
+    - event-ids
+  RecordedEventQueryResponse:
+    title: RecordedEventQueryResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/RecordedEventResponse'
+    required:
+    - results
+  RecordedEventResponse:
+    title: RecordedEventResponse
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/SeedProduct'
+      updated-at:
+        type: string
+      deleted:
+        type: boolean
+      date:
+        type: string
+      field-uuid:
+        type: string
+        format: uuid
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      cropping-year:
+        type: integer
+        format: int64
+      fmz-id:
+        type: string
+        format: uuid
+      season:
+        type: string
+      updated-by:
+        type: integer
+        format: int64
+      created-by:
+        type: integer
+        format: int64
+      id:
+        type: string
+        format: uuid
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      zone-id:
+        type: string
+      area:
+        $ref: '#/definitions/Area'
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+      created-at:
+        type: string
+    required:
+    - updated-at
+    - deleted
+    - field-uuid
+    - updated-by
+    - created-by
+    - id
+    - field-id
+    - created-at
+  RemoveProgramRequest:
+    title: RemoveProgramRequest
+    type: object
+    properties:
+      field-ids:
+        type: array
+        items:
+          type: string
+    required:
+    - field-ids
+  RemoveProgramResponse:
+    title: RemoveProgramResponse
+    type: object
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/RemoveProgramResponseResults'
+    required:
+    - results
+  RemoveProgramResponseResults:
+    title: RemoveProgramResponseResults
+    type: object
+    properties:
+      field-id:
+        type: string
+      field-uuid:
+        type: string
+        format: uuid
+      product-year:
+        type: integer
+        format: int64
+    required:
+    - field-id
+    - field-uuid
+    - product-year
+  SeedProduct:
+    title: SeedProduct
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      brand:
+        type: string
+      name:
+        type: string
+  Treatment:
+    title: Treatment
+    type: object
+    properties:
+      type:
+        type: string
+      q:
+        type: number
+        format: double
+      u:
+        type: string
+    required:
+    - type
+    - q
+    - u
+  UmberFieldPlantingProfile:
+    title: UmberFieldPlantingProfile
+    type: object
+    properties:
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+      created-at:
+        type: string
+      updated-at:
+        type: string
+      planting-program:
+        type: string
+    required:
+    - field-id
+    - product-year
+  UmberFieldPlantingProfiles:
+    title: UmberFieldPlantingProfiles
+    type: object
+    properties:
+      profiles:
+        type: array
+        items:
+          $ref: '#/definitions/UmberFieldPlantingProfile'
+    required:
+    - profiles
+  UmberFieldProfileQuery:
+    title: UmberFieldProfileQuery
+    type: object
+    properties:
+      product-year:
+        type: integer
+        format: int64
+      field-ids:
+        type: array
+        items:
+          type: string
+      updated-since:
+        type: string
+    required:
+    - product-year
+  UmberPlantingEdit:
+    title: UmberPlantingEdit
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/UmberPlantingEditsPlantingEditsSeedProduct'
+      updated-at:
+        type: string
+      liquid-application:
+        $ref: '#/definitions/UmberPlantingEditsPlantingEditsLiquidApplication'
+      target-yield:
+        $ref: '#/definitions/UmberPlantingEditsPlantingEditsTargetYield'
+      color:
+        type: string
+      name:
+        type: string
+      population:
+        $ref: '#/definitions/UmberPlantingEditsPlantingEditsPopulation'
+      zone-id:
+        type: string
+      visible:
+        type: boolean
+      crop:
+        type: string
+      created-at:
+        type: string
+      planting-date:
+        type: string
+      rm:
+        $ref: '#/definitions/UmberPlantingEditsPlantingEditsRm'
+    required:
+    - zone-id
+  UmberPlantingEdits:
+    title: UmberPlantingEdits
+    type: object
+    properties:
+      product-year:
+        type: integer
+        format: int64
+      planting-edits:
+        type: array
+        items:
+          $ref: '#/definitions/UmberPlantingEdit'
+    required:
+    - product-year
+    - planting-edits
+  UmberPlantingEditsPlantingEditsLiquidApplication:
+    title: UmberPlantingEditsPlantingEditsLiquidApplication
+    type: object
+    properties:
+      value:
+        type: number
+        format: double
+      unit:
+        type: string
+    required:
+    - value
+    - unit
+  UmberPlantingEditsPlantingEditsPopulation:
+    title: UmberPlantingEditsPlantingEditsPopulation
+    type: object
+    properties:
+      value:
+        type: number
+        format: double
+      unit:
+        type: string
+    required:
+    - value
+  UmberPlantingEditsPlantingEditsRm:
+    title: UmberPlantingEditsPlantingEditsRm
+    type: object
+    properties:
+      value:
+        type: string
+      unit:
+        type: string
+    required:
+    - value
+  UmberPlantingEditsPlantingEditsSeedProduct:
+    title: UmberPlantingEditsPlantingEditsSeedProduct
+    type: object
+    properties:
+      brand:
+        type: string
+      name:
+        type: string
+      id:
+        type: integer
+        format: int64
+  UmberPlantingEditsPlantingEditsTargetYield:
+    title: UmberPlantingEditsPlantingEditsTargetYield
+    type: object
+    properties:
+      value:
+        type: number
+        format: double
+      unit:
+        type: string
+    required:
+    - value
+  UmberPlantingProgramResponse:
+    title: UmberPlantingProgramResponse
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/UmberPlantingProgramsResponseProgramsSeedProduct'
+      updated-at:
+        type: string
+      liquid-application:
+        $ref: '#/definitions/UmberPlantingProgramsResponseProgramsLiquidApplication'
+      target-yield:
+        $ref: '#/definitions/UmberPlantingProgramsResponseProgramsTargetYield'
+      color:
+        type: string
+      name:
+        type: string
+      type:
+        type: string
+        default: planting-program
+      id:
+        type: string
+      population:
+        $ref: '#/definitions/UmberPlantingProgramsResponseProgramsPopulation'
+      product-year:
+        type: integer
+        format: int64
+      visible:
+        type: boolean
+      crop:
+        type: string
+      created-at:
+        type: string
+      planting-date:
+        type: string
+      rm:
+        $ref: '#/definitions/UmberPlantingProgramsResponseProgramsRm'
+    required:
+    - type
+    - id
+    - product-year
+  UmberPlantingProgramsResponse:
+    title: UmberPlantingProgramsResponse
+    type: object
+    properties:
+      programs:
+        type: array
+        items:
+          $ref: '#/definitions/UmberPlantingProgramResponse'
+    required:
+    - programs
+  UmberPlantingProgramsResponseProgramsLiquidApplication:
+    title: UmberPlantingProgramsResponseProgramsLiquidApplication
+    type: object
+    properties:
+      value:
+        type: number
+        format: double
+      unit:
+        type: string
+    required:
+    - value
+    - unit
+  UmberPlantingProgramsResponseProgramsPopulation:
+    title: UmberPlantingProgramsResponseProgramsPopulation
+    type: object
+    properties:
+      value:
+        type: number
+        format: double
+      unit:
+        type: string
+    required:
+    - value
+  UmberPlantingProgramsResponseProgramsRm:
+    title: UmberPlantingProgramsResponseProgramsRm
+    type: object
+    properties:
+      value:
+        type: string
+      unit:
+        type: string
+    required:
+    - value
+  UmberPlantingProgramsResponseProgramsSeedProduct:
+    title: UmberPlantingProgramsResponseProgramsSeedProduct
+    type: object
+    properties:
+      brand:
+        type: string
+      name:
+        type: string
+      id:
+        type: integer
+        format: int64
+  UmberPlantingProgramsResponseProgramsTargetYield:
+    title: UmberPlantingProgramsResponseProgramsTargetYield
+    type: object
+    properties:
+      value:
+        type: number
+        format: double
+      unit:
+        type: string
+    required:
+    - value
+  UmberProgramFieldsResponse:
+    title: UmberProgramFieldsResponse
+    type: object
+    properties:
+      field-profiles:
+        type: array
+        items:
+          $ref: '#/definitions/UmberProgramFieldsResponseFieldProfiles'
+      zone-profiles:
+        type: array
+        items:
+          $ref: '#/definitions/UmberProgramFieldsResponseZoneProfiles'
+  UmberProgramFieldsResponseFieldProfiles:
+    title: UmberProgramFieldsResponseFieldProfiles
+    type: object
+    properties:
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+      planting-program:
+        $ref: '#/definitions/UmberProgramFieldsResponseFieldProfilesPlantingProgram'
+    required:
+    - field-id
+    - product-year
+    - planting-program
+  UmberProgramFieldsResponseFieldProfilesPlantingProgram:
+    title: UmberProgramFieldsResponseFieldProfilesPlantingProgram
+    type: object
+    properties:
+      id:
+        type: string
+    required:
+    - id
+  UmberProgramFieldsResponseZoneProfiles:
+    title: UmberProgramFieldsResponseZoneProfiles
+    type: object
+    properties:
+      field-id:
+        type: string
+      fmz-id:
+        type: string
+        format: uuid
+      zone-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+      planting-program:
+        $ref: '#/definitions/UmberProgramFieldsResponseZoneProfilesPlantingProgram'
+    required:
+    - field-id
+    - fmz-id
+    - zone-id
+    - product-year
+    - planting-program
+  UmberProgramFieldsResponseZoneProfilesPlantingProgram:
+    title: UmberProgramFieldsResponseZoneProfilesPlantingProgram
+    type: object
+    properties:
+      id:
+        type: string
+    required:
+    - id
+  UmberZoneProfile:
+    title: UmberZoneProfile
+    type: object
+    properties:
+      fmz-id:
+        type: string
+        format: uuid
+      zone-id:
+        type: string
+      field-id:
+        type: string
+      product-year:
+        type: integer
+        format: int64
+      created-at:
+        type: string
+      updated-at:
+        type: string
+      planting-program:
+        type: string
+    required:
+    - fmz-id
+    - zone-id
+    - field-id
+    - product-year
+  UmberZoneProfileResponse:
+    title: UmberZoneProfileResponse
+    type: object
+    properties:
+      profiles:
+        type: array
+        items:
+          $ref: '#/definitions/UmberZoneProfile'
+    required:
+    - profiles
+  UmberZoneProfilesQuery:
+    title: UmberZoneProfilesQuery
+    type: object
+    properties:
+      product-year:
+        type: integer
+        format: int64
+      zone-ids:
+        type: array
+        items:
+          type: string
+    required:
+    - product-year
+  ValidatedSeedProduct:
+    title: ValidatedSeedProduct
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      brand:
+        type: string
+      name:
+        type: string
+  Yield:
+    title: Yield
+    type: object
+    properties:
+      q:
+        type: number
+        format: double
+      u:
+        type: string
+    required:
+    - q
+    - u
+  ZoneProgram:
+    title: ZoneProgram
+    type: object
+    properties:
+      seed-product:
+        $ref: '#/definitions/SeedProduct'
+      updated-at:
+        type: string
+      deleted:
+        type: boolean
+      target-yield:
+        $ref: '#/definitions/Yield'
+      date:
+        type: string
+      treatments:
+        type: array
+        items:
+          $ref: '#/definitions/Treatment'
+      name:
+        type: string
+      relative-maturity:
+        $ref: '#/definitions/RM'
+      crop-id:
+        type: integer
+        format: int64
+      updated-by:
+        type: integer
+        format: int64
+      created-by:
+        type: integer
+        format: int64
+      notes:
+        type: string
+      population:
+        $ref: '#/definitions/Population'
+      zone-id:
+        type: string
+      area:
+        $ref: '#/definitions/Area'
+      product-year:
+        type: integer
+        format: int64
+      visible:
+        type: boolean
+      created-at:
+        type: string
+    required:
+    - zone-id
+    - area
+  EventType:
+    title: EventType
+    type: string
+    enum:
+    - planned
+    - recorded
+    - all
+    - actual
+  Type:
+    title: Type
+    type: string
+    enum:
+    - planting-program
+  U:
+    title: U
+    type: string
+    enum:
+    - kg/hectare
+    - seed/hectare
+tags:
+- name: core
+  description: ''
+- name: legacy nitro
+  description: ''
+- name: legacy umber
+  description: ''
+- name: v1
+  description: ''
+- name: v2-validations
+  description: ''
+- name: v3-validations
+  description: ''
+- name: v3
+  description: ''
+- name: v3-planned
+  description: ''
+- name: v3-actual
+  description: ''

--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -553,6 +553,23 @@ func generateFixtures(_ testing.TB) map[string]generateFixture {
 				)
 			},
 		},
+		"tag_package_name_issue_2866": {
+			spec:   "../fixtures/bugs/2866/2866.yaml",
+			target: "server-2866",
+			prepare: func(_ *testing.T, opts *GenOpts) {
+				opts.MainPackage = "nrcodegen-server"
+				opts.IncludeMain = true
+				opts.ValidateSpec = true
+			},
+			verify: func(t *testing.T, target string) {
+				location := filepath.Join(target, "cmd", "nrcodegen-server")
+				require.True(t, fileExists("", location))
+
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
* fixes #2866

This PR addresses that case when tags used to generate a package to hold a group of operations are of the special form v[0-9]+.

This form is interpreted by go imports so that "x/v1" resolves as "x" in the program.

To fix the problem, "v[nnn]" package names are renamed "version[nnn]".