### PR TITLE
fix(markdown): handled multi-lines blocks in descriptions

### DIFF
--- a/fixtures/bugs/2700/2700.yaml
+++ b/fixtures/bugs/2700/2700.yaml
@@ -1,0 +1,33 @@
+---
+swagger: "2.0"
+info:
+  description: someTest
+  title: test
+  version: "0.0.0"
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /upload:
+    post:
+      operationId: someTest
+      responses:
+        200:
+          description: Successful upload
+          schema:
+            $ref: "#/definitions/myModel"
+
+definitions:
+ myModel:
+   type: object
+   properties:
+     fsType:
+       description: |-
+         Filesystem type of the volume that you want to mount.
+         Tip: Ensure that the filesystem type is supported by the host operating system.
+         Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+         More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+         TODO: how do we prevent errors in the filesystem from compromising the machine
+

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -140,21 +140,43 @@ func TestBaseImport(t *testing.T) {
 func TestGenerateMarkdown(t *testing.T) {
 	defer discardOutput()()
 
-	opts := testGenOpts()
-	opts.Spec = "../fixtures/enhancements/184/fixture-184.yaml"
-	output := filepath.Join(t.TempDir(), "markdown.md")
+	t.Run("should generate doc for demo fixture", func(t *testing.T) {
+		opts := testGenOpts()
+		opts.Spec = "../fixtures/enhancements/184/fixture-184.yaml"
+		output := filepath.Join(t.TempDir(), "markdown.md")
 
-	require.NoError(t, GenerateMarkdown(output, nil, nil, opts))
-	expectedCode := []string{
-		"# Markdown generator demo",
-	}
-
-	code, err := os.ReadFile(output)
-	require.NoError(t, err)
-
-	for line, codeLine := range expectedCode {
-		if !assertInCode(t, strings.TrimSpace(codeLine), string(code)) {
-			t.Logf("Code expected did not match in codegenfile %s for expected line %d: %q", output, line, expectedCode[line])
+		require.NoError(t, GenerateMarkdown(output, nil, nil, opts))
+		expectedCode := []string{
+			"# Markdown generator demo",
 		}
-	}
+
+		code, err := os.ReadFile(output)
+		require.NoError(t, err)
+
+		for line, codeLine := range expectedCode {
+			if !assertInCode(t, strings.TrimSpace(codeLine), string(code)) {
+				t.Logf("Code expected did not match in codegenfile %s for expected line %d: %q", output, line, expectedCode[line])
+			}
+		}
+	})
+
+	t.Run("should handle new lines in descriptions", func(t *testing.T) {
+		opts := testGenOpts()
+		opts.Spec = "../fixtures/bugs/2700/2700.yaml"
+		output := filepath.Join(t.TempDir(), "markdown.md")
+
+		require.NoError(t, GenerateMarkdown(output, nil, nil, opts))
+		expectedCode := []string{
+			`| Filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore</br></br>TODO: how do we prevent errors in the filesystem from compromising the machine |`,
+		}
+
+		code, err := os.ReadFile(output)
+		require.NoError(t, err)
+
+		for line, codeLine := range expectedCode {
+			if !assertInCode(t, strings.TrimSpace(codeLine), string(code)) {
+				t.Logf("Code expected did not match in codegenfile %s for expected line %d: %q", output, line, expectedCode[line])
+			}
+		}
+	})
 }

--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -134,6 +134,7 @@ func DefaultFuncMap(lang *LanguageOpts) template.FuncMap {
 		},
 		"docCollectionFormat": resolvedDocCollectionFormat,
 		"trimSpace":           strings.TrimSpace,
+		"mdBlock":             markdownBlock, // markdown block
 		"httpStatus":          httpStatus,
 		"cleanupEnumVariant":  cleanupEnumVariant,
 		"gt0":                 gt0,
@@ -931,4 +932,14 @@ func errorPath(in interface{}) (string, error) {
 	}
 
 	return pth, nil
+}
+
+const mdNewLine = "</br>"
+
+var mdNewLineReplacer = strings.NewReplacer("\r\n", mdNewLine, "\n", mdNewLine, "\r", mdNewLine)
+
+func markdownBlock(in string) string {
+	in = strings.TrimSpace(in)
+
+	return mdNewLineReplacer.Replace(in)
 }

--- a/generator/templates/markdown/docs.gotmpl
+++ b/generator/templates/markdown/docs.gotmpl
@@ -2,18 +2,18 @@
   {{- with .ExternalDocs }}
     {{- if .URL }}
       {{- if .Description }}
-> [{{ trimSpace .Description }}]({{ .URL }})
+> [{{ mdBlock .Description }}]({{ .URL }})
       {{- else }}
 > [Read more]({{ .URL }})
       {{- end }}
     {{- else }}
-> {{ trimSpace .Description }}
+> {{ mdBlock .Description }}
     {{- end }}
   {{- end }}
 {{- end }}
 
 {{- define "docParam" }}{{/* renders a parameter with simple schema */}}
-| {{ .Name }} | `{{ .Location }}` | {{ paramDocType . }} | `{{ .GoType }}` | {{ if .CollectionFormat }}`{{ docCollectionFormat .CollectionFormat .Child }}`{{ end }} | {{ if .Required }}✓{{ end }} | {{ if .Default }}`{{ json .Default }}`{{ end }} | {{ trimSpace .Description }} |
+| {{ .Name }} | `{{ .Location }}` | {{ paramDocType . }} | `{{ .GoType }}` | {{ if .CollectionFormat }}`{{ docCollectionFormat .CollectionFormat .Child }}`{{ end }} | {{ if .Required }}✓{{ end }} | {{ if .Default }}`{{ json .Default }}`{{ end }} | {{ mdBlock .Description }} |
 {{- end }}
 
 {{- define "docModelSchema" }}{{/* renders a schema */}}
@@ -46,7 +46,7 @@
   {{- else if and .IsAliased .IsPrimitive (not .IsSuperAlias) -}}
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| {{ .Name }} | {{ schemaDocType . }}| {{ .AliasedType }} | {{ if .Default }}`{{ json .Default }}`{{ end }}| {{ trimSpace .Description }} | {{ if .Example }}`{{ .Example }}`{{ end }} |
+| {{ .Name }} | {{ schemaDocType . }}| {{ .AliasedType }} | {{ if .Default }}`{{ json .Default }}`{{ end }}| {{ mdBlock .Description }} | {{ if .Example }}`{{ .Example }}`{{ end }} |
 {{ printf "\n" }}
   {{- else if or (and .IsAliased (not (.IsAdditionalProperties))) (and .IsComplexObject (not .Properties) (not .AllOf)) -}}
 [{{- dropPackage .GoType }}](#{{ dasherize (dropPackage .GoType) -}})
@@ -71,7 +71,7 @@ any
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
       {{- range .Properties }}
-| {{ .Name }} | {{ template "docSchemaSimple" . }}| `{{ .GoType }}` | {{ if .Required }}✓{{ end }} | {{ if .Default }}`{{ json .Default }}`{{ end }}| {{ trimSpace .Description }} | {{ if .Example }}`{{ .Example }}`{{ end }} |
+| {{ .Name }} | {{ template "docSchemaSimple" . }}| `{{ .GoType }}` | {{ if .Required }}✓{{ end }} | {{ if .Default }}`{{ json .Default }}`{{ end }}| {{ mdBlock .Description }} | {{ if .Example }}`{{ .Example }}`{{ end }} |
       {{- end }}
 {{ printf "\n" }}
     {{- end }}
@@ -86,7 +86,7 @@ any
 
 | Type | Go type | Default | Description | Example |
 |------|---------| ------- |-------------|---------|
-| {{ template "docSchemaSimple" . }} | `{{ .GoType }}` |{{ if .Default }}`{{ json .Default }}`{{ end }}| {{ trimSpace .Description }} | {{ if .Example }}`{{ .Example }}`{{ end }} |
+| {{ template "docSchemaSimple" . }} | `{{ .GoType }}` |{{ if .Default }}`{{ json .Default }}`{{ end }}| {{ mdBlock .Description }} | {{ if .Example }}`{{ .Example }}`{{ end }} |
         {{- else }}
 
 {{ template "docModelSchema" . }}
@@ -104,7 +104,7 @@ any
 
 | Type | Go type | Default | Description | Example |
 |------|---------| ------- |-------------|---------|
-| {{ template "docSchemaSimple" . }} | `{{ .GoType }}` |{{ if .Default }}`{{ json .Default }}`{{ end }}| {{ trimSpace .Description }} | {{ if .Example }}`{{ .Example }}`{{ end }} |
+| {{ template "docSchemaSimple" . }} | `{{ .GoType }}` |{{ if .Default }}`{{ json .Default }}`{{ end }}| {{ mdBlock .Description }} | {{ if .Example }}`{{ .Example }}`{{ end }} |
         {{- else }}
 
 {{ template "docModelSchema" . }}
@@ -161,7 +161,7 @@ any
 {{- end }}
 
 {{- define "docModelBodyParam" }}{{/* layout for body param schema */}}
-| {{ .Name }} | `body` | {{ template "docSchemaSimple" .Schema }} | `{{ .Schema.GoType }}` | | {{ if .Required }}✓{{ end }} | {{ if .Default }}`{{ json .Default }}`{{ end }}| {{ trimSpace .Description }} |
+| {{ .Name }} | `body` | {{ template "docSchemaSimple" .Schema }} | `{{ .Schema.GoType }}` | | {{ if .Required }}✓{{ end }} | {{ if .Default }}`{{ json .Default }}`{{ end }}| {{ mdBlock .Description }} |
 {{- end }}
 
 {{- define "docHeaders" }}{{/* renders response headers */}}
@@ -169,7 +169,7 @@ any
 | Name | Type | Go type | Separator | Default | Description |
 |------|------|---------|-----------|---------|-------------|
     {{- range .Headers }}
-| {{ .Name }} | {{ headerDocType . }} | `{{ .GoType }}` | {{ if .CollectionFormat }}`{{ docCollectionFormat .CollectionFormat .Child }}`{{ end }} | {{ if .Default }}`{{ json .Default }}`{{ end }} | {{ trimSpace .Description }} |
+| {{ .Name }} | {{ headerDocType . }} | `{{ .GoType }}` | {{ if .CollectionFormat }}`{{ docCollectionFormat .CollectionFormat .Child }}`{{ end }} | {{ if .Default }}`{{ json .Default }}`{{ end }} | {{ mdBlock .Description }} |
     {{- end }}
   {{- end }}
 {{- end }}
@@ -350,7 +350,7 @@ Name | Description
 {{- range .Operations }}
  {{- $opname := .Name }}
 
-### <span id="{{ dasherize .Name }}"></span> {{ if .Summary }}{{ trimSpace .Summary }}{{ else }}{{ humanize .Name }}{{ end }} (*{{ .Name }}*)
+### <span id="{{ dasherize .Name }}"></span> {{ if .Summary }}{{ mdBlock .Summary }}{{ else }}{{ humanize .Name }}{{ end }} (*{{ .Name }}*)
 
 ```
 {{ upper .Method }} {{ joinPath .BasePath .Path }}
@@ -424,16 +424,16 @@ Name | Description
 | Code | Status | Description | Has headers | Schema |
 |------|--------|-------------|:-----------:|--------|
 {{- range .Responses }}
-| [{{.Code}}](#{{ dasherize $opname }}-{{ .Code }}) | {{ httpStatus .Code }} | {{ trimSpace .Description }} | {{ if .Headers }}✓{{ end }} | [schema](#{{ dasherize $opname }}-{{ .Code }}-schema) |
+| [{{.Code}}](#{{ dasherize $opname }}-{{ .Code }}) | {{ httpStatus .Code }} | {{ mdBlock .Description }} | {{ if .Headers }}✓{{ end }} | [schema](#{{ dasherize $opname }}-{{ .Code }}-schema) |
 {{- end }}
 {{- with .DefaultResponse }}
-| [default](#{{ dasherize $opname }}-default) | | {{ trimSpace .Description }} | {{ if .Headers }}✓{{ end }} | [schema](#{{ dasherize $opname }}-default-schema) |
+| [default](#{{ dasherize $opname }}-default) | | {{ mdBlock .Description }} | {{ if .Headers }}✓{{ end }} | [schema](#{{ dasherize $opname }}-default-schema) |
 {{- end }}
 
 #### Responses
 {{ range .Responses }}
 
-##### <span id="{{ dasherize $opname }}-{{ .Code }}"></span> {{.Code}}{{ if .Description }} - {{ trimSpace .Description }}{{ end }}
+##### <span id="{{ dasherize $opname }}-{{ .Code }}"></span> {{.Code}}{{ if .Description }} - {{ mdBlock .Description }}{{ end }}
 Status: {{ httpStatus .Code }}
 
 ###### <span id="{{ dasherize $opname }}-{{ .Code }}-schema"></span> Schema
@@ -462,7 +462,7 @@ Status: {{ httpStatus .Code }}
 {{- with .DefaultResponse }}
 
 ##### <span id="{{ dasherize $opname }}-default"></span> Default Response
-{{ trimSpace .Description }}
+{{ mdBlock .Description }}
 
 ###### <span id="{{ dasherize $opname }}-default-schema"></span> Schema
   {{- if .Schema }}


### PR DESCRIPTION
* fixes #2700

This PR introduces a new template function to replace new lines (or carriage returns) in descriptions by "</br>" tags in the generated markdown.

I could verify that this renders correctly on github markdown.