### PR TITLE
fix(cli): deconflicted names for variables and funcs

### DIFF
--- a/fixtures/bugs/2650/2650.yaml
+++ b/fixtures/bugs/2650/2650.yaml
@@ -1,0 +1,57 @@
+swagger: "2.0"
+info:
+  contact:
+    email: support@swagger.com
+    name: API Support
+    url: https://swagger.com
+  title: My API
+  version: "1.0"
+host: swagger.com:80
+basePath: /api/v1
+paths:
+  /api/runner:
+    get:
+      consumes:
+        - application/json
+      operationId: Get Runner
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/Runner'
+      tags:
+        - Runner
+    post:
+      consumes:
+        - application/json
+      operationId: Post Runner
+      produces:
+        - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/Runner'
+
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: '#/definitions/RunnerGroup'
+      tags:
+        - Runner
+definitions:
+  Runner:
+    properties:
+      group_name:
+        type: string
+    type: object
+  RunnerGroup:
+    properties:
+      name:
+        description: Name should be unique per tenant
+        type: string
+    type: object

--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -139,6 +139,30 @@ func DefaultFuncMap(lang *LanguageOpts) template.FuncMap {
 		"cleanupEnumVariant":  cleanupEnumVariant,
 		"gt0":                 gt0,
 		"path":                errorPath,
+		"cmdName": func(in interface{}) (string, error) {
+			// builds the name of a CLI command for a single operation
+			op, isOperation := in.(GenOperation)
+			if !isOperation {
+				ptr, ok := in.(*GenOperation)
+				if !ok {
+					return "", fmt.Errorf("cmdName should be called on a GenOperation, but got: %T", in)
+				}
+				op = *ptr
+			}
+			name := "Operation" + pascalize(op.Package) + pascalize(op.Name) + "Cmd"
+
+			return name, nil // TODO
+		},
+		"cmdGroupName": func(in interface{}) (string, error) {
+			// builds the name of a group of CLI commands
+			opGroup, ok := in.(GenOperationGroup)
+			if !ok {
+				return "", fmt.Errorf("cmdGroupName should be called on a GenOperationGroup, but got: %T", in)
+			}
+			name := "GroupOfOperations" + pascalize(opGroup.Name) + "Cmd"
+
+			return name, nil // TODO
+		},
 	}
 
 	for k, v := range extra {

--- a/generator/templates/cli/cli.gotmpl
+++ b/generator/templates/cli/cli.gotmpl
@@ -89,7 +89,7 @@ func makeClient(cmd *cobra.Command, args []string) (*client.{{ pascalize .Name }
 // MakeRootCmd returns the root cmd
 func MakeRootCmd() (*cobra.Command, error) {
 	cobra.OnInitialize(initViperConfigs)
-	
+
 	// Use executable name as the command name
 	rootCmd := &cobra.Command{
 		Use: exeName,
@@ -117,13 +117,12 @@ func MakeRootCmd() (*cobra.Command, error) {
 	}
 	{{- end }}
 	// add all operation groups
-{{- range .OperationGroups -}}
-	{{- $operationGroupCmdVarName := printf "operationGroup%vCmd" (pascalize .Name) }}
-	{{ $operationGroupCmdVarName }}, err := makeOperationGroup{{ pascalize .Name }}Cmd()
+{{- range $index,$element := .OperationGroups }}
+	c{{ $index }}, err := make{{ cmdGroupName $element }}()
 	if err != nil {
 		return nil, err
 	}
-	rootCmd.AddCommand({{ $operationGroupCmdVarName }})
+	rootCmd.AddCommand(c{{ $index}})
 {{ end }}
 
 	// add cobra completion
@@ -157,7 +156,7 @@ func initViperConfigs() {
 }
 
 {{- if .SecurityDefinitions }}
-{{- /*youyuan: rework this since spec may define multiple auth schemes. 
+{{- /*youyuan: rework this since spec may define multiple auth schemes.
 	cli needs to detect which one user passed rather than add all of them.*/}}
 // registerAuthInoWriterFlags registers all flags needed to perform authentication
 func registerAuthInoWriterFlags(cmd *cobra.Command) error {
@@ -205,7 +204,7 @@ func makeAuthInfoWriter(cmd *cobra.Command) (runtime.ClientAuthInfoWriter, error
 	{{- end }}
 	{{- if .IsOAuth2 }}
 	if viper.IsSet("oauth2-token") {
-		// oauth2 workflow for generated CLI is not ideal. 
+		// oauth2 workflow for generated CLI is not ideal.
 		// If you have suggestions on how to support it, raise an issue here: https://github.com/go-swagger/go-swagger/issues
 		// This will be added to header: "Authorization: Bearer {oauth2-token value}"
 		token := viper.GetString("oauth2-token")
@@ -223,20 +222,19 @@ func makeAuthInfoWriter(cmd *cobra.Command) (runtime.ClientAuthInfoWriter, error
 {{- end }}
 
 {{ range .OperationGroups -}}
-func makeOperationGroup{{ pascalize .Name }}Cmd() (*cobra.Command, error) {
-	{{- $operationGroupCmdVarName := printf "operationGroup%vCmd" (pascalize .Name) }}
-	{{ $operationGroupCmdVarName }} := &cobra.Command{
+// make{{ cmdGroupName . }} returns a parent command to handle all operations with tag {{ printf "%q" .Name }}
+func make{{ cmdGroupName . }}() (*cobra.Command, error) {
+	parent := &cobra.Command{
 		Use:   "{{ .Name }}",
 		Long:  `{{ .Description }}`,
 	}
-{{ range .Operations }}
-	{{- $operationCmdVarName := printf "operation%vCmd" (pascalize .Name) }}
-	{{ $operationCmdVarName }}, err := makeOperation{{pascalize .Package}}{{ pascalize .Name }}Cmd()
+{{ range $index,$element := .Operations }}
+	sub{{ $index }}, err := make{{ cmdName $element }}()
 	if err != nil {
 		return nil, err
 	}
-	{{ $operationGroupCmdVarName }}.AddCommand({{ $operationCmdVarName }})
+	parent.AddCommand(sub{{ $index }})
 {{ end }}
-	return {{ $operationGroupCmdVarName }}, nil
+	return parent, nil
 }
 {{ end }} {{/*operation group*/}}

--- a/generator/templates/cli/operation.gotmpl
+++ b/generator/templates/cli/operation.gotmpl
@@ -19,8 +19,8 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 )
 
-// makeOperation{{pascalize .Package}}{{ pascalize .Name }}Cmd returns a cmd to handle operation {{ camelize .Name }}
-func makeOperation{{pascalize .Package}}{{ pascalize .Name }}Cmd() (*cobra.Command, error) {
+// make{{ cmdName . }} returns a command to handle operation {{ camelize .Name }}
+func make{{ cmdName . }}() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "{{ .Name }}",
 		Short: `{{ escapeBackticks .Description}}`,

--- a/generator/templates/cli/schema.gotmpl
+++ b/generator/templates/cli/schema.gotmpl
@@ -85,14 +85,14 @@ func registerModel{{pascalize .Name}}Flags(depth int, cmdPrefix string, cmd *cob
     // register anonymous fields for {{.Name}}
             {{ $anonName := .Name }}
             {{ range .Properties }}
-    if err := register{{ pascalize $modelName }}Anon{{pascalize $anonName }}{{ pascalize .Name }}(depth, cmdPrefix, cmd); err != nil{
+    if err := register{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascalize .Name }}(depth, cmdPrefix, cmd); err != nil{
         return err
     }
             {{ end }}
         {{ end }}
     {{ end }}
     {{ range .Properties }}
-    if err := register{{ pascalize $modelName }}{{ pascalize .Name }}(depth, cmdPrefix, cmd); err != nil{
+    if err := register{{ pascalize $modelName }}Prop{{ pascalize .Name }}(depth, cmdPrefix, cmd); err != nil{
         return err
     }
     {{ end }}
@@ -104,7 +104,7 @@ func registerModel{{pascalize .Name}}Flags(depth int, cmdPrefix string, cmd *cob
 // inline definition name {{ .Name }}, type {{.GoType}}
         {{ $anonName := .Name }}
         {{ range .Properties }}
-func register{{ pascalize $modelName }}Anon{{pascalize $anonName }}{{ pascalize .Name }}(depth int, cmdPrefix string, cmd *cobra.Command) error {
+func register{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascalize .Name }}(depth int, cmdPrefix string, cmd *cobra.Command) error {
     if depth > maxDepth {
         return nil
     }
@@ -117,7 +117,7 @@ func register{{ pascalize $modelName }}Anon{{pascalize $anonName }}{{ pascalize 
 
 {{/*register functions for each fields in this model */}}
 {{ range .Properties }}
-func register{{ pascalize $modelName }}{{ pascalize .Name }}(depth int, cmdPrefix string, cmd *cobra.Command) error{
+func register{{ pascalize $modelName }}Prop{{ pascalize .Name }}(depth int, cmdPrefix string, cmd *cobra.Command) error{
     if depth > maxDepth {
         return nil
     }
@@ -145,7 +145,7 @@ func retrieveModel{{pascalize $modelName }}Flags(depth int, m *{{if containsPkgS
     // retrieve allOf {{.Name}} fields
             {{ $anonName := .Name }}
             {{ range .Properties }}
-    err, {{camelize .Name}}Added := retrieve{{ pascalize $modelName }}Anon{{pascalize $anonName }}{{ pascalize .Name }}Flags(depth, m, cmdPrefix, cmd)
+    err, {{camelize .Name}}Added := retrieve{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascalize .Name }}Flags(depth, m, cmdPrefix, cmd)
     if err != nil{
         return err, false
     }
@@ -154,7 +154,7 @@ func retrieveModel{{pascalize $modelName }}Flags(depth int, m *{{if containsPkgS
         {{- end }}
     {{ end }}
     {{ range .Properties }}
-        err, {{ camelize .Name }}Added := retrieve{{pascalize $modelName }}{{pascalize .Name }}Flags(depth, m, cmdPrefix, cmd)
+        err, {{ camelize .Name }}Added := retrieve{{pascalize $modelName }}Prop{{pascalize .Name }}Flags(depth, m, cmdPrefix, cmd)
         if err != nil{
             return err, false
         }
@@ -168,7 +168,7 @@ func retrieveModel{{pascalize $modelName }}Flags(depth int, m *{{if containsPkgS
 // define retrieve functions for fields for inline definition name {{ .Name }}
         {{ $anonName := .Name }}
         {{ range .Properties }} {{/*anonymous fields will be registered directly on parent model*/}}
-func retrieve{{ pascalize $modelName }}Anon{{pascalize $anonName }}{{ pascalize .Name }}Flags(depth int, m *{{if containsPkgStr $modelType}}{{ $modelType }}{{else}}{{ $modelPkg }}.{{$modelType}}{{ end }},cmdPrefix string, cmd *cobra.Command) (error,bool) {
+func retrieve{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascalize .Name }}Flags(depth int, m *{{if containsPkgStr $modelType}}{{ $modelType }}{{else}}{{ $modelPkg }}.{{$modelType}}{{ end }},cmdPrefix string, cmd *cobra.Command) (error,bool) {
     if depth > maxDepth {
         return nil, false
     }
@@ -181,7 +181,7 @@ func retrieve{{ pascalize $modelName }}Anon{{pascalize $anonName }}{{ pascalize 
 {{ end }}
 
 {{ range .Properties }}
-func retrieve{{pascalize $modelName }}{{pascalize .Name }}Flags(depth int, m *{{if $modelPkg}}{{$modelPkg}}.{{ dropPackage $modelType }}{{else}}{{ $modelType }}{{end}}, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+func retrieve{{pascalize $modelName }}Prop{{pascalize .Name }}Flags(depth int, m *{{if $modelPkg}}{{$modelPkg}}.{{ dropPackage $modelType }}{{else}}{{ $modelType }}{{end}}, cmdPrefix string, cmd *cobra.Command) (error, bool) {
     if depth > maxDepth {
         return nil, false
     }


### PR DESCRIPTION
* fixes #2650

This PR reduces the likelihood of name conflicts, by preventing generated names to be sensitive to the "same prefix" syndrome (e.g. Group + "Name" conflicts with "GroupName").

* Also reduced the amount of input-sensitive local var names, when this is not necessary.
* Tried to lighten a bit the template by handing over naming conventions to a template function.
* testing: tested manually. It seems that CLI generation is not subject to any unit tests, so not adding more with this one.