### PR TITLE
ci: added tolerance threshold on codecov reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,7 @@
 coverage:
   status:
+    project:
+      threshold: 0.1%
     patch:
       default:
         target: 80%

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,0 @@
-fail_on_violations: true
-
-go:
-  enabled: true


### PR DESCRIPTION
Codecov sometimes messes up with coverage calculations and I found it frustrating to have failing PRs because of a (fictious) -0.03% coverage degradation.

* Also removed the configuration for an ooooold linter that this repo adopted years ago. No longer in use.