### PR TITLE
golangci-lint: enable testifylint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,21 @@ linters-settings:
     check-shadowing: true
   maligned:
     suggest-new: true
+  testifylint:
+    disable:
+      - float-compare
+      - go-require
+    enable:
+      - bool-compare
+      - compares
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      - len
+      - require-error
+      - suite-dont-use-pkg
+      - suite-extra-assert-call
 
 run:
   skip-dirs:
@@ -40,6 +55,7 @@ linters:
     - misspell
     - revive
     - stylecheck
+    - testifylint
     - unconvert
   disable:
     - dupl

--- a/codescan/meta_test.go
+++ b/codescan/meta_test.go
@@ -27,14 +27,14 @@ import (
 func TestSetInfoVersion(t *testing.T) {
 	info := new(spec.Swagger)
 	err := setInfoVersion(info, []string{"0.0.1"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "0.0.1", info.Info.Version)
 }
 
 func TestSetInfoLicense(t *testing.T) {
 	info := new(spec.Swagger)
 	err := setInfoLicense(info, []string{"MIT http://license.org/MIT"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "MIT", info.Info.License.Name)
 	assert.Equal(t, "http://license.org/MIT", info.Info.License.URL)
 }
@@ -42,7 +42,7 @@ func TestSetInfoLicense(t *testing.T) {
 func TestSetInfoContact(t *testing.T) {
 	info := new(spec.Swagger)
 	err := setInfoContact(info, []string{"Homer J. Simpson <homer@simpsons.com> http://simpsons.com"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Homer J. Simpson", info.Info.Contact.Name)
 	assert.Equal(t, "homer@simpsons.com", info.Info.Contact.Email)
 	assert.Equal(t, "http://simpsons.com", info.Info.Contact.URL)
@@ -60,7 +60,7 @@ func TestParseInfo(t *testing.T) {
 
 	err = parser.Parse(fileTree.Doc)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	verifyInfo(t, swspec.Info)
 }
 
@@ -77,7 +77,7 @@ func TestParseSwagger(t *testing.T) {
 	err = parser.Parse(fileTree.Doc)
 	verifyMeta(t, swspec)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func verifyMeta(t testing.TB, doc *spec.Swagger) {
@@ -181,7 +181,7 @@ func TestMoreParseMeta(t *testing.T) {
 		}
 
 		err = parser.Parse(fileTree.Doc)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "there are no TOS at this moment, use at your own risk we take no responsibility", swspec.Info.TermsOfService)
 		/*
 			jazon, err := json.MarshalIndent(swspec.Info, "", " ")

--- a/codescan/parser_go119_test.go
+++ b/codescan/parser_go119_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSectionedParser_TitleDescriptionGo119(t *testing.T) {
@@ -25,7 +26,7 @@ The punctuation here does indeed matter. But it won't for go.
 	st := &sectionedParser{}
 	st.setTitle = func(lines []string) {}
 	err = st.Parse(ascg(text))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"This has a title that starts with a hash tag"}, st.Title())
 	assert.EqualValues(t, []string{"The punctuation here does indeed matter. But it won't for go."}, st.Description())
@@ -33,7 +34,7 @@ The punctuation here does indeed matter. But it won't for go.
 	st = &sectionedParser{}
 	st.setTitle = func(lines []string) {}
 	err = st.Parse(ascg(text2))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"This has a title without whitespace."}, st.Title())
 	assert.EqualValues(t, []string{"The punctuation here does indeed matter. But it won't for go.", "", "# There is an inline header here that doesn't count for finding a title"}, st.Description())

--- a/codescan/parser_test.go
+++ b/codescan/parser_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // only used within this group of tests but never used within actual code base.
@@ -81,7 +82,7 @@ Sample code block:
 	st := &sectionedParser{}
 	st.setTitle = func(lines []string) {}
 	err = st.Parse(ascg(text))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"This has a title, separated by a whitespace line"}, st.Title())
 	assert.EqualValues(t, []string{"In this example the punctuation for the title should not matter for swagger.", "For go it will still make a difference though."}, st.Description())
@@ -89,7 +90,7 @@ Sample code block:
 	st = &sectionedParser{}
 	st.setTitle = func(lines []string) {}
 	err = st.Parse(ascg(text2))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"This has a title without whitespace."}, st.Title())
 	assert.EqualValues(t, []string{"The punctuation here does indeed matter. But it won't for go."}, st.Description())
@@ -97,7 +98,7 @@ Sample code block:
 	st = &sectionedParser{}
 	st.setTitle = func(lines []string) {}
 	err = st.Parse(ascg(text3))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"This has a title, and markdown in the description"}, st.Title())
 	assert.EqualValues(t, []string{"See how markdown works now, we can have lists:", "", "+ first item", "+ second item", "+ third item", "", "[Links works too](http://localhost)"}, st.Description())
@@ -105,7 +106,7 @@ Sample code block:
 	st = &sectionedParser{}
 	st.setTitle = func(lines []string) {}
 	err = st.Parse(ascg(text4))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, []string{"This has whitespace sensitive markdown in the description"}, st.Title())
 	assert.EqualValues(t, []string{"+ first item", "    + nested item", "    + also nested item", "", "Sample code block:", "", "    fmt.Println(\"Hello World!\")"}, st.Description())
@@ -139,7 +140,7 @@ maximum: 20
 	}
 
 	err = st.Parse(ascg(block))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, []string{"This has a title without whitespace."}, st.Title())
 	assert.EqualValues(t, []string{"The punctuation here does indeed matter. But it won't for go."}, st.Description())
 	assert.Len(t, st.matched, 2)
@@ -157,7 +158,7 @@ maximum: 20
 	}
 
 	err = st.Parse(ascg(block2))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, []string{"This has a title without whitespace."}, st.Title())
 	assert.EqualValues(t, []string{"The punctuation here does indeed matter. But it won't for go."}, st.Description())
 	assert.Len(t, st.matched, 2)
@@ -179,7 +180,7 @@ func TestSectionedParser_Empty(t *testing.T) {
 	st.annotation = ap
 
 	err = st.Parse(ascg(block))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, st.Title())
 	assert.Empty(t, st.Description())
 	assert.Empty(t, st.taggers)
@@ -209,7 +210,7 @@ maximum: 20
 	}
 
 	err = st.Parse(ascg(block))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, []string{"This has a title without whitespace."}, st.Title())
 	assert.EqualValues(t, []string{"The punctuation here does indeed matter. But it won't for go."}, st.Description())
 	assert.Len(t, st.matched, 2)
@@ -244,7 +245,7 @@ maximum: 20
 	}
 
 	err = st.Parse(ascg(block))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, []string{"This has a title without whitespace."}, st.Title())
 	assert.EqualValues(t, []string{"The punctuation here does indeed matter. But it won't for go."}, st.Description())
 	assert.Len(t, st.matched, 1)

--- a/codescan/responses_test.go
+++ b/codescan/responses_test.go
@@ -130,7 +130,9 @@ func TestParseResponses(t *testing.T) {
 		case "active":
 			assert.Equal(t, "Active state of the record", header.Description)
 			assert.Equal(t, "boolean", header.Type)
-			assert.Equal(t, true, header.Default)
+			active, ok2 := header.Default.(bool)
+			assert.True(t, ok2)
+			assert.True(t, active)
 
 		case "created":
 			assert.Equal(t, "Created holds the time when this entry was created", header.Description)
@@ -237,7 +239,7 @@ func TestParseResponses_Issue2007(t *testing.T) {
 	require.NoError(t, prs.Build(responses))
 
 	resp := responses["GetConfiguration"]
-	require.Len(t, resp.Headers, 0)
+	require.Empty(t, resp.Headers)
 	require.NotNil(t, resp.Schema)
 
 	require.True(t, resp.Schema.Type.Contains("object"))
@@ -257,7 +259,7 @@ func TestParseResponses_Issue2011(t *testing.T) {
 	require.NoError(t, prs.Build(responses))
 
 	resp := responses["NumPlatesResp"]
-	require.Len(t, resp.Headers, 0)
+	require.Empty(t, resp.Headers)
 	require.NotNil(t, resp.Schema)
 }
 
@@ -274,8 +276,8 @@ func TestParseResponses_Issue2145(t *testing.T) {
 	}
 	require.NoError(t, prs.Build(responses))
 	resp := responses["GetProductsResponse"]
-	require.Len(t, resp.Headers, 0)
+	require.Empty(t, resp.Headers)
 	require.NotNil(t, resp.Schema)
 
-	assert.NotEqual(t, 0, len(prs.postDecls)) // should have Product
+	assert.NotEmpty(t, prs.postDecls) // should have Product
 }

--- a/codescan/routes_test.go
+++ b/codescan/routes_test.go
@@ -227,7 +227,7 @@ func TestRoutesParserBody(t *testing.T) {
 
 func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	po := ops.Paths["/pets"]
-	assert.Equal(t, 2, len(po.Post.Parameters))
+	assert.Len(t, po.Post.Parameters, 2)
 
 	// Testing standard param properties
 	p := po.Post.Parameters[0]
@@ -240,19 +240,19 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "id", p.Name)
 	assert.Equal(t, "The pet id", p.Description)
 	assert.Equal(t, "path", p.In)
-	assert.Equal(t, true, p.Required)
-	assert.Equal(t, false, p.AllowEmptyValue)
+	assert.True(t, p.Required)
+	assert.False(t, p.AllowEmptyValue)
 
 	po = ops.Paths["/orders"]
-	assert.Equal(t, 2, len(po.Post.Parameters))
+	assert.Len(t, po.Post.Parameters, 2)
 
 	// Testing invalid value for "in"
 	p = po.Post.Parameters[0]
 	assert.Equal(t, "id", p.Name)
 	assert.Equal(t, "The order id", p.Description)
 	assert.Equal(t, "", p.In) // Invalid value should not be set
-	assert.Equal(t, false, p.Required)
-	assert.Equal(t, true, p.AllowEmptyValue)
+	assert.False(t, p.Required)
+	assert.True(t, p.AllowEmptyValue)
 
 	p = po.Post.Parameters[1]
 	assert.Equal(t, "request", p.Name)
@@ -260,14 +260,14 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "The request model.", p.Description)
 
 	po = ops.Paths["/param-test"]
-	assert.Equal(t, 6, len(po.Post.Parameters))
+	assert.Len(t, po.Post.Parameters, 6)
 
 	// Testing number param with "max" and "min" constraints
 	p = po.Post.Parameters[0]
 	assert.Equal(t, "someNumber", p.Name)
 	assert.Equal(t, "some number", p.Description)
 	assert.Equal(t, "path", p.In)
-	assert.Equal(t, true, p.Required)
+	assert.True(t, p.Required)
 	assert.Equal(t, "number", p.Type)
 	min, max, def := float64(10), float64(20), float64(15)
 	assert.Equal(t, &max, p.Maximum)
@@ -280,7 +280,7 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "someQuery", p.Name)
 	assert.Equal(t, "some query values", p.Description)
 	assert.Equal(t, "query", p.In)
-	assert.Equal(t, false, p.Required)
+	assert.False(t, p.Required)
 	assert.Equal(t, "array", p.Type)
 	minLen, maxLen := int64(5), int64(20)
 	assert.Equal(t, &maxLen, p.MaxLength)
@@ -292,9 +292,11 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Equal(t, "someBoolean", p.Name)
 	assert.Equal(t, "some boolean", p.Description)
 	assert.Equal(t, "path", p.In)
-	assert.Equal(t, false, p.Required)
+	assert.False(t, p.Required)
 	assert.Equal(t, "boolean", p.Type)
-	assert.Equal(t, true, p.Default)
+	someBoolean, ok := p.Default.(bool)
+	assert.True(t, ok)
+	assert.True(t, someBoolean)
 	assert.Nil(t, p.Schema)
 
 	// Testing that "min", "max", "minLength" and "maxLength" constraints will only be considered if the right type is provided
@@ -308,7 +310,9 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 	assert.Nil(t, p.MaxLength)
 	assert.Nil(t, p.MinLength)
 	assert.Equal(t, "abcde", p.Format)
-	assert.Equal(t, false, p.Default)
+	constraintsOnInvalidType, ok2 := p.Default.(bool)
+	assert.True(t, ok2)
+	assert.False(t, constraintsOnInvalidType)
 	assert.Nil(t, p.Schema)
 
 	// Testing that when "type" is not provided, a schema will not be created

--- a/codescan/schema_go118_test.go
+++ b/codescan/schema_go118_test.go
@@ -123,7 +123,7 @@ func TestGo118ParseResponses_Issue2011(t *testing.T) {
 	require.NoError(t, prs.Build(responses))
 
 	resp := responses["NumPlatesResp"]
-	require.Len(t, resp.Headers, 0)
+	require.Empty(t, resp.Headers)
 	require.NotNil(t, resp.Schema)
 }
 

--- a/codescan/schema_test.go
+++ b/codescan/schema_test.go
@@ -880,7 +880,7 @@ func TestStructDiscriminators(t *testing.T) {
 	schema := models["animal"]
 
 	assert.Equal(t, "BaseStruct", schema.Extensions["x-go-name"])
-	assert.Equal(t, schema.Discriminator, "jsonClass")
+	assert.Equal(t, "jsonClass", schema.Discriminator)
 
 	sch := models["gazelle"]
 	assert.Len(t, sch.AllOf, 2)

--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -187,7 +187,7 @@ func Test_GenerateClient(t *testing.T) {
 			require.NoError(t, err)
 
 			opts.DumpData = true
-			assert.NoError(t,
+			require.NoError(t,
 				GenerateClient(clientName, []string{}, []string{}, opts),
 			)
 			t.Run("make sure this did not fail and we have some output", func(t *testing.T) {

--- a/generator/discriminators_test.go
+++ b/generator/discriminators_test.go
@@ -113,7 +113,7 @@ func TestGenerateModel_Discriminators(t *testing.T) {
 	assert.True(t, genModel.IsComplexObject)
 	assert.Equal(t, "petType", genModel.DiscriminatorField)
 	assert.Len(t, genModel.Discriminates, 3)
-	assert.Len(t, genModel.ExtraSchemas, 0)
+	assert.Empty(t, genModel.ExtraSchemas)
 	assert.Equal(t, "Pet", genModel.Discriminates["Pet"])
 	assert.Equal(t, "Cat", genModel.Discriminates["cat"])
 	assert.Equal(t, "Dog", genModel.Discriminates["Dog"])

--- a/generator/language_test.go
+++ b/generator/language_test.go
@@ -56,17 +56,17 @@ func TestGolang_SliceInitializer(t *testing.T) {
 
 	a0 := []interface{}{"a", "b"}
 	res, err := goSliceInitializer(a0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `{"a","b",}`, res)
 
 	a1 := []interface{}{[]interface{}{"a", "b"}, []interface{}{"c", "d"}}
 	res, err = goSliceInitializer(a1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `{{"a","b",},{"c","d",},}`, res)
 
 	a2 := map[string]interface{}{"a": "y", "b": "z"}
 	res, err = goSliceInitializer(a2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `{"a":"y","b":"z",}`, res)
 
 	_, err = goSliceInitializer(struct {
@@ -77,7 +77,7 @@ func TestGolang_SliceInitializer(t *testing.T) {
 
 	a3 := []interface{}{}
 	res, err = goSliceInitializer(a3)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `{}`, res)
 }
 

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -2367,11 +2367,11 @@ func TestGenerateModel_Xorder(t *testing.T) {
 	foundAaa := strings.Index(res, "Aaa")
 	foundBbb := strings.Index(res, "Bbb")
 	foundZzz := strings.Index(res, "Zzz")
-	assert.True(t, foundSessionID < foundDeviceID)
-	assert.True(t, foundSessionID < foundUMain)
-	assert.True(t, foundUMain < foundAaa)
-	assert.True(t, foundAaa < foundBbb)
-	assert.True(t, foundBbb < foundZzz)
+	assert.Less(t, foundSessionID, foundDeviceID)
+	assert.Less(t, foundSessionID, foundUMain)
+	assert.Less(t, foundUMain, foundAaa)
+	assert.Less(t, foundAaa, foundBbb)
+	assert.Less(t, foundBbb, foundZzz)
 }
 
 func TestGenModel_Issue1623(t *testing.T) {
@@ -2490,7 +2490,7 @@ func TestGenModel_KeepSpecPropertiesOrder(t *testing.T) {
 	orderedDefinitions := orderedSpecDoc.Spec().Definitions
 
 	genModel, err := makeGenDefinition(abcType, "models", definitions[abcType], specDoc, opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	orderGenModel, err := makeGenDefinition(abcType, "models", orderedDefinitions[abcType], orderedSpecDoc, opts)
 	require.NoError(t, err)
 
@@ -2513,28 +2513,28 @@ func TestGenModel_KeepSpecPropertiesOrder(t *testing.T) {
 	foundA := strings.Index(modelCode, "Aaa")
 	foundB := strings.Index(modelCode, "Bbb")
 	foundC := strings.Index(modelCode, "Ccc")
-	assert.True(t, foundA < foundB)
-	assert.True(t, foundB < foundC)
+	assert.Less(t, foundA, foundB)
+	assert.Less(t, foundB, foundC)
 
 	foundOrderA := strings.Index(orderModelCode, "Aaa")
 	foundOrderB := strings.Index(orderModelCode, "Bbb")
 	foundOrderC := strings.Index(orderModelCode, "Ccc")
 
-	assert.True(t, foundOrderC < foundOrderB)
-	assert.True(t, foundOrderB < foundOrderA)
+	assert.Less(t, foundOrderC, foundOrderB)
+	assert.Less(t, foundOrderB, foundOrderA)
 
 	foundInnerA := strings.Index(modelCode, "InnerAaa")
 	foundInnerB := strings.Index(modelCode, "InnerBbb")
 	foundInnerC := strings.Index(modelCode, "InnerCcc")
-	assert.True(t, foundInnerA < foundInnerB)
-	assert.True(t, foundInnerB < foundInnerC)
+	assert.Less(t, foundInnerA, foundInnerB)
+	assert.Less(t, foundInnerB, foundInnerC)
 
 	foundOrderInnerA := strings.Index(orderModelCode, "InnerAaa")
 	foundOrderInnerB := strings.Index(orderModelCode, "InnerBbb")
 	foundOrderInnerC := strings.Index(orderModelCode, "InnerCcc")
 
-	assert.True(t, foundOrderInnerC < foundOrderInnerB)
-	assert.True(t, foundOrderInnerB < foundOrderInnerA)
+	assert.Less(t, foundOrderInnerC, foundOrderInnerB)
+	assert.Less(t, foundOrderInnerB, foundOrderInnerA)
 }
 
 func TestGenModel_StrictAdditionalProperties(t *testing.T) {

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -824,7 +824,7 @@ func TestGenClientIssue890_ValidationFalseFlatteningTrue(t *testing.T) {
 	opts.FlattenOpts.Minimal = false
 	// Testing this is enough as there is only one operation which is specified as $ref.
 	// If this doesn't get resolved then there will be an error definitely.
-	assert.NoError(t, GenerateClient("foo", nil, nil, opts))
+	require.NoError(t, GenerateClient("foo", nil, nil, opts))
 }
 
 func TestGenServerIssue890_ValidationFalseFlattenFalse(t *testing.T) {
@@ -857,7 +857,7 @@ func TestGenServerIssue890_ValidationFalseFlattenFalse(t *testing.T) {
 	opts.FlattenOpts.Minimal = true
 	_, err := newAppGenerator("JsonRefOperation", nil, nil, opts)
 	// if flatten is not set, expand takes over so this would resume normally
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGenClientIssue890_ValidationFalseFlattenFalse(t *testing.T) {
@@ -876,7 +876,7 @@ func TestGenClientIssue890_ValidationFalseFlattenFalse(t *testing.T) {
 	// Testing this is enough as there is only one operation which is specified as $ref.
 	// If this doesn't get resolved then there will be an error definitely.
 	// New: Now if flatten is false, expand takes over so server generation should resume normally
-	assert.NoError(t, GenerateClient("foo", nil, nil, opts))
+	require.NoError(t, GenerateClient("foo", nil, nil, opts))
 }
 
 func TestGenServerIssue890_ValidationTrueFlattenFalse(t *testing.T) {
@@ -910,7 +910,7 @@ func TestGenServerIssue890_ValidationTrueFlattenFalse(t *testing.T) {
 
 	_, err := newAppGenerator("JsonRefOperation", nil, nil, opts)
 	// now if flatten is false, expand takes over so server generation should resume normally
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGenServerWithTemplate(t *testing.T) {
@@ -1005,7 +1005,7 @@ func TestGenClientIssue890_ValidationTrueFlattenFalse(t *testing.T) {
 	// Testing this is enough as there is only one operation which is specified as $ref.
 	// If this doesn't get resolved then there will be an error definitely.
 	// same here: now if flatten doesn't resume, expand takes over
-	assert.NoError(t, GenerateClient("foo", nil, nil, opts))
+	require.NoError(t, GenerateClient("foo", nil, nil, opts))
 }
 
 // This tests that securityDefinitions generate stable code
@@ -1172,7 +1172,7 @@ func TestGenSecurityRequirements(t *testing.T) {
 	b.Security = b.Analyzed.SecurityRequirementsFor(&b.Operation)
 	genRequirements := b.makeSecurityRequirements("o")
 	assert.NotNil(t, genRequirements)
-	assert.Len(t, genRequirements, 0)
+	assert.Empty(t, genRequirements)
 
 	operation = "nosecOp"
 	b, err = opBuilder(operation, "../fixtures/bugs/1214/fixture-1214-2.yaml")
@@ -1224,11 +1224,11 @@ func TestGenerateServerOperation(t *testing.T) {
 
 	// check expected files are generated and that's it
 	_, err := os.Stat(filepath.Join(tgt, "tasks", "create_task.go"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = os.Stat(filepath.Join(tgt, "tasks", "create_task_parameters.go"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = os.Stat(filepath.Join(tgt, "tasks", "create_task_responses.go"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	origStdout := os.Stdout
 	defer func() {
@@ -1238,9 +1238,9 @@ func TestGenerateServerOperation(t *testing.T) {
 	o.DumpData = true
 	// just checks this does not fail
 	err = GenerateServerOperation([]string{"createTask"}, o)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = os.Stat(filepath.Join(tgt, "stdout"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // This tests that mimetypes generate stable code

--- a/generator/schemavalidation_test.go
+++ b/generator/schemavalidation_test.go
@@ -776,7 +776,7 @@ func TestAdditionalProperties_Simple(t *testing.T) {
 	assert.Nil(t, fsm.Next)
 	assert.Equal(t, "#/definitions/NamedMapComplexAnon", fsm.Type.AdditionalProperties.Schema.Ref.GetURL().String())
 
-	assert.NoError(t, lsm.Build())
+	require.NoError(t, lsm.Build())
 }
 
 func TestAdditionalProperties_Nested(t *testing.T) {
@@ -828,7 +828,7 @@ func TestAdditionalProperties_Nested(t *testing.T) {
 	assert.NotNil(t, fsm.Next.Next.ValueRef)
 	assert.Nil(t, fsm.Next.Next.Next)
 	assert.Equal(t, fsm.Next.Next, lsm)
-	assert.NoError(t, lsm.Build())
+	require.NoError(t, lsm.Build())
 }
 
 func TestSchemaValidation_NamedNestedMapComplex(t *testing.T) {

--- a/generator/server_test.go
+++ b/generator/server_test.go
@@ -21,15 +21,11 @@ const invalidSpecExample = "../fixtures/bugs/825/swagger.yml"
 
 func testAppGenerator(t testing.TB, specPath, name string) (*appGenerator, error) {
 	specDoc, err := loads.Spec(specPath)
-	if !assert.NoError(t, err) {
-		return nil, err
-	}
+	require.NoError(t, err)
 	analyzed := analysis.New(specDoc.Spec())
 
 	models, err := gatherModels(specDoc, nil)
-	if !assert.NoError(t, err) {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	operations := gatherOperations(analyzed, nil)
 	if len(operations) == 0 {
@@ -122,7 +118,7 @@ func TestServer_InvalidSpec(t *testing.T) {
 	opts.Spec = invalidSpecExample
 	opts.ValidateSpec = true
 
-	assert.Error(t, GenerateServer("foo", nil, nil, opts))
+	require.Error(t, GenerateServer("foo", nil, nil, opts))
 }
 
 func TestServer_TrailingSlash(t *testing.T) {

--- a/generator/shared_test.go
+++ b/generator/shared_test.go
@@ -89,41 +89,41 @@ func TestShared_CheckOpts(t *testing.T) {
 	opts.Target = filepath.Join(".", "a", "b", "c")
 	opts.ServerPackage = filepath.Join(cwd, "a", "b", "c")
 	err := opts.CheckOpts()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	opts.Target = filepath.Join(cwd, "a", "b", "c")
 	opts.ServerPackage = testPath
 	opts.Spec = filepath.Join(cwd, "nowhere", "swagger.yaml")
 	err = opts.CheckOpts()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	opts.Target = filepath.Join(cwd, "a", "b", "c")
 	opts.ServerPackage = testPath
 	opts.Spec = "https://ab/c"
 	err = opts.CheckOpts()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	opts.Target = filepath.Join(cwd, "a", "b", "c")
 	opts.ServerPackage = testPath
 	opts.Spec = "http://ab/c"
 	err = opts.CheckOpts()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	opts.Target = filepath.Join("a", "b", "c")
 	opts.ServerPackage = testPath
 	opts.Spec = filepath.Join(cwd, "..", "fixtures", "codegen", "swagger-codegen-tests.json")
 	err = opts.CheckOpts()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	opts.Target = filepath.Join("a", "b", "c")
 	opts.ServerPackage = testPath
 	opts.Spec = filepath.Join("..", "fixtures", "codegen", "swagger-codegen-tests.json")
 	err = opts.CheckOpts()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	opts = nil
 	err = opts.CheckOpts()
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestShared_EnsureDefaults(t *testing.T) {
@@ -335,8 +335,8 @@ func TestShared_ExecTemplate(t *testing.T) {
 	}
 
 	buf1, err := opts.render(&tplOpts, nil)
-	assert.NoError(t, err, "Template rendering should put <no value> instead of missing data, and report no error")
-	assert.Equal(t, string(buf1), "func x <no value>")
+	require.NoError(t, err, "Template rendering should put <no value> instead of missing data, and report no error")
+	assert.Equal(t, "func x <no value>", string(buf1))
 
 	execfailure2 := "func {{ .MyFaultyMethod }}"
 
@@ -353,7 +353,7 @@ func TestShared_ExecTemplate(t *testing.T) {
 
 	data := new(myTemplateData)
 	buf2, err := opts.render(&tplOpts2, data)
-	assert.Error(t, err, "Error should be handled here: missing func in template yields an error")
+	require.Error(t, err, "Error should be handled here: missing func in template yields an error")
 	assert.Contains(t, err.Error(), "template execution failed")
 	assert.Nil(t, buf2, "Upon error, GenOpts.render() should return nil buffer")
 }
@@ -399,7 +399,7 @@ func TestShared_BadFormatTemplate(t *testing.T) {
 
 	// The badly formatted file has been dumped for debugging purposes
 	_, exists := os.Stat(tplOpts.FileName)
-	assert.True(t, !os.IsNotExist(exists), "The template file has not been generated as expected")
+	assert.False(t, os.IsNotExist(exists), "The template file has not been generated as expected")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "source formatting on generated source")
@@ -420,10 +420,10 @@ func TestShared_BadFormatTemplate(t *testing.T) {
 
 	// The unformatted file has been dumped without format checks
 	_, exists2 := os.Stat(tplOpts2.FileName)
-	assert.True(t, !os.IsNotExist(exists2), "The template file has not been generated as expected")
+	assert.False(t, os.IsNotExist(exists2), "The template file has not been generated as expected")
 	_ = os.Remove(tplOpts2.FileName)
 
-	assert.Nil(t, err2)
+	require.NoError(t, err2)
 
 	// os.RemoveAll(filepath.Join(filepath.FromSlash(dr),"restapi"))
 }
@@ -462,10 +462,10 @@ func TestShared_DirectoryTemplate(t *testing.T) {
 
 	// The badly formatted file has been dumped for debugging purposes
 	_, exists := os.Stat(filepath.Join(tplOpts.Target, tplOpts.FileName))
-	assert.True(t, !os.IsNotExist(exists), "The template file has not been generated as expected")
+	assert.False(t, os.IsNotExist(exists), "The template file has not been generated as expected")
 	_ = os.RemoveAll(tplOpts.Target)
 
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }
 
 // Test templates which are not assets (open in file)
@@ -484,14 +484,14 @@ func TestShared_LoadTemplate(t *testing.T) {
 	}
 
 	buf, err := opts.render(&tplOpts, nil)
-	assert.Error(t, err, "Error should be handled here")
+	require.Error(t, err, "Error should be handled here")
 	assert.Contains(t, err.Error(), "open File")
 	assert.Contains(t, err.Error(), "error while opening")
 	assert.Nil(t, buf, "Upon error, GenOpts.render() should return nil buffer")
 
 	opts.TemplateDir = filepath.Join(".", "myTemplateDir")
 	buf, err = opts.render(&tplOpts, nil)
-	assert.Error(t, err, "Error should be handled here")
+	require.Error(t, err, "Error should be handled here")
 	assert.Contains(t, err.Error(), "open "+filepath.Join("myTemplateDir", "File"))
 	assert.Contains(t, err.Error(), "error while opening")
 	assert.Nil(t, buf, "Upon error, GenOpts.render() should return nil buffer")
@@ -523,13 +523,13 @@ func TestShared_AppNameOrDefault(t *testing.T) {
 	opts.FlattenOpts.Spec = analysis.New(specDoc.Spec())
 	opts.FlattenOpts.Minimal = true
 	err = analysis.Flatten(*opts.FlattenOpts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	specDoc, _ = loads.Spec(specPath) // needs reload
 	opts.FlattenOpts.Spec = analysis.New(specDoc.Spec())
 	opts.FlattenOpts.Minimal = false
 	err = analysis.Flatten(*opts.FlattenOpts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestShared_GatherModel(t *testing.T) {
@@ -539,7 +539,7 @@ func TestShared_GatherModel(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = gatherModels(specDoc, []string{"unknown"})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	res, err := gatherModels(specDoc, []string{"Image", "Application"})
 	require.NoError(t, err)
@@ -787,7 +787,7 @@ func TestShared_Issue2113(t *testing.T) {
 	opts.Spec = specPath
 	opts.ValidateSpec = true
 	_, err = opts.validateAndFlattenSpec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestShared_Issue2743(t *testing.T) {
@@ -803,7 +803,7 @@ func TestShared_Issue2743(t *testing.T) {
 		opts.Spec = specPath
 		opts.ValidateSpec = true
 		_, err = opts.validateAndFlattenSpec()
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("should flatten valid spec that used NOT to work", func(t *testing.T) {
@@ -815,6 +815,6 @@ func TestShared_Issue2743(t *testing.T) {
 		opts.Spec = specPath
 		opts.ValidateSpec = true
 		_, err = opts.validateAndFlattenSpec()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/generator/spec_test.go
+++ b/generator/spec_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,30 +15,30 @@ func TestSpec_Issue1429(t *testing.T) {
 	// acknowledge fix in go-openapi/spec
 	specPath := filepath.Join("..", "fixtures", "bugs", "1429", "swagger-1429.yaml")
 	_, err := loads.Spec(specPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	opts := testGenOpts()
 	opts.Spec = specPath
 	_, err = opts.validateAndFlattenSpec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// more aggressive fixture on $refs, with validation errors, but flatten ok
 	specPath = filepath.Join("..", "fixtures", "bugs", "1429", "swagger.yaml")
 	specDoc, err := loads.Spec(specPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	opts.Spec = specPath
 	opts.FlattenOpts.BasePath = specDoc.SpecFilePath()
 	opts.FlattenOpts.Spec = analysis.New(specDoc.Spec())
 	opts.FlattenOpts.Minimal = true
 	err = analysis.Flatten(*opts.FlattenOpts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	specDoc, _ = loads.Spec(specPath) // needs reload
 	opts.FlattenOpts.Spec = analysis.New(specDoc.Spec())
 	opts.FlattenOpts.Minimal = false
 	err = analysis.Flatten(*opts.FlattenOpts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSpec_Issue2527(t *testing.T) {
@@ -72,10 +71,10 @@ func TestSpec_Issue2527(t *testing.T) {
 
 func TestSpec_FindSwaggerSpec(t *testing.T) {
 	keepErr := func(_ string, err error) error { return err }
-	assert.Error(t, keepErr(findSwaggerSpec("")))
-	assert.Error(t, keepErr(findSwaggerSpec("nowhere")))
-	assert.Error(t, keepErr(findSwaggerSpec(filepath.Join("..", "fixtures"))))
-	assert.NoError(t, keepErr(findSwaggerSpec(filepath.Join("..", "fixtures", "codegen", "shipyard.yml"))))
+	require.Error(t, keepErr(findSwaggerSpec("")))
+	require.Error(t, keepErr(findSwaggerSpec("nowhere")))
+	require.Error(t, keepErr(findSwaggerSpec(filepath.Join("..", "fixtures"))))
+	require.NoError(t, keepErr(findSwaggerSpec(filepath.Join("..", "fixtures", "codegen", "shipyard.yml"))))
 }
 
 func TestSpec_Issue1621(t *testing.T) {
@@ -90,7 +89,7 @@ func TestSpec_Issue1621(t *testing.T) {
 	opts.Spec = specPath
 	opts.ValidateSpec = true
 	_, err = opts.validateAndFlattenSpec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestShared_Issue1614(t *testing.T) {
@@ -105,7 +104,7 @@ func TestShared_Issue1614(t *testing.T) {
 	opts.Spec = specPath
 	opts.ValidateSpec = true
 	_, err = opts.validateAndFlattenSpec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func Test_AnalyzeSpec_Issue2216(t *testing.T) {
@@ -119,7 +118,7 @@ func Test_AnalyzeSpec_Issue2216(t *testing.T) {
 		opts.ValidateSpec = true
 		opts.PropertiesSpecOrder = true
 		_, _, err := opts.analyzeSpec()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("splitted-swagger-file", func(t *testing.T) {
@@ -130,6 +129,6 @@ func Test_AnalyzeSpec_Issue2216(t *testing.T) {
 		opts.ValidateSpec = true
 		opts.PropertiesSpecOrder = true
 		_, _, err := opts.analyzeSpec()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/generator/template_repo_test.go
+++ b/generator/template_repo_test.go
@@ -62,7 +62,7 @@ Dict={{ template "dictTemplate" dict "Animal" "Pony" "Shape" "round" "Furniture"
 func TestTemplates_CustomTemplates(t *testing.T) {
 	var buf bytes.Buffer
 	headerTempl, err := templates.Get("bindprimitiveparam")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = headerTempl.Execute(&buf, nil)
 	require.NoError(t, err)
@@ -71,14 +71,14 @@ func TestTemplates_CustomTemplates(t *testing.T) {
 
 	buf.Reset()
 	err = templates.AddFile("bindprimitiveparam", customHeader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	headerTempl, err = templates.Get("bindprimitiveparam")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, headerTempl)
 
 	err = headerTempl.Execute(&buf, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "custom header", buf.String())
 }
 
@@ -86,10 +86,10 @@ func TestTemplates_CustomTemplatesMultiple(t *testing.T) {
 	var buf bytes.Buffer
 
 	err := templates.AddFile("differentFileName", customMultiple)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	headerTempl, err := templates.Get("bindprimitiveparam")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = headerTempl.Execute(&buf, nil)
 	require.NoError(t, err)
@@ -101,13 +101,13 @@ func TestTemplates_CustomNewTemplates(t *testing.T) {
 	var buf bytes.Buffer
 
 	err := templates.AddFile("newtemplate", customNewTemplate)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = templates.AddFile("existingUsesNew", customExistingUsesNew)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	headerTempl, err := templates.Get("bindprimitiveparam")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = headerTempl.Execute(&buf, nil)
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestTemplates_RepoLoadingTemplates(t *testing.T) {
 	repo := NewRepository(nil)
 
 	err := repo.AddFile("simple", singleTemplate)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	templ, err := repo.Get("simple")
 	require.NoError(t, err)
@@ -136,10 +136,10 @@ func TestTemplates_RepoLoadsAllTemplatesDefined(t *testing.T) {
 	repo := NewRepository(nil)
 
 	err := repo.AddFile("multiple", multipleDefinitions)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	templ, err := repo.Get("multiple")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = templ.Execute(&b, nil)
 	require.NoError(t, err)
@@ -167,10 +167,10 @@ func TestTemplates_RepoLoadsAllDependantTemplates(t *testing.T) {
 	repo := NewRepository(nil)
 
 	err := repo.AddFile("multiple", multipleDefinitions)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = repo.AddFile("dependant", dependantTemplate)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	templ, err := repo.Get("dependant")
 	require.NoError(t, err)
@@ -187,10 +187,10 @@ func TestTemplates_RepoRecursiveTemplates(t *testing.T) {
 	repo := NewRepository(nil)
 
 	err := repo.AddFile("c1", cirularDeps1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = repo.AddFile("c2", cirularDeps2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	templ, err := repo.Get("c1")
 	require.NoError(t, err)
@@ -252,7 +252,7 @@ func TestTemplates_DefinitionCopyright(t *testing.T) {
 	repo := NewRepository(nil)
 
 	err := repo.AddFile("copyright", copyright)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	templ, err := repo.Get("copyright")
 	require.NoError(t, err)
@@ -269,7 +269,7 @@ func TestTemplates_DefinitionCopyright(t *testing.T) {
 
 	rendered := bytes.NewBuffer(nil)
 	err = templ.Execute(rendered, genModel)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, rendered.String())
 
 	// executes template against operations definitions
@@ -293,7 +293,7 @@ func TestTemplates_DefinitionTargetImportPath(t *testing.T) {
 	repo := NewRepository(nil)
 
 	err := repo.AddFile("targetimportpath", targetImportPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	templ, err := repo.Get("targetimportpath")
 	require.NoError(t, err)
@@ -311,7 +311,7 @@ func TestTemplates_DefinitionTargetImportPath(t *testing.T) {
 
 	rendered := bytes.NewBuffer(nil)
 	err = templ.Execute(rendered, genModel)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, expected, rendered.String())
 
@@ -470,7 +470,7 @@ func TestTemplates_LoadDir(t *testing.T) {
 	protectedTemplates = make(map[string]bool)
 	repo := NewRepository(FuncMapFunc(DefaultLanguageFunc()))
 	err = repo.LoadDir("templates")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Test LoadDir
@@ -486,7 +486,7 @@ func TestTemplates_SetAllowOverride(t *testing.T) {
 	// adding protected file with allowOverride set to true should not fail
 	templates.SetAllowOverride(true)
 	err = templates.AddFile("schemabody", "some data")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Test LoadContrib
@@ -512,9 +512,9 @@ func TestTemplates_LoadContrib(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := templates.LoadContrib(tt.template)
 			if tt.wantError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
Helps follow best practices with testify use.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>