### PR TITLE
doc: sync'ed doc source with website

### DIFF
--- a/docs/use/spec/route.md
+++ b/docs/use/spec/route.md
@@ -61,7 +61,7 @@ func ServeAPI(host, basePath string, schemes []string) error {
   //     Parameters:
   //       + name: limit
   //         in: query
-  //         description: maximum umber of results to return
+  //         description: maximum number of results to return
   //         required: false
   //         type: integer
   //         format: int32
@@ -112,7 +112,7 @@ paths:
         - write
       parameters:
         description: maximum number of results to return
-        format: int43
+        format: int32
         in: query
         name: limit
         type: integer


### PR DESCRIPTION
A few typos have been fixed directly by patching the generated html in go-swagger/go-swagger.github.io.

This PR resyncs the original source markdown.