### PR TITLE
fix: duplicated tags when using `x-go-custom-tag` extension

### DIFF
--- a/generator/model.go
+++ b/generator/model.go
@@ -2059,22 +2059,23 @@ func (sg *schemaGenContext) makeGenSchema() error {
 			sg.GenSchema.ExtraImports[alias] = pkg
 		}
 
-		if !tpe.IsEmbedded {
-			sg.GenSchema.resolvedType = tpe
-			sg.GenSchema.Required = sg.Required
-			// assume we validate everything but interface and io.Reader - validation may be disabled by using the noValidation hint
-			sg.GenSchema.HasValidations = !(tpe.IsInterface || tpe.IsStream || tpe.SkipExternalValidation)
-			sg.GenSchema.IsAliased = sg.GenSchema.HasValidations
-
-			log.Printf("INFO: type %s is external, with inferred spec type %s, referred to as %s", sg.GenSchema.Name, sg.GenSchema.GoType, extType)
-			sg.GenSchema.GoType = extType
-			sg.GenSchema.AliasedType = extType
-
-			// short circuit schema building for external types
-			return nil
+		if tpe.IsEmbedded {
+			sg.GenSchema.IsAnonymous = true
 		}
 		// TODO: case for embedded types as anonymous definitions
-		return fmt.Errorf("ERROR: inline definitions embedded types are not supported")
+		sg.GenSchema.resolvedType = tpe
+		sg.GenSchema.Required = sg.Required
+		// assume we validate everything but interface and io.Reader - validation may be disabled by using the noValidation hint
+		sg.GenSchema.HasValidations = !(tpe.IsInterface || tpe.IsStream || tpe.SkipExternalValidation)
+		sg.GenSchema.IsAliased = sg.GenSchema.HasValidations
+
+		log.Printf("INFO: type %s is external, with inferred spec type %s, referred to as %s", sg.GenSchema.Name, sg.GenSchema.GoType, extType)
+		log.Printf("INFO: pkg: %s, alias: %s", pkg, alias)
+		sg.GenSchema.GoType = extType
+		sg.GenSchema.AliasedType = extType
+
+		// short circuit schema building for external types
+		return nil
 	}
 
 	debugLog("gschema nullable: %t", sg.GenSchema.IsNullable)

--- a/generator/model.go
+++ b/generator/model.go
@@ -2062,7 +2062,7 @@ func (sg *schemaGenContext) makeGenSchema() error {
 		if tpe.IsEmbedded {
 			sg.GenSchema.IsAnonymous = true
 		}
-		// TODO: case for embedded types as anonymous definitions
+
 		sg.GenSchema.resolvedType = tpe
 		sg.GenSchema.Required = sg.Required
 		// assume we validate everything but interface and io.Reader - validation may be disabled by using the noValidation hint

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -178,6 +178,8 @@ func TestGenerateModel_SchemaField(t *testing.T) {
 	gmp.MinItems = &in2
 	gmp.UniqueItems = true
 	gmp.ReadOnly = true
+	gmp.CustomTag = "mytag:\"foobar,foobaz\" json:\",inline\""
+	require.NotNil(t, getCustomTagKeyMap(gmp.CustomTag))
 	gmp.StructTags = []string{"json", "db", "example"}
 	gmp.Example = "some example\""
 	tt.assertRender(&gmp, `// The title of the property
@@ -194,9 +196,10 @@ func TestGenerateModel_SchemaField(t *testing.T) {
 // Max Items: 30
 // Min Items: 30
 // Unique: true
-`+"SomeName string `json:\"some name\" db:\"some name\" example:\"some example\\\"\" mytag:\"foobar,foobaz\"`\n")
+`+"SomeName string `db:\"some name\" example:\"some example\\\"\" mytag:\"foobar,foobaz\" json:\",inline\"`\n")
 
 	gmp.Example = "some example``"
+	gmp.CustomTag = "db:\",inline\" mytag:\"foobar,foobaz\" json:\",inline\""
 	tt.assertRender(&gmp, `// The title of the property
 //
 // The description of the property
@@ -211,7 +214,7 @@ func TestGenerateModel_SchemaField(t *testing.T) {
 // Max Items: 30
 // Min Items: 30
 // Unique: true
-`+"SomeName string \"json:\\\"some name\\\" db:\\\"some name\\\" example:\\\"some example``\\\" mytag:\\\"foobar,foobaz\\\"\"\n")
+`+"SomeName string \"example:\\\"some example``\\\" db:\\\",inline\\\" mytag:\\\"foobar,foobaz\\\" json:\\\",inline\\\"\"\n")
 }
 
 var schTypeGenDataSimple = []struct {

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -215,6 +215,23 @@ func TestGenerateModel_SchemaField(t *testing.T) {
 // Min Items: 30
 // Unique: true
 `+"SomeName string \"example:\\\"some example``\\\" db:\\\",inline\\\" mytag:\\\"foobar,foobaz\\\" json:\\\",inline\\\"\"\n")
+
+	gmp.IsAnonymous = true
+	tt.assertRender(&gmp, `// The title of the property
+//
+// The description of the property
+// Example: some example`+"``"+`
+// Required: true
+// Read Only: true
+// Maximum: < 10
+// Minimum: > 10
+// Max Length: 20
+// Min Length: 20
+// Pattern: \w[\w- ]+
+// Max Items: 30
+// Min Items: 30
+// Unique: true
+`+"string \"example:\\\"some example``\\\" db:\\\",inline\\\" mytag:\\\"foobar,foobaz\\\" json:\\\",inline\\\"\"\n")
 }
 
 var schTypeGenDataSimple = []struct {

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -139,6 +139,8 @@ func (g GenSchema) PrintTags() string {
 		orderedTags = append(orderedTags, "xml")
 	}
 
+	customMap := getCustomTagKeyMap(g.CustomTag)
+
 	// Add extra struct tags, only if the tag hasn't already been set, i.e. example.
 	// Extra struct tags have the same value has the `json` tag.
 	for _, tag := range g.StructTags {
@@ -154,10 +156,27 @@ func (g GenSchema) PrintTags() string {
 		case tag == "description" && len(g.Description) > 0:
 			tags["description"] = g.Description
 		default:
+			if customMap[tag] {
+				// dedupe
+				continue
+			}
 			tags[tag] = tags["json"]
 		}
 
 		orderedTags = append(orderedTags, tag)
+	}
+
+	if customMap["json"] {
+		// avoid duplication
+		delete(tags, "json")
+		var newOrderedTags []string
+		for i, tag := range orderedTags {
+			if tag == "json" {
+				continue
+			}
+			newOrderedTags = append(newOrderedTags, orderedTags[i])
+		}
+		orderedTags = newOrderedTags
 	}
 
 	// Assemble the tags in key value pairs with the value properly quoted.

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -82,6 +82,7 @@ type GenSchema struct {
 	StrictAdditionalProperties bool
 	ReadOnly                   bool
 	IsVirtual                  bool
+	IsAnonymous                bool
 	IsBaseType                 bool
 	HasBaseType                bool
 	IsSubType                  bool

--- a/generator/templates/structfield.gotmpl
+++ b/generator/templates/structfield.gotmpl
@@ -3,7 +3,13 @@
     // {{ template "docstring" . }}
     {{- template "propertyValidationDocString" .}}
   {{- end}}
+{{ if not $.IsAnonymous }}
 {{ pascalize .Name}} {{ template "schemaType" . }} {{ .PrintTags }}
+{{ else }}
+  {{- if and (not .IsMap) .IsNullable (not .IsSuperAlias) }}*{{ end }}
+  {{- if .IsSuperAlias }} = {{ end }}
+  {{- .GoType }} {{ .PrintTags }}
+{{ end }}
 {{ end }}
 
 {{- define "tuplefield" }}

--- a/generator/types.go
+++ b/generator/types.go
@@ -152,7 +152,8 @@ func (t typeResolver) knownDefGoType(def string, schema spec.Schema, clear func(
 		def = nm
 	}
 	extType, isExternalType := t.resolveExternalType(ext)
-	if !isExternalType || extType.Embedded {
+	// if !isExternalType || extType.Embedded {
+	if !isExternalType {
 		if clear == nil {
 			debugLog("known def type no clear: %q", def)
 			return def, t.definitionPkg, ""
@@ -815,7 +816,7 @@ func (t *typeResolver) ResolveSchema(schema *spec.Schema, isAnonymous, isRequire
 	extType, isExternalType := t.resolveExternalType(schema.Extensions)
 	if isExternalType {
 		tpe, pkg, alias := t.knownDefGoType(t.ModelName, *schema, t.goTypeName)
-		debugLog("found type %s declared as external, imported from %s as %s. Has type hints? %t, rendered has embedded? %t",
+		log.Printf("found type %s declared as external, imported from %s as %s. Has type hints? %t, rendered has embedded? %t",
 			t.ModelName, pkg, tpe, extType.Hints.Kind != "", extType.Embedded)
 
 		if extType.Hints.Kind != "" && !extType.Embedded {

--- a/generator/types.go
+++ b/generator/types.go
@@ -816,7 +816,7 @@ func (t *typeResolver) ResolveSchema(schema *spec.Schema, isAnonymous, isRequire
 	extType, isExternalType := t.resolveExternalType(schema.Extensions)
 	if isExternalType {
 		tpe, pkg, alias := t.knownDefGoType(t.ModelName, *schema, t.goTypeName)
-		log.Printf("found type %s declared as external, imported from %s as %s. Has type hints? %t, rendered has embedded? %t",
+		debugLog("found type %s declared as external, imported from %s as %s. Has type hints? %t, rendered has embedded? %t",
 			t.ModelName, pkg, tpe, extType.Hints.Kind != "", extType.Embedded)
 
 		if extType.Hints.Kind != "" && !extType.Embedded {

--- a/generator/util.go
+++ b/generator/util.go
@@ -1,0 +1,21 @@
+package generator
+
+import "strings"
+
+func getCustomTagKeyMap(tagStr string) map[string]bool {
+	res := map[string]bool{}
+	for {
+		output := strings.SplitN(tagStr, ":", 2)
+		if len(output) != 2 {
+			break
+		}
+		res[output[0]] = true
+		output = strings.SplitN(output[1], " ", 2)
+		if len(output) != 2 {
+			break
+		}
+		tagStr = output[1]
+	}
+
+	return res
+}


### PR DESCRIPTION
Go-swagger would generate duplicated tags while using the `x-go-custom-tag` extension.
for example:
```
    properties:
      tags:
        items:
          type: string
        type: array
        x-go-custom-tag: '"json:",inline"'
```
The output looks like this:
```
Tags []string `json:"tags" json:",inline"`
```

After this PR merged, the output will be:
```
Tags []string `json:",inline"`
```