### PR TITLE
Preserve descriptions and tags of fields containing embedded structures

### DIFF
--- a/fixtures/bugs/3125/item.go
+++ b/fixtures/bugs/3125/item.go
@@ -1,0 +1,20 @@
+package _3125
+
+// swagger:model Item
+type Item struct {
+	// Nullable value
+	// required: true
+	// Extensions:
+	// ---
+	// x-nullable: true
+	Value1 *ValueStruct `json:"value1"`
+
+	// Non-nullable value
+	// required: true
+	// example: {"value": 42}
+	Value2 ValueStruct `json:"value2"`
+}
+
+type ValueStruct struct {
+	Value int `json:"value"`
+}


### PR DESCRIPTION
For an unknown reason, descriptions and tags of fields containing embedded structures have been ignored except for the 'required' tag. This change makes go-swagger respect descriptions and all tags of such fields.

Fixes #3125
Fixes #3094
Fixes #2540
Fixes #2106
(and maybe some others)