### PR TITLE
fix the template layout reference

### DIFF
--- a/docs/faq/faq_server.md
+++ b/docs/faq/faq_server.md
@@ -217,7 +217,7 @@ https://github.com/go-swagger/go-swagger/blob/master/generator/templates.go#L61-
 
 Note: customizing templates already brings many options to the table, including generating artifacts in other languages than go.
 
-There is some documentation on the config file format here: https://github.com/go-swagger/go-swagger/blob/gen-layout-configfile/docs/use/template_layout.md
+There is some documentation on the config file format here: https://github.com/go-swagger/go-swagger/blob/master/docs/reference/templates/template_layout.md
 
 Also keep in mind that `go-openapi` and `go-swagger` constitute a _toolkit_
 and provide you the *tools* to adapt to your own use case.


### PR DESCRIPTION
# PR Summary
Commit b44601d48a17c24dc821681ded1b6465ddb5f918 moved the location of the `template_layout.md` file. This PR adjusts sources to changes.