### PR TITLE
Ignore types.Alias to avoid panics

### DIFF
--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -303,6 +303,8 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 	}
 
 	switch titpe := tpe.(type) {
+	case *types.Alias:
+		return nil // resolves panic
 	case *types.Basic:
 		return swaggerSchemaForType(titpe.String(), tgt)
 	case *types.Pointer:


### PR DESCRIPTION
This PR adds a no-op for `types.Alias`, which prevents the panics, see #3131.

Unfortunately, `types.Alias` are no longer supported by `go-swagger`, which would require a proper fix.