### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/examples/composed-auth/restapi/server.go
+++ b/examples/composed-auth/restapi/server.go
@@ -280,7 +280,7 @@ func (s *Server) Serve() (err error) {
 			caCertPool := x509.NewCertPool()
 			ok := caCertPool.AppendCertsFromPEM(caCert)
 			if !ok {
-				return fmt.Errorf("cannot parse CA certificate")
+				return errors.New("cannot parse CA certificate")
 			}
 			httpsServer.TLSConfig.ClientCAs = caCertPool
 			httpsServer.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters