### PR TITLE
Revert "feat: Support for Cookies Session Authentication Alongside Bearer Token (#3111)""

### DIFF
--- a/docs/usage/cookies_auth.md
+++ b/docs/usage/cookies_auth.md
@@ -1,0 +1,1 @@
+This file has been removed as part of the revert.

--- a/middleware/cookie_authenticator.go
+++ b/middleware/cookie_authenticator.go
@@ -1,0 +1,1 @@
+This file has been removed as part of the revert.

--- a/middleware/multi_authenticator.go
+++ b/middleware/multi_authenticator.go
@@ -1,0 +1,1 @@
+This file has been removed as part of the revert.


### PR DESCRIPTION

This PR reverts the changes introduced in #3147 to preserve the code state at commit 84b35e3eeb603319b18f7debe8710056b839e077.

Reverted changes:
- Removed `docs/usage/cookies_auth.md` 
- Removed `middleware/cookie_authenticator.go`
- Removed `middleware/multi_authenticator.go`
