### PR TITLE
fix(CI/tests): checkout the PR commits, not master

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -58,6 +60,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
@@ -96,6 +100,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
@@ -158,6 +164,8 @@ jobs:
       GOCOVERDIR: /tmp/cov
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}


### PR DESCRIPTION
The CI checkout in pull requests was checking out the master branch, which made it easy to miss the issues in tests and to push changes with test issues to master, because these issues were not seen in the PR

I added
```
        with:
           ref: ${{ github.head_ref }}
```
into every job that is lint/test/build related, not sure if we need it in the docker jobs

I will address the issues with tests in the next PR

cc @casualjim 