### PR TITLE
fix(ci): checkout action fix & move out pr pipeline

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -1,0 +1,200 @@
+name: Run CI (PR)
+
+env:
+  GOCOVMODE: atomic
+
+on:
+  pull_request_target:
+
+#  pull_request:
+#    paths-ignore:
+#    - docs/*
+#    - hack/hugo/*
+#    - .github/workflows/update-doc.yaml
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          check-latest: true
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --verbose
+          only-new-issues: true
+          skip-cache: true
+          version: latest
+
+  build:
+    # description: |
+    #   Make sure we build and run elementary operations.
+    #   And that, at this moment, it still runs with go 1.20.
+    #   The full test suite warrants support for the 2 latest go minor releases.
+    needs: [lint]
+    strategy:
+      matrix:
+        go: ["oldstable", "stable"]
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          check-latest: true
+          cache: true
+
+      - name: Build binary
+        run: |
+          go install ./cmd/swagger
+
+      - name: Verify that examples build
+        run: |
+          cd examples
+          go build ./...
+          go test ./...
+
+      - name: Run validation tests
+        run: |
+          swagger validate fixtures/bugs/2493/fixture-2492.json
+          swagger validate fixtures/bugs/2493/fixture-2493.json
+          swagger validate fixtures/bugs/2493/fixture-2492.yaml
+          swagger validate fixtures/bugs/2493/fixture-2493.yaml
+          swagger validate fixtures/bugs/2866/2866.yaml
+
+  test:
+    # description: |
+    #   Run unit tests on the 2 most recent go releases and 3 popular platforms.
+    needs: [lint]
+    strategy:
+      matrix:
+        go: ["oldstable", "stable"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude: # <- temporarily exclude go1.22.0 on windows. We hit this bug:https://github.com/golang/go/issues/65653
+          - go: stable
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          check-latest: true
+          cache: true
+
+      - name: Install Tools
+        run: |
+          go install gotest.tools/gotestsum@latest
+
+      - name: Run unit tests with code coverage
+        run: >
+          gotestsum --
+          -p 1
+          -timeout=20m
+          -coverprofile='coverage-${{ matrix.os }}-${{ matrix.go }}.txt'
+          -covermode=atomic
+          -coverpkg=$(go list)/...
+          ./...
+
+      - name: Publish To Codecov
+        # retry after 30s whenever codecov servers experience delays.
+        # inspired by https://github.com/Kong/kubernetes-testing-framework/blob/230e26621db6af0d8543e784afb208e8c2a6b710/.github/workflows/tests.yaml#L57
+        # until retries are eventually natively supported by the codecov CLI: https://github.com/codecov/codecov-action/issues/926
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: codecov/codecov-action@v4
+          attempt_limit: 10
+          attempt_delay: 30000
+          with: |
+            files: 'coverage-${{ matrix.os }}-${{ matrix.go }}.txt'
+            flags: 'unit-${{ matrix.go }}'
+            os: '${{ matrix.os }}'
+            fail_ci_if_error: true
+            verbose: true
+            # This secret is not passed on when triggered by PR from a fork: in this case,
+            # tokenless upload is used by the codecov CLI.
+            # It is used when running the workflow from pushed commits or tags on master.
+            token: ${{ secrets.CODECOV_TOKEN }}
+
+  codegen_test:
+    # description: |
+    #   Exercise go-swagger from the command line, with a bunch of specs
+    #   and several options (flatten/expand spec).
+    #
+    #   The test matrix applies to linux only. OS-specific quirks should
+    #   be covered by unit tests.
+    needs: [lint]
+    strategy:
+      matrix:
+        go: ["oldstable", "stable"]
+        os: [ubuntu-latest]
+        include:
+          - fixture: codegen-fixtures # <- complex API specs to torture the code generator
+            args: "-skip-models -skip-full-flatten"
+          - fixture: canary-fixtures # <- popular real-life API specs
+            args: "-skip-models -skip-full-flatten -skip-expand"
+    runs-on: ${{ matrix.os }}
+    env:
+      GOCOVERDIR: /tmp/cov
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          check-latest: true
+          cache: true
+
+      - name: Install Tools
+        run: |
+          go get gotest.tools/icmd@latest
+          mkdir /tmp/cov
+
+      - name: Build binary with test coverage instrumentation
+        run: >
+          ./hack/build-docker.sh --github-action
+          -cover
+          -covermode=atomic
+          -coverpkg=$(go list)/...
+
+      - name: Run codegen tests
+        run: >
+          go test -v -timeout 30m -parallel 3
+          hack/codegen_nonreg_test.go
+          -args -fixture-file "${{ matrix.fixture }}.yaml" $${{ matrix.args }}
+      - name: Construct coverage reports from integration tests
+        run: >
+          go tool covdata textfmt
+          -i "${GOCOVERDIR}"
+          -o "codegen-coverage-${{ matrix.os }}-${{ matrix.go }}-${{ matrix.fixture }}.txt"
+
+      - name: Publish To Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: "codegen-coverage-${{ matrix.os }}-${{ matrix.go }}-${{ matrix.fixture }}.txt"
+          flags: "codegen-${{ matrix.go }}-${{ matrix.fixture }}"
+          os: "${{ matrix.os }}"
+          fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }} # <- this secret is not passed on when triggered by PR from a fork

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Run CI
+name: Run CI (master/tag)
 
 env:
   GOCOVMODE: atomic
@@ -14,14 +14,6 @@ on:
       - hack/hugo/*
       - .github/workflows/update-doc.yaml
 
-  pull_request_target:
-
-#  pull_request:
-#    paths-ignore:
-#    - docs/*
-#    - hack/hugo/*
-#    - .github/workflows/update-doc.yaml
-
 permissions:
   contents: write
   pull-requests: read
@@ -32,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -60,8 +50,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
@@ -100,8 +88,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
@@ -164,8 +150,6 @@ jobs:
       GOCOVERDIR: /tmp/cov
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}


### PR DESCRIPTION
Second try, I'm moving out the PR action in it's own file and adding the solution for forks from https://github.com/actions/checkout/issues/551

The reason the previous one is failing is the fact that the commit from the fork doesn't actually exist in this repo

Reverted the changes from the previous commit in `test.yaml` that from now on should be only triggered on master/tag builds

@casualjim let's try this again, hopefully it works this time around.
And thank you for helping out with the merges
