### PR TITLE
fix(ci/scorecard): update upload-artifact to v4

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -42,7 +42,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Fixing one more github workflow:


> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
> Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/


`actions/upload-artifact@v3` is deprecated, use `actions/upload-artifact@v4`

Example of a successful run in the fork: https://github.com/nikolaiianchuk/go-swagger/actions/runs/13315910532/job/37189735413