### PR TITLE
fix(ci/update-doc): pin hugo-book version

### DIFF
--- a/.github/workflows/update-doc.yaml
+++ b/.github/workflows/update-doc.yaml
@@ -50,7 +50,7 @@ jobs:
       -
         name: Initialize themes
         run: |
-          (cd hack/doc-site/hugo/ && git clone https://github.com/alex-shpak/hugo-book themes/hugo-book)
+          (cd hack/doc-site/hugo/ && git clone --branch v9 https://github.com/alex-shpak/hugo-book themes/hugo-book)
 
       -
         name: Prepare config


### PR DESCRIPTION
```
WARN  Module "hugo-book" is not compatible with this Hugo version: Min 0.128.0; run "hugo mod graph" for more information.
Start building sites … 
```

We were checking out the master branch, I set it to v9 tag as v10 needs hugo `v0.124.0` to work and we have `v0.123.8`. See the tags here: https://github.com/alex-shpak/hugo-book/releases

Can't test it on my fork, but I think this should fix it. 

Also, couldn't find any logs as to which commit was it using because the last successful job ran around a year ago, and the logs are no longer present there