### PR TITLE
fix(ci): fix codeql security issues

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -4,16 +4,9 @@ env:
   GOCOVMODE: atomic
 
 on:
-  pull_request_target:
-
-#  pull_request:
-#    paths-ignore:
-#    - docs/*
-#    - hack/hugo/*
-#    - .github/workflows/update-doc.yaml
+  pull_request:
 
 permissions:
-  contents: write
   pull-requests: read
 
 jobs:
@@ -130,10 +123,6 @@ jobs:
             os: '${{ matrix.os }}'
             fail_ci_if_error: true
             verbose: true
-            # This secret is not passed on when triggered by PR from a fork: in this case,
-            # tokenless upload is used by the codecov CLI.
-            # It is used when running the workflow from pushed commits or tags on master.
-            token: ${{ secrets.CODECOV_TOKEN }}
 
   codegen_test:
     # description: |
@@ -197,4 +186,3 @@ jobs:
           os: "${{ matrix.os }}"
           fail_ci_if_error: true
           verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }} # <- this secret is not passed on when triggered by PR from a fork


### PR DESCRIPTION
My recent changes to the PR CI pipeline trigger a critical issue on the OpenSSF Scorecard

Related to: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
And 
```
          ref: ${{ github.event.pull_request.head.ref }}
          repository: ${{ github.event.pull_request.head.repo.full_name }}
```

Basically, the issue being, we should not give the code from the forks any write permissions to the repo and any access to the secrets, which `pull_request_target` seems to provide

Changing the `pull_request_target` to `pull_requst` as it has less permissions, also removing write permissions and secrets from the PR workflow

Pull request CI ran without issues in this PR, see the jobs with (pull_request) suffix

I'm going to create and close two more test PR's that are supposed to test the linters failure and the test failure

UPD: Tested in #3166 #3167 CI jobs with (pull_request) suffix