### PR TITLE
Fix replacement of generated packages with a version

### DIFF
--- a/fixtures/bugs/3143/3143.yaml
+++ b/fixtures/bugs/3143/3143.yaml
@@ -1,0 +1,45 @@
+swagger: '2.0'
+info:
+  version: '0.0.1'
+  title: Planting Service
+  description: Testing regression issue#3143
+  contact: {}
+host: www.example.com
+basePath: /
+securityDefinitions: {}
+schemes:
+- https
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  /healthz:
+    get:
+      description: Service health check
+      summary: Service health check
+      tags:
+      - av2on
+      operationId: Servicehealthcheck
+      deprecated: false
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        default:
+          description: ''
+          headers: {}
+  /wizz:
+    get:
+      description: fake
+      summary: dummy
+      tags:
+      - trailingv2
+      deprecated: false
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        default:
+          description: ''
+          headers: {}

--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -565,6 +565,33 @@ func generateFixtures(_ testing.TB) map[string]generateFixture {
 				location := filepath.Join(target, "cmd", "nrcodegen-server")
 				require.True(t, fileExists("", location))
 
+				require.True(t, fileExists("", filepath.Join(target, "restapi", "operations", "version1")))
+				require.True(t, fileExists("", filepath.Join(target, "restapi", "operations", "version3")))
+				require.True(t, fileExists("", filepath.Join(target, "restapi", "operations", "v2_validations")))
+				require.True(t, fileExists("", filepath.Join(target, "restapi", "operations", "v3_validations")))
+				require.True(t, fileExists("", filepath.Join(target, "restapi", "operations", "v3_actual")))
+				require.True(t, fileExists("", filepath.Join(target, "restapi", "operations", "v3_planned")))
+
+				t.Run("building generated server",
+					goExecInDir(location, "build"),
+				)
+			},
+		},
+		"tag_package_name_regression_3143": {
+			spec:   "../fixtures/bugs/3143/3143.yaml",
+			target: "server-3143",
+			prepare: func(_ *testing.T, opts *GenOpts) {
+				opts.MainPackage = "nrcodegen-server"
+				opts.IncludeMain = true
+				opts.ValidateSpec = true
+			},
+			verify: func(t *testing.T, target string) {
+				location := filepath.Join(target, "cmd", "nrcodegen-server")
+				require.True(t, fileExists("", location))
+
+				require.True(t, fileExists("", filepath.Join(target, "restapi", "operations", "av2on")))
+				require.True(t, fileExists("", filepath.Join(target, "restapi", "operations", "trailingv2")))
+
 				t.Run("building generated server",
 					goExecInDir(location, "build"),
 				)

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -1258,7 +1258,7 @@ func (b *codeGenOpBuilder) analyzeTags() (string, []string, bool) {
 	return tag, intersected, len(filter) == 0 || len(filter) > 0 && len(intersected) > 0
 }
 
-var versionedPkgRex = regexp.MustCompile(`(?i)(v)([0-9]+)`)
+var versionedPkgRex = regexp.MustCompile(`(?i)^(v)([0-9]+)$`)
 
 func maxInt(a, b int) int {
 	if a > b {


### PR DESCRIPTION
* Fixes #3143

TL,DR:
* tags like "v[nnn]" should generate "version[nnn}" packages
* but anything that matches "*v[nnn]*" doesn't need to be rewritten