### PR TITLE
Introduce a new command-line parameter for "generate spec"

### DIFF
--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -30,17 +30,18 @@ import (
 
 // SpecFile command to generate a swagger spec from a go application
 type SpecFile struct {
-	WorkDir     string         `long:"work-dir" short:"w" description:"the base path to use" default:"."`
-	BuildTags   string         `long:"tags" short:"t" description:"build tags" default:""`
-	ScanModels  bool           `long:"scan-models" short:"m" description:"includes models that were annotated with 'swagger:model'"`
-	Compact     bool           `long:"compact" description:"when present, doesn't prettify the json"`
-	Output      flags.Filename `long:"output" short:"o" description:"the file to write to"`
-	Input       flags.Filename `long:"input" short:"i" description:"an input swagger file with which to merge"`
-	Include     []string       `long:"include" short:"c" description:"include packages matching pattern"`
-	Exclude     []string       `long:"exclude" short:"x" description:"exclude packages matching pattern"`
-	IncludeTags []string       `long:"include-tag" short:"" description:"include routes having specified tags (can be specified many times)"`
-	ExcludeTags []string       `long:"exclude-tag" short:"" description:"exclude routes having specified tags (can be specified many times)"`
-	ExcludeDeps bool           `long:"exclude-deps" short:"" description:"exclude all dependencies of project"`
+	WorkDir                 string         `long:"work-dir" short:"w" description:"the base path to use" default:"."`
+	BuildTags               string         `long:"tags" short:"t" description:"build tags" default:""`
+	ScanModels              bool           `long:"scan-models" short:"m" description:"includes models that were annotated with 'swagger:model'"`
+	Compact                 bool           `long:"compact" description:"when present, doesn't prettify the json"`
+	Output                  flags.Filename `long:"output" short:"o" description:"the file to write to"`
+	Input                   flags.Filename `long:"input" short:"i" description:"an input swagger file with which to merge"`
+	Include                 []string       `long:"include" short:"c" description:"include packages matching pattern"`
+	Exclude                 []string       `long:"exclude" short:"x" description:"exclude packages matching pattern"`
+	IncludeTags             []string       `long:"include-tag" short:"" description:"include routes having specified tags (can be specified many times)"`
+	ExcludeTags             []string       `long:"exclude-tag" short:"" description:"exclude routes having specified tags (can be specified many times)"`
+	ExcludeDeps             bool           `long:"exclude-deps" short:"" description:"exclude all dependencies of project"`
+	SetXNullableForPointers bool           `long:"nullable-pointers" short:"n" description:"set x-nullable extension to true automatically for fields of pointer types without 'omitempty'"`
 }
 
 // Execute runs this command
@@ -65,6 +66,7 @@ func (s *SpecFile) Execute(args []string) error {
 	opts.IncludeTags = s.IncludeTags
 	opts.ExcludeTags = s.ExcludeTags
 	opts.ExcludeDeps = s.ExcludeDeps
+	opts.SetXNullableForPointers = s.SetXNullableForPointers
 	swspec, err := codescan.Run(&opts)
 	if err != nil {
 		return err

--- a/cmd/swagger/completion/swagger.zsh-completion
+++ b/cmd/swagger/completion/swagger.zsh-completion
@@ -113,6 +113,7 @@ __generate_spec() {
     '(-h,--help)'{-h,--help}'[Print help message]' \
     '(-w,--work-dir)'{-w,--work-dir}"[the base path to use (default: .)]:work-dir" \
     '(-m,--scan-models)'{-m,--scan-models}"[includes models that were annotated with 'swagger:model']" \
+    '(-n,--nullable-pointers)'{-n,--nullable-pointers}"[set x-nullable extension to true automatically for fields of pointer types without 'omitempty']" \
     "(--compact)--compact[when present, doesn't prettify the the json]" \
     '(-o,--output)'{-o,--output}"[the file to write to]:output" \
     '(-i,--input)'{-i,--input}"[an input swagger file with which to merge]:input" && return 0

--- a/codescan/application.go
+++ b/codescan/application.go
@@ -42,16 +42,17 @@ const (
 
 // Options for the scanner
 type Options struct {
-	Packages    []string
-	InputSpec   *spec.Swagger
-	ScanModels  bool
-	WorkDir     string
-	BuildTags   string
-	ExcludeDeps bool
-	Include     []string
-	Exclude     []string
-	IncludeTags []string
-	ExcludeTags []string
+	Packages                []string
+	InputSpec               *spec.Swagger
+	ScanModels              bool
+	WorkDir                 string
+	BuildTags               string
+	ExcludeDeps             bool
+	Include                 []string
+	Exclude                 []string
+	IncludeTags             []string
+	ExcludeTags             []string
+	SetXNullableForPointers bool
 }
 
 type scanCtx struct {
@@ -94,7 +95,7 @@ func newScanCtx(opts *Options) (*scanCtx, error) {
 
 	app, err := newTypeIndex(pkgs, opts.ExcludeDeps,
 		sliceToSet(opts.IncludeTags), sliceToSet(opts.ExcludeTags),
-		opts.Include, opts.Exclude)
+		opts.Include, opts.Exclude, opts.SetXNullableForPointers)
 	if err != nil {
 		return nil, err
 	}
@@ -418,16 +419,17 @@ func (s *scanCtx) FindEnumValues(pkg *packages.Package, enumName string) (list [
 	return list, descList, true
 }
 
-func newTypeIndex(pkgs []*packages.Package, excludeDeps bool, includeTags, excludeTags map[string]bool, includePkgs, excludePkgs []string) (*typeIndex, error) {
+func newTypeIndex(pkgs []*packages.Package, excludeDeps bool, includeTags, excludeTags map[string]bool, includePkgs, excludePkgs []string, setXNullableForPointers bool) (*typeIndex, error) {
 	ac := &typeIndex{
-		AllPackages: make(map[string]*packages.Package),
-		Models:      make(map[*ast.Ident]*entityDecl),
-		ExtraModels: make(map[*ast.Ident]*entityDecl),
-		excludeDeps: excludeDeps,
-		includeTags: includeTags,
-		excludeTags: excludeTags,
-		includePkgs: includePkgs,
-		excludePkgs: excludePkgs,
+		AllPackages:             make(map[string]*packages.Package),
+		Models:                  make(map[*ast.Ident]*entityDecl),
+		ExtraModels:             make(map[*ast.Ident]*entityDecl),
+		excludeDeps:             excludeDeps,
+		includeTags:             includeTags,
+		excludeTags:             excludeTags,
+		includePkgs:             includePkgs,
+		excludePkgs:             excludePkgs,
+		setXNullableForPointers: setXNullableForPointers,
 	}
 	if err := ac.build(pkgs); err != nil {
 		return nil, err
@@ -436,19 +438,20 @@ func newTypeIndex(pkgs []*packages.Package, excludeDeps bool, includeTags, exclu
 }
 
 type typeIndex struct {
-	AllPackages map[string]*packages.Package
-	Models      map[*ast.Ident]*entityDecl
-	ExtraModels map[*ast.Ident]*entityDecl
-	Meta        []metaSection
-	Routes      []parsedPathContent
-	Operations  []parsedPathContent
-	Parameters  []*entityDecl
-	Responses   []*entityDecl
-	excludeDeps bool
-	includeTags map[string]bool
-	excludeTags map[string]bool
-	includePkgs []string
-	excludePkgs []string
+	AllPackages             map[string]*packages.Package
+	Models                  map[*ast.Ident]*entityDecl
+	ExtraModels             map[*ast.Ident]*entityDecl
+	Meta                    []metaSection
+	Routes                  []parsedPathContent
+	Operations              []parsedPathContent
+	Parameters              []*entityDecl
+	Responses               []*entityDecl
+	excludeDeps             bool
+	includeTags             map[string]bool
+	excludeTags             map[string]bool
+	includePkgs             []string
+	excludePkgs             []string
+	setXNullableForPointers bool
 }
 
 func (a *typeIndex) build(pkgs []*packages.Package) error {

--- a/codescan/parameters.go
+++ b/codescan/parameters.go
@@ -339,7 +339,7 @@ func (p *parameterBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, 
 			continue
 		}
 
-		name, ignore, _, err := parseJSONTag(afld)
+		name, ignore, _, _, err := parseJSONTag(afld)
 		if err != nil {
 			return err
 		}

--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -333,7 +333,7 @@ func (r *responseBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, r
 			continue
 		}
 
-		name, ignore, _, err := parseJSONTag(afld)
+		name, ignore, _, _, err := parseJSONTag(afld)
 		if err != nil {
 			return err
 		}

--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -653,6 +653,12 @@ func (s *schemaBuilder) buildFromInterface(decl *entityDecl, it *types.Interface
 			ps.AddExtension("x-go-name", fld.Name())
 		}
 
+		if s.ctx.app.setXNullableForPointers {
+			if _, isPointer := fld.Type().(*types.Signature).Results().At(0).Type().(*types.Pointer); isPointer && (ps.Extensions == nil || (ps.Extensions["x-nullable"] == nil && ps.Extensions["x-isnullable"] == nil)) {
+				ps.AddExtension("x-nullable", true)
+			}
+		}
+
 		seen[name] = fld.Name()
 		tgt.Properties[name] = ps
 	}
@@ -718,7 +724,7 @@ func (s *schemaBuilder) buildFromStruct(decl *entityDecl, st *types.Struct, sche
 			continue
 		}
 
-		_, ignore, _, err := parseJSONTag(afld)
+		_, ignore, _, _, err := parseJSONTag(afld)
 		if err != nil {
 			return err
 		}
@@ -818,7 +824,7 @@ func (s *schemaBuilder) buildFromStruct(decl *entityDecl, st *types.Struct, sche
 			continue
 		}
 
-		name, ignore, isString, err := parseJSONTag(afld)
+		name, ignore, isString, omitEmpty, err := parseJSONTag(afld)
 		if err != nil {
 			return err
 		}
@@ -853,6 +859,13 @@ func (s *schemaBuilder) buildFromStruct(decl *entityDecl, st *types.Struct, sche
 
 		if ps.Ref.String() == "" && name != fld.Name() {
 			addExtension(&ps.VendorExtensible, "x-go-name", fld.Name())
+		}
+
+		if s.ctx.app.setXNullableForPointers {
+			if _, isPointer := fld.Type().(*types.Pointer); isPointer && !omitEmpty &&
+				(ps.Extensions == nil || (ps.Extensions["x-nullable"] == nil && ps.Extensions["x-isnullable"] == nil)) {
+				ps.AddExtension("x-nullable", true)
+			}
 		}
 
 		// we have 2 cases:
@@ -1108,17 +1121,17 @@ func (t tagOptions) Name() string {
 	return t[0]
 }
 
-func parseJSONTag(field *ast.Field) (name string, ignore bool, isString bool, err error) {
+func parseJSONTag(field *ast.Field) (name string, ignore, isString, omitEmpty bool, err error) {
 	if len(field.Names) > 0 {
 		name = field.Names[0].Name
 	}
 	if field.Tag == nil || len(strings.TrimSpace(field.Tag.Value)) == 0 {
-		return name, false, false, nil
+		return name, false, false, false, nil
 	}
 
 	tv, err := strconv.Unquote(field.Tag.Value)
 	if err != nil {
-		return name, false, false, err
+		return name, false, false, false, err
 	}
 
 	if strings.TrimSpace(tv) != "" {
@@ -1131,16 +1144,18 @@ func parseJSONTag(field *ast.Field) (name string, ignore bool, isString bool, er
 			isString = isFieldStringable(field.Type)
 		}
 
+		omitEmpty = jsonParts.Contain("omitempty")
+
 		switch jsonParts.Name() {
 		case "-":
-			return name, true, isString, nil
+			return name, true, isString, omitEmpty, nil
 		case "":
-			return name, false, isString, nil
+			return name, false, isString, omitEmpty, nil
 		default:
-			return jsonParts.Name(), false, isString, nil
+			return jsonParts.Name(), false, isString, omitEmpty, nil
 		}
 	}
-	return name, false, false, nil
+	return name, false, false, false, nil
 }
 
 // isFieldStringable check if the field type is a scalar. If the field type is

--- a/codescan/schema_test.go
+++ b/codescan/schema_test.go
@@ -833,6 +833,76 @@ func TestEmbeddedAllOf(t *testing.T) {
 	assertProperty(t, &asch, "string", "cat", "", "Cat")
 }
 
+func TestPointersAreNullableByDefaultWhenSetXNullableForPointersIsSet(t *testing.T) {
+	assertModel := func(sctx *scanCtx, packagePath, modelName string) {
+		decl, _ := sctx.FindDecl(packagePath, modelName)
+		require.NotNil(t, decl)
+		prs := &schemaBuilder{
+			ctx:  sctx,
+			decl: decl,
+		}
+		models := make(map[string]spec.Schema)
+		require.NoError(t, prs.Build(models))
+
+		schema := models[modelName]
+		require.Len(t, schema.Properties, 5)
+
+		require.Contains(t, schema.Properties, "Value1")
+		assert.Equal(t, true, schema.Properties["Value1"].Extensions["x-nullable"])
+		require.Contains(t, schema.Properties, "Value2")
+		assert.NotContains(t, schema.Properties["Value2"].Extensions, "x-nullable")
+		require.Contains(t, schema.Properties, "Value3")
+		assert.Equal(t, false, schema.Properties["Value3"].Extensions["x-nullable"])
+		require.Contains(t, schema.Properties, "Value4")
+		assert.NotContains(t, schema.Properties["Value4"].Extensions, "x-nullable")
+		assert.Equal(t, false, schema.Properties["Value4"].Extensions["x-isnullable"])
+		require.Contains(t, schema.Properties, "Value5")
+		assert.NotContains(t, schema.Properties["Value5"].Extensions, "x-nullable")
+	}
+
+	packagePath := "github.com/go-swagger/go-swagger/fixtures/enhancements/pointers-nullable-by-default"
+	sctx, err := newScanCtx(&Options{Packages: []string{packagePath}, SetXNullableForPointers: true})
+	require.NoError(t, err)
+
+	assertModel(sctx, packagePath, "Item")
+	assertModel(sctx, packagePath, "ItemInterface")
+}
+
+func TestPointersAreNotNullableByDefaultWhenSetXNullableForPointersIsNotSet(t *testing.T) {
+	assertModel := func(sctx *scanCtx, packagePath, modelName string) {
+		decl, _ := sctx.FindDecl(packagePath, modelName)
+		require.NotNil(t, decl)
+		prs := &schemaBuilder{
+			ctx:  sctx,
+			decl: decl,
+		}
+		models := make(map[string]spec.Schema)
+		require.NoError(t, prs.Build(models))
+
+		schema := models[modelName]
+		require.Len(t, schema.Properties, 5)
+
+		require.Contains(t, schema.Properties, "Value1")
+		assert.NotContains(t, schema.Properties["Value1"].Extensions, "x-nullable")
+		require.Contains(t, schema.Properties, "Value2")
+		assert.NotContains(t, schema.Properties["Value2"].Extensions, "x-nullable")
+		require.Contains(t, schema.Properties, "Value3")
+		assert.Equal(t, false, schema.Properties["Value3"].Extensions["x-nullable"])
+		require.Contains(t, schema.Properties, "Value4")
+		assert.NotContains(t, schema.Properties["Value4"].Extensions, "x-nullable")
+		assert.Equal(t, false, schema.Properties["Value4"].Extensions["x-isnullable"])
+		require.Contains(t, schema.Properties, "Value5")
+		assert.NotContains(t, schema.Properties["Value5"].Extensions, "x-nullable")
+	}
+
+	packagePath := "github.com/go-swagger/go-swagger/fixtures/enhancements/pointers-nullable-by-default"
+	sctx, err := newScanCtx(&Options{Packages: []string{packagePath}})
+	require.NoError(t, err)
+
+	assertModel(sctx, packagePath, "Item")
+	assertModel(sctx, packagePath, "ItemInterface")
+}
+
 func TestSwaggerTypeNamed(t *testing.T) {
 	sctx := loadClassificationPkgsCtx(t)
 	decl := getClassificationModel(sctx, "NamedWithType")

--- a/docs/generate-spec/_index.md
+++ b/docs/generate-spec/_index.md
@@ -32,6 +32,7 @@ Help Options:
           --include-tag=       include routes having specified tags (can be specified many times)
           --exclude-tag=       exclude routes having specified tags (can be specified many times)
           --exclude-deps       exclude all dependencies of project
+      -n, --nullable-pointers  set x-nullable extension to true automatically for fields of pointer types without 'omitempty'
 ```
 
 See code annotation rules [here](../reference/annotations)

--- a/fixtures/enhancements/pointers-nullable-by-default/item.go
+++ b/fixtures/enhancements/pointers-nullable-by-default/item.go
@@ -1,0 +1,40 @@
+package pointers_nullable_by_default
+
+// swagger:model Item
+type Item struct {
+	Value1 *int
+
+	Value2 int
+
+	// Extensions:
+	// ---
+	// x-nullable: false
+	Value3 *int
+
+	// Extensions:
+	// ---
+	// x-isnullable: false
+	Value4 *int
+
+	Value5 *int `json:"Value5,omitempty"`
+}
+
+// swagger:model ItemInterface
+type ItemInterface interface {
+	Value1() *int
+	Value2() int
+
+	// Value3 is a nullable value
+	// Extensions:
+	// ---
+	// x-nullable: false
+	Value3() *int
+
+	// Value4 is a non-nullable value
+	// Extensions:
+	// ---
+	// x-isnullable: false
+	Value4() *int
+
+	Value5() int
+}


### PR DESCRIPTION
Introduce a new command-line parameter for "generate spec" allowing to set "x-nullable: true" by default for each Go field having a pointer type and not having JSON 'omitempty' option set