### PR TITLE
add t.Helper() for test utilities

### DIFF
--- a/generator/utils_test.go
+++ b/generator/utils_test.go
@@ -28,18 +28,22 @@ func reqOri(str string) *regexp.Regexp {
 }
 
 func assertInCode(t testing.TB, expr, code string) bool {
+	t.Helper()
 	return assert.Regexp(t, reqm(expr), code)
 }
 
 func assertRegexpInCode(t testing.TB, expr, code string) bool {
+	t.Helper()
 	return assert.Regexp(t, reqOri(expr), code)
 }
 
 func assertNotInCode(t testing.TB, expr, code string) bool {
+	t.Helper()
 	return assert.NotRegexp(t, reqm(expr), code)
 }
 
 func assertRegexpNotInCode(t testing.TB, expr, code string) bool {
+	t.Helper()
 	return assert.NotRegexp(t, reqOri(expr), code)
 }
 
@@ -55,6 +59,7 @@ func requireValidation(t testing.TB, pth, expr string, gm GenSchema) {
 }
 
 func assertValidation(t testing.TB, pth, expr string, gm GenSchema) bool {
+	t.Helper()
 	if !assert.True(t, gm.HasValidations, "expected the schema to have validations") {
 		return false
 	}
@@ -82,6 +87,7 @@ func funcBody(code string, signature string) string {
 // testing utilities for codegen build
 
 func testCwd(t testing.TB) string {
+	t.Helper()
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	return cwd


### PR DESCRIPTION
Issue: N/A

**Context**
I'm working on https://github.com/go-swagger/go-swagger/discussions/3190 and found some file and line information in test are not useful enough. Calling [`t.Helper()`](https://pkg.go.dev/testing#T.Helper) should improve them.

**Further candidates to add t.Helper()**
There are more test utilities but I'm not sure whether they make sense to add `t.Helper()`.

<details><summary>examples</summary>

- https://github.com/go-swagger/go-swagger/blob/a70901f095da9244f76cc954596e92bb79d88f17/codescan/schema_test.go#L1121-L1131
- https://github.com/go-swagger/go-swagger/blob/a70901f095da9244f76cc954596e92bb79d88f17/codescan/schema_test.go#L1133-L1137
- https://github.com/go-swagger/go-swagger/blob/a70901f095da9244f76cc954596e92bb79d88f17/codescan/schema_test.go#L1139-L1151
- https://github.com/go-swagger/go-swagger/blob/9e98a1c267c7e21e05a21874023676e584e843f8/generator/pointer_test.go#L521-L566
- https://github.com/go-swagger/go-swagger/blob/9e98a1c267c7e21e05a21874023676e584e843f8/generator/pointer_test.go#L568-L624

</details>