### PR TITLE
lint: adopt new grouping rules for imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,8 @@ linters:
         - float-compare
         - go-require
   exclusions:
-    generated: lax
+    warn-unused: false
+    generated: disable  # enable linting on generated code (in examples, in generated code under test)
     presets:
       - comments
       - common-false-positives
@@ -61,21 +62,34 @@ linters:
       - std-error-handling
     paths:
       - fixtures/
+      # TODO: do not exclude examples from linting
       - examples/
+    rules:
+      - path: examples/
+        linters:
+          - gofumpt # we don't run gofumpt on generated examples, only goimports
+      - path: 'generator/generated/'
+        linters:
+          - gofumpt # we don't run gofumpt on generated fixtures
+      - path: _test.go
+        linters:
+          - unparam
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  new: true
+  new: false
 formatters:
   enable:
     - gofumpt
     - goimports
   settings:
+    # local prefixes regroup imports from these packages
     goimports:
       local-prefixes:
-        - github.com/go-swagger/go-swagger
+        - github.com/go-openapi
+        - github.com/go-swagger/go-swagger # this is for imports in generated examples
   exclusions:
-    generated: lax
+    # TODO: do not exclude examples from linting
     paths:
       - fixtures/
       - examples/

--- a/cmd/swagger/commands/diff/checks_test.go
+++ b/cmd/swagger/commands/diff/checks_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/go-openapi/spec"
 )
 
 func Test_getRef(t *testing.T) {

--- a/cmd/swagger/commands/diff/schema_test.go
+++ b/cmd/swagger/commands/diff/schema_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/go-openapi/spec"
 )
 
 func TestGetTypeFromSimpleSchema(t *testing.T) {

--- a/cmd/swagger/commands/diff/spec_analyser_test.go
+++ b/cmd/swagger/commands/diff/spec_analyser_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-openapi/loads"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/loads"
 
 	"github.com/go-swagger/go-swagger/cmd/swagger/commands/internal/cmdtest"
 )

--- a/cmd/swagger/commands/expand.go
+++ b/cmd/swagger/commands/expand.go
@@ -8,10 +8,11 @@ import (
 	"log"
 	"os"
 
+	flags "github.com/jessevdk/go-flags"
+
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
-	flags "github.com/jessevdk/go-flags"
 )
 
 // ExpandSpec is a command that expands the $refs in a swagger document.

--- a/cmd/swagger/commands/flatten.go
+++ b/cmd/swagger/commands/flatten.go
@@ -3,9 +3,10 @@ package commands
 import (
 	"errors"
 
+	flags "github.com/jessevdk/go-flags"
+
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
-	flags "github.com/jessevdk/go-flags"
 
 	"github.com/go-swagger/go-swagger/cmd/swagger/commands/generate"
 )

--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-openapi/analysis"
-	"github.com/go-openapi/swag"
 	flags "github.com/jessevdk/go-flags"
 	"github.com/spf13/viper"
+
+	"github.com/go-openapi/analysis"
+	"github.com/go-openapi/swag"
 
 	"github.com/go-swagger/go-swagger/generator"
 )

--- a/cmd/swagger/commands/generate/shared_test.go
+++ b/cmd/swagger/commands/generate/shared_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/go-openapi/analysis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/analysis"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -23,10 +23,11 @@ import (
 
 	"github.com/go-swagger/go-swagger/codescan"
 
-	"github.com/go-openapi/loads"
-	"github.com/go-openapi/spec"
 	"github.com/jessevdk/go-flags"
 	"gopkg.in/yaml.v3"
+
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/spec"
 )
 
 // SpecFile command to generate a swagger spec from a go application

--- a/cmd/swagger/commands/mixin.go
+++ b/cmd/swagger/commands/mixin.go
@@ -6,10 +6,11 @@ import (
 	"log"
 	"os"
 
+	flags "github.com/jessevdk/go-flags"
+
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
-	flags "github.com/jessevdk/go-flags"
 
 	"github.com/go-swagger/go-swagger/generator"
 )

--- a/cmd/swagger/commands/serve.go
+++ b/cmd/swagger/commands/serve.go
@@ -10,12 +10,13 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/gorilla/handlers"
+	"github.com/toqueteos/webbrowser"
+
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
-	"github.com/gorilla/handlers"
-	"github.com/toqueteos/webbrowser"
 )
 
 // ServeCmd to serve a swagger spec with docs ui

--- a/codescan/meta_test.go
+++ b/codescan/meta_test.go
@@ -19,9 +19,10 @@ import (
 	"go/token"
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 )
 
 func TestSetInfoVersion(t *testing.T) {

--- a/codescan/operations_go119_test.go
+++ b/codescan/operations_go119_test.go
@@ -3,9 +3,10 @@ package codescan
 import (
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 )
 
 func TestIndentedYAMLBlock(t *testing.T) {

--- a/codescan/operations_test.go
+++ b/codescan/operations_test.go
@@ -3,8 +3,9 @@ package codescan
 import (
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/codescan/parameters_test.go
+++ b/codescan/parameters_test.go
@@ -3,9 +3,10 @@ package codescan
 import (
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 )
 
 const (

--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -11,9 +11,10 @@ import (
 	"strconv"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/go-openapi/loads/fmts"
 	"github.com/go-openapi/spec"
-	"gopkg.in/yaml.v3"
 )
 
 func shouldAcceptTag(tags []string, includeTags map[string]bool, excludeTags map[string]bool) bool {

--- a/codescan/parser_test.go
+++ b/codescan/parser_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 )
 
 // only used within this group of tests but never used within actual code base.

--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -7,8 +7,9 @@ import (
 	"go/types"
 	"strings"
 
-	"github.com/go-openapi/spec"
 	"golang.org/x/tools/go/ast/astutil"
+
+	"github.com/go-openapi/spec"
 )
 
 type responseTypable struct {

--- a/codescan/responses_test.go
+++ b/codescan/responses_test.go
@@ -3,9 +3,10 @@ package codescan
 import (
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 )
 
 func getResponse(sctx *scanCtx, nm string) *entityDecl {

--- a/codescan/routes_test.go
+++ b/codescan/routes_test.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/go-openapi/spec"
 )
 
 func TestRouteExpression(t *testing.T) {

--- a/codescan/schema_go118_test.go
+++ b/codescan/schema_go118_test.go
@@ -3,9 +3,10 @@ package codescan
 import (
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 )
 
 var go118ClassificationCtx *scanCtx

--- a/codescan/schema_test.go
+++ b/codescan/schema_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 )
 
 const epsilon = 1e-9

--- a/generator/discriminators_test.go
+++ b/generator/discriminators_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/swag"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBuildDiscriminatorMap(t *testing.T) {

--- a/generator/enum_test.go
+++ b/generator/enum_test.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-openapi/loads"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/loads"
 )
 
 func TestEnum_StringThing(t *testing.T) {

--- a/generator/language.go
+++ b/generator/language.go
@@ -13,8 +13,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-openapi/swag"
 	"golang.org/x/tools/imports"
+
+	"github.com/go-openapi/swag"
 )
 
 var (

--- a/generator/media_test.go
+++ b/generator/media_test.go
@@ -4,9 +4,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/go-openapi/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/runtime"
 )
 
 func TestMediaWellKnownMime(t *testing.T) {

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -25,10 +25,11 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/go-openapi/loads"
-	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/swag"
 )
 
 type templateTest struct {

--- a/generator/moreschemavalidation_test.go
+++ b/generator/moreschemavalidation_test.go
@@ -24,10 +24,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
-	"github.com/stretchr/testify/require"
 )
 
 // modelExpectations is a test structure to capture expected codegen lines of code

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -21,11 +21,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUniqueOperationNameMangling(t *testing.T) {

--- a/generator/parameter_test.go
+++ b/generator/parameter_test.go
@@ -22,10 +22,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-openapi/spec"
-	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/swag"
 )
 
 func TestBodyParams(t *testing.T) {

--- a/generator/pointer_test.go
+++ b/generator/pointer_test.go
@@ -3,11 +3,12 @@ package generator
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTypeResolver_NestedAliasedSlice(t *testing.T) {

--- a/generator/response_test.go
+++ b/generator/response_test.go
@@ -20,9 +20,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/spec"
 )
 
 func TestSimpleResponseRender(t *testing.T) {

--- a/generator/schemavalidation_test.go
+++ b/generator/schemavalidation_test.go
@@ -18,10 +18,11 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/go-openapi/loads"
-	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/swag"
 )
 
 func TestSchemaValidation_RequiredProps(t *testing.T) {

--- a/generator/server_test.go
+++ b/generator/server_test.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/swag"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const invalidSpecExample = "../fixtures/bugs/825/swagger.yml"

--- a/generator/shared_test.go
+++ b/generator/shared_test.go
@@ -9,10 +9,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-openapi/analysis"
-	"github.com/go-openapi/loads"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/analysis"
+	"github.com/go-openapi/loads"
 )
 
 const (

--- a/generator/spec_test.go
+++ b/generator/spec_test.go
@@ -4,9 +4,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/loads"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSpec_Issue1429(t *testing.T) {

--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -18,10 +18,11 @@ import (
 	"unicode"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/kr/pretty"
+
 	"github.com/go-openapi/inflect"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/swag"
-	"github.com/kr/pretty"
 )
 
 var (

--- a/generator/template_repo_test.go
+++ b/generator/template_repo_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/go-openapi/loads"
-	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/swag"
 )
 
 const (

--- a/generator/typeresolver_test.go
+++ b/generator/typeresolver_test.go
@@ -17,10 +17,11 @@ package generator
 import (
 	"testing"
 
-	"github.com/go-openapi/loads"
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/spec"
 )
 
 func schTypeVals() []struct{ Type, Format, Expected string } {

--- a/generator/types.go
+++ b/generator/types.go
@@ -21,11 +21,12 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/kr/pretty"
+
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
-	"github.com/go-viper/mapstructure/v2"
-	"github.com/kr/pretty"
 )
 
 const (

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -5,10 +5,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
-	"github.com/stretchr/testify/require"
 )
 
 type externalTypeFixture struct {


### PR DESCRIPTION
* prepared the linter config for the forthcoming relinting of generated code (in "examples/")
* reviewed and updated the linter config, after the "auto-migrated" config produced when last upgrading golangci to v2
* the "local-prefix" rule that was incidentally added at that time is a good idea and is only modified to regroup imports from go-openapi (and go-swagger for internal dependencies within this repo)

In a forthcoming PR, we want generated code to be linted just as well, as a promise of go-swagger is to produce "code that plays well with govet and linters". This is no longer the case, and more work is needed there.