### PR TITLE
feat: add csv consumer and producer

### DIFF
--- a/generator/media.go
+++ b/generator/media.go
@@ -44,6 +44,7 @@ var knownProducers = map[string]string{
 	"xml":           "runtime.XMLProducer()",
 	"txt":           "runtime.TextProducer()",
 	"bin":           "runtime.ByteStreamProducer()",
+	"csv":           "runtime.CSVProducer()",
 	"urlform":       "runtime.DiscardProducer",
 	"multipartform": "runtime.DiscardProducer",
 }
@@ -54,6 +55,7 @@ var knownConsumers = map[string]string{
 	"xml":           "runtime.XMLConsumer()",
 	"txt":           "runtime.TextConsumer()",
 	"bin":           "runtime.ByteStreamConsumer()",
+	"csv":           "runtime.CSVConsumer()",
 	"urlform":       "runtime.DiscardConsumer",
 	"multipartform": "runtime.DiscardConsumer",
 }


### PR DESCRIPTION
Hello,
It's a PR to have csv producer and consumer to avoid this kind of block inside `configure_xxxx_api.go`:
```go
	api.CsvProducer = runtime.ProducerFunc(func(w io.Writer, data interface{}) error {
		return errors.NotImplemented("csv producer has not yet been implemented")
	})
```
and rather have
```go
	api.CsvProducer = runtime.CSVProducer()
```

Thx !