### PR TITLE
fix: correct typo in `docs/usage/generate.md`

### DIFF
--- a/docs/usage/generate.md
+++ b/docs/usage/generate.md
@@ -36,7 +36,7 @@ Available commands:
   support    generate supporting files like the main function and the api builder
 ```
 
-For code generation targets (`cli`, `client`, `model`, `operaion`, `server`, `support`), read more [here](../generate/).
+For code generation targets (`cli`, `client`, `model`, `operation`, `server`, `support`), read more [here](../generate/).
 
 For spec generation targets (`spec`), read more [there](../generate-spec/).
 


### PR DESCRIPTION
I noticed a small typo, "operaion" instead of "operation" in `docs/usage/generate.md`.