### PR TITLE
Pin go version on CI as a workaround of #3220

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -20,7 +20,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: 1.24 # workaround for #3220
           check-latest: true
           cache: true
       - name: golangci-lint
@@ -39,7 +39,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        go: ["oldstable", "stable"]
+        go: ["1.23", "1.24"] # workaround for #3220
         os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
@@ -77,7 +77,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        go: ["oldstable", "stable"]
+        go: ["1.23", "1.24"] # workaround for #3220
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude: # <- temporarily exclude go1.22.0 on windows. We hit this bug:https://github.com/golang/go/issues/65653
           - go: stable
@@ -134,7 +134,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        go: ["oldstable", "stable"]
+        go: ["1.23", "1.24"] # workaround for #3220
         os: [ubuntu-latest]
         include:
           - fixture: codegen-fixtures # <- complex API specs to torture the code generator

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: 1.24 # workaround for #3220
           check-latest: true
           cache: true
       - name: golangci-lint
@@ -47,7 +47,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        go: ["oldstable", "stable"]
+        go: ["1.23", "1.24"] # workaround for #3220
         os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
@@ -82,7 +82,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        go: ["oldstable", "stable"]
+        go: ["1.23", "1.24"] # workaround for #3220
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude: # <- temporarily exclude go1.22.0 on windows. We hit this bug:https://github.com/golang/go/issues/65653
           - go: stable
@@ -140,7 +140,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        go: ["oldstable", "stable"]
+        go: ["1.23", "1.24"] # workaround for #3220
         os: [ubuntu-latest]
         include:
           - fixture: codegen-fixtures # <- complex API specs to torture the code generator
@@ -250,7 +250,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: 1.24 # workaround for #3220
           check-latest: true
           cache: true
 


### PR DESCRIPTION
Issue: #3220 (This PR is just a temporal workaround. Doesn't resolve the real issue)

Related comment: https://github.com/go-swagger/go-swagger/pull/3195#issuecomment-3225987022
