### PR TITLE
remove naked returns to fix gofumpt linting

### DIFF
--- a/cmd/swagger/commands/diff/array_diff.go
+++ b/cmd/swagger/commands/diff/array_diff.go
@@ -47,7 +47,7 @@ func (f fromArrayStruct) DiffsTo(toArray []string) (added, deleted, common []str
 			common = append(common, key)
 		}
 	}
-	return
+	return added, deleted, common
 }
 
 // fromMapStruct utility struct to encompass diffing of string arrays

--- a/cmd/swagger/commands/diff/checks.go
+++ b/cmd/swagger/commands/diff/checks.go
@@ -148,7 +148,7 @@ func CheckRefChange(diffs []TypeDiff, type1, type2 interface{}) (diffReturn []Ty
 	} else if isRefType(type1) != isRefType(type2) {
 		diffReturn = addTypeDiff(diffReturn, TypeDiff{Change: ChangedType, FromType: getSchemaTypeStr(type1), ToType: getSchemaTypeStr(type2)})
 	}
-	return
+	return diffReturn
 }
 
 // checkNumericTypeChanges checks for changes to or from a numeric type

--- a/cmd/swagger/commands/diff/difftypes.go
+++ b/cmd/swagger/commands/diff/difftypes.go
@@ -244,7 +244,7 @@ func (s SpecChangeCode) Description() (result string) {
 		log.Printf("warning: No description for %v", s)
 		result = "UNDEFINED"
 	}
-	return
+	return result
 }
 
 // MarshalJSON marshals the enum as a quoted json string

--- a/cmd/swagger/commands/diff/reporting.go
+++ b/cmd/swagger/commands/diff/reporting.go
@@ -24,7 +24,7 @@ func Compare(spec1, spec2 *spec.Swagger) (diffs SpecDifferences, err error) {
 		return nil, err
 	}
 	diffs = analyser.Diffs
-	return
+	return diffs, nil
 }
 
 // PathItemOp - combines path and operation into a single keyed entity

--- a/cmd/swagger/commands/diff/schema.go
+++ b/cmd/swagger/commands/diff/schema.go
@@ -73,7 +73,7 @@ func getSchemaType(item interface{}) (typeName string, isArray bool) {
 		typeName = "unknown"
 	}
 
-	return
+	return typeName, isArray
 }
 
 func formatTypeString(typ string, isarray bool) string {

--- a/cmd/swagger/commands/diff/spec_analyser.go
+++ b/cmd/swagger/commands/diff/spec_analyser.go
@@ -836,7 +836,7 @@ func (sd *SpecAnalyser) schemaFromRef(ref spec.Ref, defns *spec.Definitions) (ac
 	}
 	sd.ReferencedDefinitions[definitionName] = true
 	actualSchema = &foundSchema
-	return
+	return actualSchema, definitionName
 }
 
 func schemaLocationKey(location DifferenceLocation) string {

--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -29,7 +29,7 @@ func (f *FlattenCmdOptions) SetFlattenOptions(dflt *analysis.FlattenOpts) (res *
 		*res = *dflt
 	}
 	if f == nil {
-		return
+		return res
 	}
 	verboseIsSet := false
 	minimalIsSet := false
@@ -70,7 +70,7 @@ func (f *FlattenCmdOptions) SetFlattenOptions(dflt *analysis.FlattenOpts) (res *
 			res.KeepNames = true
 		}
 	}
-	return
+	return res
 }
 
 type sharedCommand interface {

--- a/codescan/application.go
+++ b/codescan/application.go
@@ -152,7 +152,7 @@ func (d *entityDecl) Names() (name, goName string) {
 	goName = d.Ident.Name
 	name = goName
 	if d.Comments == nil {
-		return
+		return name, goName
 	}
 
 DECLS:
@@ -169,14 +169,14 @@ DECLS:
 		}
 	}
 
-	return
+	return name, goName
 }
 
 func (d *entityDecl) ResponseNames() (name, goName string) {
 	goName = d.Ident.Name
 	name = goName
 	if d.Comments == nil {
-		return
+		return name, goName
 	}
 
 DECLS:
@@ -192,7 +192,7 @@ DECLS:
 			}
 		}
 	}
-	return
+	return name, goName
 }
 
 func (d *entityDecl) OperationIDs() (result []string) {
@@ -216,7 +216,7 @@ func (d *entityDecl) OperationIDs() (result []string) {
 			}
 		}
 	}
-	return
+	return result
 }
 
 func (d *entityDecl) HasModelAnnotation() bool {

--- a/codescan/enum.go
+++ b/codescan/enum.go
@@ -28,5 +28,5 @@ const extEnumDesc = "x-go-enum-desc"
 
 func getEnumDesc(extensions spec.Extensions) (desc string) {
 	desc, _ = extensions.GetString(extEnumDesc)
-	return
+	return desc
 }

--- a/codescan/meta.go
+++ b/codescan/meta.go
@@ -242,11 +242,11 @@ func splitURL(line string) (notURL, url string) {
 		if len(str) > 0 {
 			notURL = str
 		}
-		return
+		return notURL, ""
 	}
 	if len(parts) > 0 {
 		notURL = strings.TrimSpace(str[:parts[0]])
 		url = strings.TrimSpace(str[parts[0]:])
 	}
-	return
+	return notURL, url
 }

--- a/codescan/operations.go
+++ b/codescan/operations.go
@@ -78,7 +78,7 @@ func parsePathAnnotation(annotation *regexp.Regexp, lines []*ast.Comment) (cnt p
 		}
 	}
 
-	return
+	return cnt
 }
 
 func setPathOperation(method, id string, pthObj *spec.PathItem, op *spec.Operation) *spec.Operation {

--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -70,7 +70,7 @@ func removeEmptyLines(lines []string) (notEmpty []string) {
 			notEmpty = append(notEmpty, l)
 		}
 	}
-	return
+	return notEmpty
 }
 
 func rxf(rxp, ar string) *regexp.Regexp {
@@ -479,30 +479,31 @@ func (sp *yamlSpecScanner) UnmarshalSpec(u func([]byte) error) (err error) {
 	yamlContent := strings.Join(specYaml, "\n")
 	err = yaml.Unmarshal([]byte(yamlContent), &yamlValue)
 	if err != nil {
-		return
+		return err
 	}
 
 	// 2. convert to json
 	var jsonValue json.RawMessage
 	jsonValue, err = fmts.YAMLToJSON(yamlValue)
 	if err != nil {
-		return
+		return err
 	}
 
 	// 3. unmarshal the json into an interface
 	var data []byte
 	data, err = jsonValue.MarshalJSON()
 	if err != nil {
-		return
+		return err
 	}
 	err = u(data)
 	if err != nil {
-		return
+		return err
 	}
 
 	// all parsed, returning...
 	sp.yamlSpec = nil // spec is now consumed, so let's erase the parsed lines
-	return
+
+	return nil
 }
 
 // removes indent base on the first line
@@ -1362,12 +1363,12 @@ func parseTags(line string) (modelOrResponse string, arrays int, isDefinitionRef
 				err = fmt.Errorf("invalid tag: %s", tag)
 			}
 			// return error
-			return
+			return modelOrResponse, arrays, isDefinitionRef, description, err
 		}
 	}
 
 	// TODO: Maybe do, if !parsedModelOrResponse {return some error}
-	return
+	return modelOrResponse, arrays, isDefinitionRef, description, err
 }
 
 func (ss *setOpResponses) Parse(lines []string) error {

--- a/codescan/parser_helpers.go
+++ b/codescan/parser_helpers.go
@@ -27,7 +27,7 @@ func collectScannerTitleDescription(headers []string) (title, desc []string) {
 		} else {
 			desc = nil
 		}
-		return
+		return title, desc
 	}
 
 	if len(hdrs) > 0 {
@@ -44,5 +44,5 @@ func collectScannerTitleDescription(headers []string) (title, desc []string) {
 		}
 	}
 
-	return
+	return title, desc
 }

--- a/codescan/regexprs_test.go
+++ b/codescan/regexprs_test.go
@@ -125,7 +125,7 @@ func makeMinMax(lower string) (res []string) {
 	for _, a := range []string{"", "imum"} {
 		res = append(res, lower+a, strings.Title(lower)+a) //nolint:staticcheck
 	}
-	return
+	return res
 }
 
 func verifyBoolean(t *testing.T, matcher *regexp.Regexp, names, names2 []string) {

--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -125,7 +125,7 @@ type schemaBuilder struct {
 func (s *schemaBuilder) inferNames() (goName string, name string) {
 	if s.GoName != "" {
 		goName, name = s.GoName, s.Name
-		return
+		return goName, name
 	}
 
 	goName = s.decl.Ident.Name
@@ -135,7 +135,7 @@ func (s *schemaBuilder) inferNames() (goName string, name string) {
 		s.Name = name
 	}()
 	if s.decl.Comments == nil {
-		return
+		return goName, name
 	}
 
 DECLS:
@@ -151,7 +151,7 @@ DECLS:
 			}
 		}
 	}
-	return
+	return goName, name
 }
 
 func (s *schemaBuilder) Build(definitions map[string]spec.Schema) error {

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -49,7 +49,7 @@ func (tt *templateTest) assertRender(data any, expected string) (success bool) {
 	exp := strings.TrimLeft(expected, "\n\t ")
 	assert.Equal(tt.t, exp, trimmed)
 
-	return
+	return !tt.t.Failed()
 }
 
 func TestGenerateModel_Sanity(t *testing.T) {

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -674,7 +674,8 @@ func (b *codeGenOpBuilder) MakeHeaderItem(receiver, paramName, indexVar, path, v
 func (b *codeGenOpBuilder) HasValidations(sh spec.CommonValidations, rt resolvedType) (hasValidations bool, hasSliceValidations bool) {
 	hasSliceValidations = sh.HasArrayValidations() || sh.HasEnum()
 	hasValidations = sh.HasNumberValidations() || sh.HasStringValidations() || hasSliceValidations || hasFormatValidation(rt)
-	return
+
+	return hasValidations, hasSliceValidations
 }
 
 func (b *codeGenOpBuilder) MakeParameterItem(receiver, paramName, indexVar, path, valueExpression, location string, resolver *typeResolver, items, _ *spec.Items) (GenItems, error) {
@@ -1066,7 +1067,7 @@ func (b *codeGenOpBuilder) liftExtraSchemas(resolver, rslv *typeResolver, bs *sp
 
 	// rebuild schema within local package
 	if err = pg.makeGenSchema(); err != nil {
-		return
+		return nil, err
 	}
 
 	// lift nested extra schemas (inlined types)
@@ -1080,7 +1081,7 @@ func (b *codeGenOpBuilder) liftExtraSchemas(resolver, rslv *typeResolver, bs *sp
 		}
 	}
 	schema = &pg.GenSchema
-	return
+	return schema, nil
 }
 
 // buildOperationSchema constructs a schema for an operation (for body params or responses).

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -393,7 +393,7 @@ func opBuildGetOpts(specName string, withFlatten bool, withMinimalFlatten bool) 
 	if err := opts.EnsureDefaults(); err != nil {
 		panic("Cannot initialize GenOpts")
 	}
-	return
+	return opts
 }
 
 // opBuilderWithFlatten prepares the making of an operation with spec full flattening prior to rendering
@@ -1069,13 +1069,11 @@ func TestBuilder_Issue1214(t *testing.T) {
 			`CAuth: func\(token string\) \(any, error\) {`+matchAny+
 			`DAuth: func\(token string\) \(any, error\) {`+matchAny+
 			`EAuth: func\(token string, scopes \[\]string\) \(any, error\) {`+matchAny+
-
 			`AAuth func\(string, string\) \(any, error\)`+matchAny+
 			`BAuth func\(string\) \(any, error\)`+matchAny+
 			`CAuth func\(string\) \(any, error\)`+matchAny+
 			`DAuth func\(string\) \(any, error\)`+matchAny+
 			`EAuth func\(string, \[\]string\) \(any, error\)`+matchAny+
-
 			`if o\.AAuth == nil {`+matchAny+
 			`unregistered = append\(unregistered, "AAuth"\)`+matchAny+
 			`if o\.BAuth == nil {`+matchAny+
@@ -1086,7 +1084,6 @@ func TestBuilder_Issue1214(t *testing.T) {
 			`unregistered = append\(unregistered, "K3Auth"\)`+matchAny+
 			`if o\.EAuth == nil {`+matchAny+
 			`unregistered = append\(unregistered, "EAuth"\)`+matchAny+
-
 			`case "A":`+matchAny+
 			`case "B":`+matchAny+
 			`case "C":`+matchAny+

--- a/generator/parameter_test.go
+++ b/generator/parameter_test.go
@@ -263,7 +263,7 @@ func (ctx *paramTestContext) assertParameter(t testing.TB) (result bool) {
 		assert.True(t, ctx.assertGenParam(t, param, gp))
 	}
 
-	return
+	return !t.Failed()
 }
 
 func (ctx *paramTestContext) assertGenParam(t testing.TB, param spec.Parameter, gp GenParameter) bool {

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -996,7 +996,8 @@ func pruneEmpty(in []string) (out []string) {
 			out = append(out, v)
 		}
 	}
-	return
+
+	return out
 }
 
 func trimBOM(in string) string {
@@ -1042,7 +1043,7 @@ func gatherSecuritySchemes(securitySchemes map[string]spec.SecurityScheme, appNa
 		})
 	}
 	sort.Sort(security)
-	return
+	return security
 }
 
 // securityRequirements just clones the original SecurityRequirements from either the spec

--- a/generator/types.go
+++ b/generator/types.go
@@ -83,7 +83,7 @@ func simpleResolvedType(tn, fmt string, items *spec.Items, v *spec.CommonValidat
 		result.IsPrimitive = true
 		result.GoType = formatMapping[str][binary]
 		result.IsStream = true
-		return
+		return result
 	}
 
 	if fmt != "" {
@@ -102,7 +102,7 @@ func simpleResolvedType(tn, fmt string, items *spec.Items, v *spec.CommonValidat
 				result.IsStream = fmt == binary
 				// special case of swagger format "byte", rendered as a strfmt.Base64 type: no validation
 				result.IsBase64 = fmt == b64
-				return
+				return result
 			}
 		}
 	}
@@ -111,7 +111,7 @@ func simpleResolvedType(tn, fmt string, items *spec.Items, v *spec.CommonValidat
 		result.GoType = tpe
 		_, result.IsPrimitive = primitives[tpe]
 		result.IsPrimitive = ok
-		return
+		return result
 	}
 
 	if tn == array {
@@ -121,15 +121,15 @@ func simpleResolvedType(tn, fmt string, items *spec.Items, v *spec.CommonValidat
 		result.IsNullable = false
 		if items == nil {
 			result.GoType = "[]" + iface
-			return
+			return result
 		}
 		res := simpleResolvedType(items.Type, items.Format, items.Items, &items.CommonValidations)
 		result.GoType = "[]" + res.GoType
-		return
+		return result
 	}
 	result.GoType = tn
 	_, result.IsPrimitive = primitives[tn]
-	return
+	return result
 }
 
 func newTypeResolver(pkg, _ string, doc *loads.Document) *typeResolver {
@@ -293,7 +293,7 @@ func (t *typeResolver) withDefinitionPackage(pkg string) *typeResolver {
 
 func (t *typeResolver) resolveSchemaRef(schema *spec.Schema, isRequired bool) (returns bool, result resolvedType, err error) {
 	if schema.Ref.String() == "" {
-		return
+		return false, result, nil
 	}
 	debugLog("resolving ref (anon: %t, req: %t) %s", false, isRequired, schema.Ref.String())
 
@@ -305,7 +305,7 @@ func (t *typeResolver) resolveSchemaRef(schema *spec.Schema, isRequired bool) (r
 	if er != nil {
 		debugLog("error resolving ref %s: %v", schema.Ref.String(), er)
 		err = er
-		return
+		return returns, result, err
 	}
 
 	extType, isExternalType := t.resolveExternalType(schema.Extensions)
@@ -317,7 +317,7 @@ func (t *typeResolver) resolveSchemaRef(schema *spec.Schema, isRequired bool) (r
 	res, er := t.ResolveSchema(ref, false, isRequired)
 	if er != nil {
 		err = er
-		return
+		return returns, result, err
 	}
 	result = res
 
@@ -333,7 +333,8 @@ func (t *typeResolver) resolveSchemaRef(schema *spec.Schema, isRequired bool) (r
 	result.IsBaseType = result.HasDiscriminator
 	result.IsNullable = result.IsNullable || t.isNullable(ref) // this has to be overridden for slices and maps
 	result.IsEnumCI = false
-	return
+
+	return returns, result, err
 }
 
 func (t *typeResolver) inferAliasing(result *resolvedType, _ *spec.Schema, isAnonymous bool, _ bool) {
@@ -389,7 +390,7 @@ func (t *typeResolver) resolveFormat(schema *spec.Schema, isAnonymous bool, isRe
 	}
 
 	guardFormatConflicts(schema.Format, schema)
-	return
+	return returns, result, nil
 }
 
 // isNullable hints the generator as to render the type with a pointer or not.
@@ -1198,7 +1199,7 @@ func (rt *resolvedType) setIsEmptyOmitted(schema *spec.Schema, tpe string) {
 		return
 	}
 	// array of primitives are by default not empty-omitted, but arrays of aliased type are
-	rt.IsEmptyOmitted = (tpe != array) || (tpe == array && rt.IsAliased)
+	rt.IsEmptyOmitted = (tpe != array) || rt.IsAliased
 }
 
 func (rt *resolvedType) setIsJSONString(schema *spec.Schema, _ string) {


### PR DESCRIPTION
- relates to https://github.com/go-swagger/go-swagger/pull/3233 / https://github.com/thaJeztah/go-swagger/pull/1
- relates to https://github.com/thaJeztah/go-swagger/pull/2

```
Error: cmd/swagger/commands/diff/array_diff.go:50:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: cmd/swagger/commands/diff/checks.go:151:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: cmd/swagger/commands/diff/difftypes.go:247:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: cmd/swagger/commands/diff/reporting.go:27:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: cmd/swagger/commands/diff/schema.go:76:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: cmd/swagger/commands/diff/spec_analyser.go:839:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: cmd/swagger/commands/generate/shared.go:32:1: File is not properly formatted (gofumpt)
  		return
  ^
  Error: codescan/application.go:155:1: File is not properly formatted (gofumpt)
  		return
  ^
  Error: codescan/enum.go:31:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: codescan/meta.go:245:1: File is not properly formatted (gofumpt)
  		return
  ^
  Error: codescan/operations.go:81:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: codescan/parser.go:73:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: codescan/parser_helpers.go:30:1: File is not properly formatted (gofumpt)
  		return
  ^
  Error: codescan/regexprs_test.go:128:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: codescan/schema.go:128:1: File is not properly formatted (gofumpt)
  		return
  ^
  Error: generator/model_test.go:52:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: generator/operation.go:677:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: generator/operation_test.go:396:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: generator/parameter_test.go:266:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: generator/shared.go:999:1: File is not properly formatted (gofumpt)
  	return
  ^
  Error: generator/types.go:86:1: File is not properly formatted (gofumpt)
  		return
  ^
```