### PR TITLE
chore: updated linting config & relinted (partially)

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -79,9 +79,6 @@ jobs:
       matrix:
         go: ["oldstable", "stable"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude: # <- temporarily exclude go1.22.0 on windows. We hit this bug:https://github.com/golang/go/issues/65653
-          - go: stable
-            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -97,6 +94,16 @@ jobs:
       - name: Install Tools
         run: |
           go install gotest.tools/gotestsum@latest
+
+      - name: Ensure TMP is created on windows runners
+        # On windows, tests require testing.TempDir to reside on the same drive as the code.
+        # TMP is used by os.TempDir() to determine the location of temporary files.
+        if: ${{ runner.os  == 'Windows' }}
+        shell: bash
+        run: |
+          TMP="${{ github.workspace }}\..\tmp"
+          mkdir -p ${TMP}
+          echo "TMP=${TMP}" >> "${GITHUB_ENV}"
 
       - name: Run unit tests with code coverage
         run: >

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,9 +84,6 @@ jobs:
       matrix:
         go: ["oldstable", "stable"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude: # <- temporarily exclude go1.22.0 on windows. We hit this bug:https://github.com/golang/go/issues/65653
-          - go: stable
-            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +96,16 @@ jobs:
       - name: Install Tools
         run: |
           go install gotest.tools/gotestsum@latest
+
+      - name: Ensure TMP is created on windows runners
+        # On windows, tests require testing.TempDir to reside on the same drive as the code.
+        # TMP is used by os.TempDir() to determine the location of temporary files.
+        if: ${{ runner.os  == 'Windows' }}
+        shell: bash
+        run: |
+          TMP="${{ github.workspace }}\..\tmp"
+          mkdir -p ${TMP}
+          echo "TMP=${TMP}" >> "${GITHUB_ENV}"
 
       - name: Run unit tests with code coverage
         run: >

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ _test
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out
-
+*.out
 *.cgo1.go
 *.cgo2.c
 _cgo_defun.c

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,24 +1,43 @@
 version: "2"
 linters:
-  enable:
-    - depguard
-    - errorlint
-    - gocritic
-    - gosec
-    - ineffassign
-    - misspell
-    - nakedret
-    - revive
-    - staticcheck
-    - testifylint
-    - unconvert
-    - unused
+  # Project stance regarding linting - see also https://github.com/go-swagger/go-swagger/issues/3237:
+  #
+  # * we enable all linters by default
+  # * we disable explicitly linters which:
+  #   * do not correspond to our own views of go best practices (e.g. recvcheck, nonamedreturns)
+  #   * impose a lot of (cosmetic) changes for no real value AND do not provide an auto-fix (e.g. godox, nlreturn)
+  #   * impose a lot of not-cosmetic changes with no high value AND do not provide an auto-fix (e.g. err113)
+  #   * introduce breaking changes (normally, we should disable them sparingly with code hints, no globally)
+  #   * we overall agree with but are temporarily disabled: these issues would be addressed progressively
+  #
+  # This project has been living around for about 10 years now.
+  # It adopted golangci-lint as one of its early adopters.
+  # Since then, we've seen a lot of back and forth on how we should write good go code.
+  # So we pick every month's new doxa with a pinch of salt.
+  default: all
   disable:
-    - dupl
-    - gochecknoglobals
-    - gochecknoinits
-    - lll
-    - unparam
+    - dupl  # temporary => should be disabled sparingly
+    - err113 # temporary
+    - exhaustruct # temporary
+    - funlen # temporary
+    - gochecknoglobals  # agree, but breaking
+    - gochecknoinits # agree, but breaking
+    - godox # temporary
+    - ireturn # temporary
+    - lll # unclear added value
+    - nestif # temporary
+    - nonamedreturns # unclear added value
+    - nlreturn # unclear added value
+    - noinlineerr # unclear added value
+    - paralleltest # unclear added value
+    - recvcheck  # disagree
+    - tagliatelle # false positives, want to impose camel case everywhere => should be disabled sparingly only
+    - testpackage # disagree: we like test packages, just not for everything like the linter suggest
+    - tparallel
+    - varnamelen
+    - wrapcheck
+    - wsl # unclear added value
+    - wsl_v5 # unclear added value
   settings:
     depguard:
       rules:
@@ -31,13 +50,18 @@ linters:
       threshold: 200
     goconst:
       min-len: 2
-      min-occurrences: 2
+      min-occurrences: 3
     gocyclo:
-      min-complexity: 25
+      min-complexity: 30
+    cyclop:
+      max-complexity: 30
     govet:
       enable-all: true
       disable:
         - fieldalignment
+    thelper:
+      tb:
+        name: false  # dont' want issue "parameter testing.TB should have name tb"
     testifylint:
       enable:
         - bool-compare

--- a/cmd/swagger/commands/diff.go
+++ b/cmd/swagger/commands/diff.go
@@ -13,24 +13,24 @@ import (
 	"github.com/go-swagger/go-swagger/cmd/swagger/commands/diff"
 )
 
-// JSONFormat for json
+// JSONFormat for json.
 const JSONFormat = "json"
 
 // DiffCommand is a command that generates the diff of two swagger specs.
 //
 // There are no specific options for this expansion.
 type DiffCommand struct {
-	OnlyBreakingChanges bool   `long:"break" short:"b" description:"When present, only shows incompatible changes"`
-	Format              string `long:"format" short:"f" description:"When present, writes output as json" default:"txt" choice:"txt" choice:"json"`
-	IgnoreFile          string `long:"ignore" short:"i" description:"Exception file of diffs to ignore (copy output from json diff format)"  default:"none specified"`
-	Destination         string `long:"dest" short:"d" description:"Output destination file or stdout" default:"stdout"`
+	OnlyBreakingChanges bool   `description:"When present, only shows incompatible changes" long:"break"                                                                        short:"b"`
+	Format              string `choice:"txt"                                                choice:"json"                                                                       default:"txt" description:"When present, writes output as json" long:"format" short:"f"`
+	IgnoreFile          string `default:"none specified"                                    description:"Exception file of diffs to ignore (copy output from json diff format)" long:"ignore" short:"i"`
+	Destination         string `default:"stdout"                                            description:"Output destination file or stdout"                                     long:"dest"   short:"d"`
 	Args                struct {
 		OldSpec string `positional-arg-name:"{old spec}"`
 		NewSpec string `positional-arg-name:"{new spec}"`
 	} `required:"2" positional-args:"specs" description:"Input specs to be diff-ed"`
 }
 
-// Execute diffs the two specs provided
+// Execute diffs the two specs provided.
 func (c *DiffCommand) Execute(_ []string) error {
 	if c.Args.OldSpec == "" || c.Args.NewSpec == "" {
 		return errors.New(`missing arguments for diff command (use --help for more info)`)

--- a/cmd/swagger/commands/diff/array_diff.go
+++ b/cmd/swagger/commands/diff/array_diff.go
@@ -2,17 +2,17 @@ package diff
 
 // This is a simple DSL for diffing arrays
 
-// fromArrayStruct utility struct to encompass diffing of string arrays
+// fromArrayStruct utility struct to encompass diffing of string arrays.
 type fromArrayStruct struct {
 	from []string
 }
 
-// fromStringArray starts a fluent diff expression
+// fromStringArray starts a fluent diff expression.
 func fromStringArray(from []string) fromArrayStruct {
 	return fromArrayStruct{from}
 }
 
-// DiffsTo completes a fluent diff expression
+// DiffsTo completes a fluent diff expression.
 func (f fromArrayStruct) DiffsTo(toArray []string) (added, deleted, common []string) {
 	inFrom := 1
 	inTo := 2
@@ -50,23 +50,23 @@ func (f fromArrayStruct) DiffsTo(toArray []string) (added, deleted, common []str
 	return added, deleted, common
 }
 
-// fromMapStruct utility struct to encompass diffing of string arrays
+// fromMapStruct utility struct to encompass diffing of string arrays.
 type fromMapStruct struct {
 	srcMap map[string]interface{}
 }
 
-// fromStringMap starts a comparison by declaring a source map
+// fromStringMap starts a comparison by declaring a source map.
 func fromStringMap(srcMap map[string]interface{}) fromMapStruct {
 	return fromMapStruct{srcMap}
 }
 
-// Pair stores a pair of items which share a key in two maps
+// Pair stores a pair of items which share a key in two maps.
 type Pair struct {
 	First  interface{}
 	Second interface{}
 }
 
-// DiffsTo - generates diffs for a comparison
+// DiffsTo - generates diffs for a comparison.
 func (f fromMapStruct) DiffsTo(destMap map[string]interface{}) (added, deleted, common map[string]interface{}) {
 	added = make(map[string]interface{})
 	deleted = make(map[string]interface{})

--- a/cmd/swagger/commands/diff/checks.go
+++ b/cmd/swagger/commands/diff/checks.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-openapi/spec"
 )
 
-// CompareEnums returns added, deleted enum values
+// CompareEnums returns added, deleted enum values.
 func CompareEnums(left, right []interface{}) []TypeDiff {
 	diffs := []TypeDiff{}
 
@@ -32,7 +32,7 @@ func CompareEnums(left, right []interface{}) []TypeDiff {
 	return diffs
 }
 
-// CompareProperties recursive property comparison
+// CompareProperties recursive property comparison.
 func CompareProperties(location DifferenceLocation, schema1 *spec.Schema, schema2 *spec.Schema, getRefFn1 SchemaFromRefFn, getRefFn2 SchemaFromRefFn, cmp CompareSchemaFn) []SpecDifference {
 	propDiffs := []SpecDifference{}
 
@@ -45,7 +45,6 @@ func CompareProperties(location DifferenceLocation, schema1 *spec.Schema, schema
 
 	// find deleted and changed properties
 	for eachProp1Name, eachProp1 := range schema1Props {
-		eachProp1 := eachProp1
 		childLoc := addChildDiffNode(location, eachProp1Name, eachProp1.Schema)
 
 		if eachProp2, ok := schema2Props[eachProp1Name]; ok {
@@ -63,7 +62,6 @@ func CompareProperties(location DifferenceLocation, schema1 *spec.Schema, schema
 
 	// find added properties
 	for eachProp2Name, eachProp2 := range schema2.Properties {
-		eachProp2 := eachProp2
 		if _, ok := schema1.Properties[eachProp2Name]; !ok {
 			childLoc := addChildDiffNode(location, eachProp2Name, &eachProp2)
 
@@ -78,7 +76,7 @@ func CompareProperties(location DifferenceLocation, schema1 *spec.Schema, schema
 	return propDiffs
 }
 
-// CompareFloatValues compares a float data item
+// CompareFloatValues compares a float data item.
 func CompareFloatValues(fieldName string, val1 *float64, val2 *float64, ifGreaterCode SpecChangeCode, ifLessCode SpecChangeCode) []TypeDiff {
 	diffs := []TypeDiff{}
 	if val1 != nil && val2 != nil {
@@ -99,7 +97,7 @@ func CompareFloatValues(fieldName string, val1 *float64, val2 *float64, ifGreate
 	return diffs
 }
 
-// CompareIntValues compares to int data items
+// CompareIntValues compares to int data items.
 func CompareIntValues(fieldName string, val1 *int64, val2 *int64, ifGreaterCode SpecChangeCode, ifLessCode SpecChangeCode) []TypeDiff {
 	diffs := []TypeDiff{}
 	if val1 != nil && val2 != nil {
@@ -120,7 +118,7 @@ func CompareIntValues(fieldName string, val1 *int64, val2 *int64, ifGreaterCode 
 	return diffs
 }
 
-// CheckToFromPrimitiveType check for diff to or from a primitive
+// CheckToFromPrimitiveType check for diff to or from a primitive.
 func CheckToFromPrimitiveType(diffs []TypeDiff, type1, type2 interface{}) []TypeDiff {
 	type1IsPrimitive := isPrimitive(type1)
 	type2IsPrimitive := isPrimitive(type2)
@@ -135,7 +133,7 @@ func CheckToFromPrimitiveType(diffs []TypeDiff, type1, type2 interface{}) []Type
 	return diffs
 }
 
-// CheckRefChange has the property ref changed
+// CheckRefChange has the property ref changed.
 func CheckRefChange(diffs []TypeDiff, type1, type2 interface{}) (diffReturn []TypeDiff) {
 	diffReturn = diffs
 	if isRefType(type1) && isRefType(type2) {
@@ -151,7 +149,7 @@ func CheckRefChange(diffs []TypeDiff, type1, type2 interface{}) (diffReturn []Ty
 	return diffReturn
 }
 
-// checkNumericTypeChanges checks for changes to or from a numeric type
+// checkNumericTypeChanges checks for changes to or from a numeric type.
 func checkNumericTypeChanges(diffs []TypeDiff, type1, type2 *spec.SchemaProps) []TypeDiff {
 	// Number
 	_, type1IsNumeric := numberWideness[type1.Type[0]]
@@ -185,7 +183,7 @@ func checkNumericTypeChanges(diffs []TypeDiff, type1, type2 *spec.SchemaProps) [
 	return diffs
 }
 
-// CheckStringTypeChanges checks for changes to or from a string type
+// CheckStringTypeChanges checks for changes to or from a string type.
 func CheckStringTypeChanges(diffs []TypeDiff, type1, type2 *spec.SchemaProps) []TypeDiff {
 	// string changes
 	if type1.Type[0] == StringType &&
@@ -207,7 +205,7 @@ func CheckStringTypeChanges(diffs []TypeDiff, type1, type2 *spec.SchemaProps) []
 	return diffs
 }
 
-// CheckToFromRequired checks for changes to or from a required property
+// CheckToFromRequired checks for changes to or from a required property.
 func CheckToFromRequired(required1, required2 bool) (diffs []TypeDiff) {
 	if required1 != required2 {
 		code := ChangedOptionalToRequired

--- a/cmd/swagger/commands/diff/checks_test.go
+++ b/cmd/swagger/commands/diff/checks_test.go
@@ -58,7 +58,7 @@ func Test_getRef(t *testing.T) {
 // 	}
 // 	tests := []struct {
 // 		name string
-// 		args args
+// 		args
 // 		want []TypeDiff
 // 	}{
 // 		{

--- a/cmd/swagger/commands/diff/compatibility.go
+++ b/cmd/swagger/commands/diff/compatibility.go
@@ -1,6 +1,6 @@
 package diff
 
-// CompatibilityPolicy decides which changes are breaking and which are not
+// CompatibilityPolicy decides which changes are breaking and which are not.
 type CompatibilityPolicy struct {
 	ForResponse map[SpecChangeCode]Compatibility
 	ForRequest  map[SpecChangeCode]Compatibility

--- a/cmd/swagger/commands/diff/difference_location.go
+++ b/cmd/swagger/commands/diff/difference_location.go
@@ -1,6 +1,6 @@
 package diff
 
-// DifferenceLocation indicates where the difference occurs
+// DifferenceLocation indicates where the difference occurs.
 type DifferenceLocation struct {
 	URL      string `json:"url"`
 	Method   string `json:"method,omitempty"`
@@ -8,7 +8,7 @@ type DifferenceLocation struct {
 	Node     *Node  `json:"node,omitempty"`
 }
 
-// AddNode returns a copy of this location with the leaf node added
+// AddNode returns a copy of this location with the leaf node added.
 func (dl DifferenceLocation) AddNode(node *Node) DifferenceLocation {
 	newLoc := dl
 

--- a/cmd/swagger/commands/diff/difftypes.go
+++ b/cmd/swagger/commands/diff/difftypes.go
@@ -7,117 +7,117 @@ import (
 	"log"
 )
 
-// SpecChangeCode enumerates the various types of diffs from one spec to another
+// SpecChangeCode enumerates the various types of diffs from one spec to another.
 type SpecChangeCode int
 
 const (
-	// NoChangeDetected - the specs have no changes
+	// NoChangeDetected - the specs have no changes.
 	NoChangeDetected SpecChangeCode = iota
-	// DeletedProperty - A message property has been deleted in the new spec
+	// DeletedProperty - A message property has been deleted in the new spec.
 	DeletedProperty
-	// AddedProperty - A message property has been added in the new spec
+	// AddedProperty - A message property has been added in the new spec.
 	AddedProperty
-	// AddedRequiredProperty - A required message property has been added in the new spec
+	// AddedRequiredProperty - A required message property has been added in the new spec.
 	AddedRequiredProperty
-	// DeletedOptionalParam - An endpoint parameter has been deleted in the new spec
+	// DeletedOptionalParam - An endpoint parameter has been deleted in the new spec.
 	DeletedOptionalParam
-	// ChangedDescripton - Changed a description
+	// ChangedDescripton - Changed a description.
 	ChangedDescripton
-	// AddedDescripton - Added a description
+	// AddedDescripton - Added a description.
 	AddedDescripton
-	// DeletedDescripton - Deleted a description
+	// DeletedDescripton - Deleted a description.
 	DeletedDescripton
-	// ChangedTag - Changed a tag
+	// ChangedTag - Changed a tag.
 	ChangedTag
-	// AddedTag - Added a tag
+	// AddedTag - Added a tag.
 	AddedTag
-	// DeletedTag - Deleted a tag
+	// DeletedTag - Deleted a tag.
 	DeletedTag
-	// DeletedResponse - An endpoint response has been deleted in the new spec
+	// DeletedResponse - An endpoint response has been deleted in the new spec.
 	DeletedResponse
-	// DeletedEndpoint - An endpoint has been deleted in the new spec
+	// DeletedEndpoint - An endpoint has been deleted in the new spec.
 	DeletedEndpoint
-	// DeletedDeprecatedEndpoint - A deprecated endpoint has been deleted in the new spec
+	// DeletedDeprecatedEndpoint - A deprecated endpoint has been deleted in the new spec.
 	DeletedDeprecatedEndpoint
-	// AddedRequiredParam - A required parameter has been added in the new spec
+	// AddedRequiredParam - A required parameter has been added in the new spec.
 	AddedRequiredParam
-	// DeletedRequiredParam - A required parameter has been deleted in the new spec
+	// DeletedRequiredParam - A required parameter has been deleted in the new spec.
 	DeletedRequiredParam
-	// AddedEndpoint - An endpoint has been added in the new spec
+	// AddedEndpoint - An endpoint has been added in the new spec.
 	AddedEndpoint
-	// WidenedType - An type has been changed to a more permissive type eg int->string
+	// WidenedType - An type has been changed to a more permissive type eg int->string.
 	WidenedType
-	// NarrowedType - An type has been changed to a less permissive type eg string->int
+	// NarrowedType - An type has been changed to a less permissive type eg string->int.
 	NarrowedType
-	// ChangedToCompatibleType - An type has been changed to a compatible type eg password->string
+	// ChangedToCompatibleType - An type has been changed to a compatible type eg password->string.
 	ChangedToCompatibleType
-	// ChangedType - An type has been changed to a type whose relative compatibility cannot be determined
+	// ChangedType - An type has been changed to a type whose relative compatibility cannot be determined.
 	ChangedType
-	// AddedEnumValue - An enum type has had a new potential value added to it
+	// AddedEnumValue - An enum type has had a new potential value added to it.
 	AddedEnumValue
-	// DeletedEnumValue - An enum type has had a existing value removed from it
+	// DeletedEnumValue - An enum type has had a existing value removed from it.
 	DeletedEnumValue
-	// AddedOptionalParam - A new optional parameter has been added to the new spec
+	// AddedOptionalParam - A new optional parameter has been added to the new spec.
 	AddedOptionalParam
-	// ChangedOptionalToRequired - An optional parameter is now required in the new spec
+	// ChangedOptionalToRequired - An optional parameter is now required in the new spec.
 	ChangedOptionalToRequired
-	// ChangedRequiredToOptional - An required parameter is now optional in the new spec
+	// ChangedRequiredToOptional - An required parameter is now optional in the new spec.
 	ChangedRequiredToOptional
-	// AddedResponse An endpoint has new response code in the new spec
+	// AddedResponse An endpoint has new response code in the new spec.
 	AddedResponse
-	// AddedConsumesFormat - a new consumes format (json/xml/yaml etc) has been added in the new spec
+	// AddedConsumesFormat - a new consumes format (json/xml/yaml etc) has been added in the new spec.
 	AddedConsumesFormat
-	// DeletedConsumesFormat - an existing format has been removed in the new spec
+	// DeletedConsumesFormat - an existing format has been removed in the new spec.
 	DeletedConsumesFormat
-	// AddedProducesFormat - a new produces format (json/xml/yaml etc) has been added in the new spec
+	// AddedProducesFormat - a new produces format (json/xml/yaml etc) has been added in the new spec.
 	AddedProducesFormat
-	// DeletedProducesFormat - an existing produces format has been removed in the new spec
+	// DeletedProducesFormat - an existing produces format has been removed in the new spec.
 	DeletedProducesFormat
-	// AddedSchemes - a new scheme has been added to the new spec
+	// AddedSchemes - a new scheme has been added to the new spec.
 	AddedSchemes
-	// DeletedSchemes - a scheme has been removed from the new spec
+	// DeletedSchemes - a scheme has been removed from the new spec.
 	DeletedSchemes
 	// ChangedHostURL - the host url has been changed. If this is used in the client generation, then clients will break.
 	ChangedHostURL
 	// ChangedBasePath - the host base path has been changed. If this is used in the client generation, then clients will break.
 	ChangedBasePath
-	// AddedResponseHeader Added a header Item
+	// AddedResponseHeader Added a header Item.
 	AddedResponseHeader
-	// ChangedResponseHeader Added a header Item
+	// ChangedResponseHeader Added a header Item.
 	ChangedResponseHeader
-	// DeletedResponseHeader Added a header Item
+	// DeletedResponseHeader Added a header Item.
 	DeletedResponseHeader
-	// RefTargetChanged Changed a ref to point to a different object
+	// RefTargetChanged Changed a ref to point to a different object.
 	RefTargetChanged
-	// RefTargetRenamed Renamed a ref to point to the same object
+	// RefTargetRenamed Renamed a ref to point to the same object.
 	RefTargetRenamed
-	// DeletedConstraint Deleted a schema constraint
+	// DeletedConstraint Deleted a schema constraint.
 	DeletedConstraint
-	// AddedConstraint Added a schema constraint
+	// AddedConstraint Added a schema constraint.
 	AddedConstraint
-	// DeletedDefinition removed one of the definitions
+	// DeletedDefinition removed one of the definitions.
 	DeletedDefinition
-	// AddedDefinition removed one of the definitions
+	// AddedDefinition removed one of the definitions.
 	AddedDefinition
-	// ChangedDefault - Changed default value
+	// ChangedDefault - Changed default value.
 	ChangedDefault
-	// AddedDefault - Added a default value
+	// AddedDefault - Added a default value.
 	AddedDefault
-	// DeletedDefault - Deleted a default value
+	// DeletedDefault - Deleted a default value.
 	DeletedDefault
-	// ChangedExample - Changed an example value
+	// ChangedExample - Changed an example value.
 	ChangedExample
-	// AddedExample - Added an example value
+	// AddedExample - Added an example value.
 	AddedExample
-	// DeletedExample - Deleted an example value
+	// DeletedExample - Deleted an example value.
 	DeletedExample
-	// ChangedCollectionFormat - A collectionFormat has been changed to a collectionFormat whose relative compatibility cannot be determined
+	// ChangedCollectionFormat - A collectionFormat has been changed to a collectionFormat whose relative compatibility cannot be determined.
 	ChangedCollectionFormat
-	// DeletedExtension deleted an extension
+	// DeletedExtension deleted an extension.
 	DeletedExtension
-	// AddedExtension added an extension
+	// AddedExtension added an extension.
 	AddedExtension
-	// ChangedExtensionValue changed an extension value
+	// ChangedExtensionValue changed an extension value.
 	ChangedExtensionValue
 )
 
@@ -237,7 +237,7 @@ var toStringSpecChangeCode = map[SpecChangeCode]string{
 
 var toIDSpecChangeCode = map[string]SpecChangeCode{}
 
-// Description returns an english version of this error
+// Description returns an english version of this error.
 func (s SpecChangeCode) Description() (result string) {
 	result, ok := toLongStringSpecChangeCode[s]
 	if !ok {
@@ -247,12 +247,12 @@ func (s SpecChangeCode) Description() (result string) {
 	return result
 }
 
-// MarshalJSON marshals the enum as a quoted json string
+// MarshalJSON marshals the enum as a quoted json string.
 func (s SpecChangeCode) MarshalJSON() ([]byte, error) {
 	return stringAsQuotedBytes(toStringSpecChangeCode[s])
 }
 
-// UnmarshalJSON unmashalls a quoted json string to the enum value
+// UnmarshalJSON unmashalls a quoted json string to the enum value.
 func (s *SpecChangeCode) UnmarshalJSON(b []byte) error {
 	str, err := readStringFromByteStream(b)
 	if err != nil {
@@ -269,15 +269,15 @@ func (s *SpecChangeCode) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Compatibility - whether this is a breaking or non-breaking change
+// Compatibility - whether this is a breaking or non-breaking change.
 type Compatibility int
 
 const (
-	// Breaking this change could break existing clients
+	// Breaking this change could break existing clients.
 	Breaking Compatibility = iota
-	// NonBreaking This is a backwards-compatible API change
+	// NonBreaking This is a backwards-compatible API change.
 	NonBreaking
-	// Warning changes are technically non-breaking but can cause behavior changes in client and thus should be reported differently
+	// Warning changes are technically non-breaking but can cause behavior changes in client and thus should be reported differently.
 	Warning
 )
 
@@ -293,12 +293,12 @@ var toStringCompatibility = map[Compatibility]string{
 
 var toIDCompatibility = map[string]Compatibility{}
 
-// MarshalJSON marshals the enum as a quoted json string
+// MarshalJSON marshals the enum as a quoted json string.
 func (s Compatibility) MarshalJSON() ([]byte, error) {
 	return stringAsQuotedBytes(toStringCompatibility[s])
 }
 
-// UnmarshalJSON unmashals a quoted json string to the enum value
+// UnmarshalJSON unmashals a quoted json string to the enum value.
 func (s *Compatibility) UnmarshalJSON(b []byte) error {
 	str, err := readStringFromByteStream(b)
 	if err != nil {

--- a/cmd/swagger/commands/diff/node.go
+++ b/cmd/swagger/commands/diff/node.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-openapi/spec"
 )
 
-// Node is the position od a diff in a spec
+// Node is the position od a diff in a spec.
 type Node struct {
 	Field     string `json:"name,omitempty"`
 	TypeName  string `json:"type,omitempty"`
@@ -14,7 +14,7 @@ type Node struct {
 	ChildNode *Node  `json:"child,omitempty"`
 }
 
-// String std string render
+// String std string render.
 func (n *Node) String() string {
 	name := n.Field
 	if n.IsArray {
@@ -28,7 +28,7 @@ func (n *Node) String() string {
 	return name
 }
 
-// AddLeafNode Adds (recursive) a Child to the first non-nil child found
+// AddLeafNode Adds (recursive) a Child to the first non-nil child found.
 func (n *Node) AddLeafNode(toAdd *Node) *Node {
 	if n.ChildNode == nil {
 		n.ChildNode = toAdd
@@ -39,7 +39,7 @@ func (n *Node) AddLeafNode(toAdd *Node) *Node {
 	return n
 }
 
-// Copy deep copy of this node and children
+// Copy deep copy of this node and children.
 func (n Node) Copy() *Node {
 	newChild := n.ChildNode
 	if newChild != nil {

--- a/cmd/swagger/commands/diff/reporting.go
+++ b/cmd/swagger/commands/diff/reporting.go
@@ -9,14 +9,14 @@ import (
 	"github.com/go-openapi/spec"
 )
 
-// ArrayType const for array
+// ArrayType const for array.
 var ArrayType = "array"
 
-// ObjectType const for object
+// ObjectType const for object.
 var ObjectType = "object"
 
 // Compare returns the result of analysing breaking and non breaking changes
-// between to Swagger specs
+// between to Swagger specs.
 func Compare(spec1, spec2 *spec.Swagger) (diffs SpecDifferences, err error) {
 	analyser := NewSpecAnalyser()
 	err = analyser.Analyse(spec1, spec2)
@@ -27,26 +27,26 @@ func Compare(spec1, spec2 *spec.Swagger) (diffs SpecDifferences, err error) {
 	return diffs, nil
 }
 
-// PathItemOp - combines path and operation into a single keyed entity
+// PathItemOp - combines path and operation into a single keyed entity.
 type PathItemOp struct {
 	ParentPathItem *spec.PathItem  `json:"pathitem"`
 	Operation      *spec.Operation `json:"operation"`
 	Extensions     spec.Extensions `json:"extensions"`
 }
 
-// URLMethod - combines url and method into a single keyed entity
+// URLMethod - combines url and method into a single keyed entity.
 type URLMethod struct {
 	Path   string `json:"path"`
 	Method string `json:"method"`
 }
 
-// DataDirection indicates the direction of change Request vs Response
+// DataDirection indicates the direction of change Request vs Response.
 type DataDirection int
 
 const (
-	// Request Used for messages/param diffs in a request
+	// Request Used for messages/param diffs in a request.
 	Request DataDirection = iota
-	// Response Used for messages/param diffs in a response
+	// Response Used for messages/param diffs in a response.
 	Response
 )
 
@@ -81,15 +81,15 @@ func primitiveTypeString(typeName, typeFormat string) string {
 	return typeName
 }
 
-// TypeDiff - describes a primitive type change
+// TypeDiff - describes a primitive type change.
 type TypeDiff struct {
-	Change      SpecChangeCode `json:"change-type,omitempty"`
+	Change      SpecChangeCode `json:"change_type,omitempty"`
 	Description string         `json:"description,omitempty"`
-	FromType    string         `json:"from-type,omitempty"`
+	FromType    string         `json:"from_type,omitempty"`
 	ToType      string         `json:"to-type,omitempty"`
 }
 
-// didn't use 'width' so as not to confuse with bit width
+// didn't use 'width' so as not to confuse with bit width.
 var numberWideness = map[string]int{
 	"number":        3,
 	"number.double": 3,
@@ -108,7 +108,7 @@ func prettyprint(b []byte) (io.ReadWriter, error) {
 	return &out, err
 }
 
-// JSONMarshal allows the item to be correctly rendered to json
+// JSONMarshal allows the item to be correctly rendered to json.
 func JSONMarshal(t interface{}) ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)

--- a/cmd/swagger/commands/diff/spec_analyser.go
+++ b/cmd/swagger/commands/diff/spec_analyser.go
@@ -10,25 +10,25 @@ import (
 	"github.com/go-openapi/spec"
 )
 
-// StringType For identifying string types
+// StringType For identifying string types.
 const StringType = "string"
 
-// URLMethodResponse encapsulates these three elements to act as a map key
+// URLMethodResponse encapsulates these three elements to act as a map key.
 type URLMethodResponse struct {
 	Path     string `json:"path"`
 	Method   string `json:"method"`
 	Response string `json:"response"`
 }
 
-// MarshalText - for serializing as a map key
+// MarshalText - for serializing as a map key.
 func (p URLMethod) MarshalText() (text []byte, err error) {
 	return fmt.Appendf([]byte{}, "%s %s", p.Path, p.Method), nil
 }
 
-// URLMethods allows iteration of endpoints based on url and method
+// URLMethods allows iteration of endpoints based on url and method.
 type URLMethods map[URLMethod]*PathItemOp
 
-// SpecAnalyser contains all the differences for a Spec
+// SpecAnalyser contains all the differences for a Spec.
 type SpecAnalyser struct {
 	Diffs                 SpecDifferences
 	urlMethods1           URLMethods
@@ -43,7 +43,7 @@ type SpecAnalyser struct {
 	titler          cases.Caser
 }
 
-// NewSpecAnalyser returns an empty SpecDiffs
+// NewSpecAnalyser returns an empty SpecDiffs.
 func NewSpecAnalyser() *SpecAnalyser {
 	return &SpecAnalyser{
 		Diffs:                 SpecDifferences{},
@@ -52,7 +52,7 @@ func NewSpecAnalyser() *SpecAnalyser {
 	}
 }
 
-// Analyse the differences in two specs
+// Analyse the differences in two specs.
 func (sd *SpecAnalyser) Analyse(spec1, spec2 *spec.Swagger) error {
 	sd.schemasCompared = make(map[string]struct{})
 	sd.Definitions1 = spec1.Definitions
@@ -132,7 +132,7 @@ func (sd *SpecAnalyser) analyseEndpoints() {
 	sd.findAddedEndpoints()
 }
 
-// AnalyseDefinitions check for changes to definition objects not referenced in any endpoint
+// AnalyseDefinitions check for changes to definition objects not referenced in any endpoint.
 func (sd *SpecAnalyser) AnalyseDefinitions() {
 	alreadyReferenced := map[string]bool{}
 	for k := range sd.ReferencedDefinitions {
@@ -172,7 +172,6 @@ func (sd *SpecAnalyser) analyseEndpointData() {
 			}
 
 			sd.compareDescripton(location, op1.Operation.Description, op2.Operation.Description)
-
 		}
 	}
 }
@@ -185,7 +184,6 @@ func (sd *SpecAnalyser) analyseRequestParams() {
 		sd.titler.Reset()
 		for URLMethod, op2 := range sd.urlMethods2 {
 			if op1, ok := sd.urlMethods1[URLMethod]; ok {
-
 				params1 := getParams(op1.ParentPathItem.Parameters, op1.Operation.Parameters, paramLocation)
 				params2 := getParams(op2.ParentPathItem.Parameters, op2.Operation.Parameters, paramLocation)
 
@@ -305,7 +303,6 @@ func (sd *SpecAnalyser) analyseResponseParams() {
 							Code:               AddedProperty,
 						})
 					}
-
 				} else {
 					// op2Response
 					sd.Diffs = sd.Diffs.addDiff(SpecDifference{
@@ -361,7 +358,6 @@ func (sd *SpecAnalyser) analyzeOperationExtensions() {
 				resp2 := op2.Operation.Responses.StatusCodeResponses[code]
 				sd.analyzeSchemaExtensions(resp.Schema, resp2.Schema, code, urlMethod)
 			}
-
 		}
 	}
 
@@ -546,7 +542,7 @@ func addTypeDiff(diffs []TypeDiff, diff TypeDiff) []TypeDiff {
 	return diffs
 }
 
-// CompareProps computes type specific property diffs
+// CompareProps computes type specific property diffs.
 func (sd *SpecAnalyser) CompareProps(type1, type2 *spec.SchemaProps) []TypeDiff {
 	diffs := []TypeDiff{}
 
@@ -671,7 +667,7 @@ func (sd *SpecAnalyser) getRefSchemaFromSpec2(ref spec.Ref) (*spec.Schema, strin
 	return sd.schemaFromRef(ref, &sd.Definitions2)
 }
 
-// CompareSchemaFn Fn spec for comparing schemas
+// CompareSchemaFn Fn spec for comparing schemas.
 type CompareSchemaFn func(location DifferenceLocation, schema1, schema2 *spec.Schema)
 
 func (sd *SpecAnalyser) compareSchema(location DifferenceLocation, schema1, schema2 *spec.Schema) {
@@ -847,11 +843,11 @@ func schemaLocationKey(location DifferenceLocation) string {
 	return k
 }
 
-// PropertyDefn combines a property with its required-ness
+// PropertyDefn combines a property with its required-ness.
 type PropertyDefn struct {
 	Schema   *spec.Schema
 	Required bool
 }
 
-// PropertyMap a unified map including all AllOf fields
+// PropertyMap a unified map including all AllOf fields.
 type PropertyMap map[string]PropertyDefn

--- a/cmd/swagger/commands/diff/spec_difference.go
+++ b/cmd/swagger/commands/diff/spec_difference.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// SpecDifference encapsulates the details of an individual diff in part of a spec
+// SpecDifference encapsulates the details of an individual diff in part of a spec.
 type SpecDifference struct {
 	DifferenceLocation DifferenceLocation `json:"location"`
 	Code               SpecChangeCode     `json:"code"`
@@ -17,10 +17,10 @@ type SpecDifference struct {
 	DiffInfo           string             `json:"info,omitempty"`
 }
 
-// SpecDifferences list of differences
+// SpecDifferences list of differences.
 type SpecDifferences []SpecDifference
 
-// Matches returns true if the diff matches another
+// Matches returns true if the diff matches another.
 func (sd SpecDifference) Matches(other SpecDifference) bool {
 	return sd.Code == other.Code &&
 		sd.Compatibility == other.Compatibility &&
@@ -48,7 +48,7 @@ func equalNodes(a, b *Node) bool {
 		equalNodes(a.ChildNode, b.ChildNode)
 }
 
-// BreakingChangeCount Calculates the breaking change count
+// BreakingChangeCount Calculates the breaking change count.
 func (sd SpecDifferences) BreakingChangeCount() int {
 	count := 0
 	for _, eachDiff := range sd {
@@ -59,7 +59,7 @@ func (sd SpecDifferences) BreakingChangeCount() int {
 	return count
 }
 
-// WarningChangeCount Calculates the warning change count
+// WarningChangeCount Calculates the warning change count.
 func (sd SpecDifferences) WarningChangeCount() int {
 	count := 0
 	for _, eachDiff := range sd {
@@ -70,7 +70,7 @@ func (sd SpecDifferences) WarningChangeCount() int {
 	return count
 }
 
-// FilterIgnores returns a copy of the list without the items in the specified ignore list
+// FilterIgnores returns a copy of the list without the items in the specified ignore list.
 func (sd SpecDifferences) FilterIgnores(ignores SpecDifferences) SpecDifferences {
 	newDiffs := SpecDifferences{}
 	for _, eachDiff := range sd {
@@ -81,7 +81,7 @@ func (sd SpecDifferences) FilterIgnores(ignores SpecDifferences) SpecDifferences
 	return newDiffs
 }
 
-// Contains Returns true if the item contains the specified item
+// Contains Returns true if the item contains the specified item.
 func (sd SpecDifferences) Contains(diff SpecDifference) bool {
 	for _, eachDiff := range sd {
 		if eachDiff.Matches(diff) {
@@ -91,7 +91,7 @@ func (sd SpecDifferences) Contains(diff SpecDifference) bool {
 	return false
 }
 
-// String std string renderer
+// String std string renderer.
 func (sd SpecDifference) String() string {
 	isResponse := sd.DifferenceLocation.Response > 0
 	hasMethod := len(sd.DifferenceLocation.Method) > 0
@@ -143,7 +143,7 @@ func (sd SpecDifferences) addDiff(diff SpecDifference) SpecDifferences {
 	return append(sd, diff)
 }
 
-// ReportCompatibility lists and spec
+// ReportCompatibility lists and spec.
 func (sd *SpecDifferences) ReportCompatibility() (io.Reader, error, error) {
 	var out bytes.Buffer
 	breakingCount := sd.BreakingChangeCount()
@@ -181,7 +181,7 @@ func (sd SpecDifferences) reportChanges(compat Compatibility) io.Reader {
 	return &out
 }
 
-// ReportAllDiffs lists all the diffs between two specs
+// ReportAllDiffs lists all the diffs between two specs.
 func (sd SpecDifferences) ReportAllDiffs(fmtJSON bool) (io.Reader, error, error) {
 	if fmtJSON {
 		b, err := JSONMarshal(sd)
@@ -193,7 +193,7 @@ func (sd SpecDifferences) ReportAllDiffs(fmtJSON bool) (io.Reader, error, error)
 	}
 	numDiffs := len(sd)
 	if numDiffs == 0 {
-		return bytes.NewBuffer([]byte("No changes identified\n")), nil, nil
+		return bytes.NewBufferString("No changes identified\n"), nil, nil
 	}
 
 	var out bytes.Buffer

--- a/cmd/swagger/commands/diff/type_adapters.go
+++ b/cmd/swagger/commands/diff/type_adapters.go
@@ -70,7 +70,7 @@ func forParam(param spec.Parameter) *spec.SchemaProps {
 	}
 }
 
-// OperationMap saves indexing operations in PathItems individually
+// OperationMap saves indexing operations in PathItems individually.
 type OperationMap map[string]*spec.Operation
 
 func toMap(item *spec.PathItem) OperationMap {
@@ -104,7 +104,6 @@ func getURLMethodsFor(spec *spec.Swagger) URLMethods {
 	returnURLMethods := URLMethods{}
 
 	for url, eachPath := range spec.Paths.Paths {
-		eachPath := eachPath
 		opsMap := toMap(&eachPath)
 		for method, op := range opsMap {
 			returnURLMethods[URLMethod{url, method}] = &PathItemOp{&eachPath, op, eachPath.Extensions}
@@ -117,7 +116,7 @@ func isStringType(typeName string) bool {
 	return typeName == "string" || typeName == "password"
 }
 
-// SchemaFromRefFn define this to get a schema for a ref
+// SchemaFromRefFn define this to get a schema for a ref.
 type SchemaFromRefFn func(spec.Ref) (*spec.Schema, string)
 
 func propertiesFor(schema *spec.Schema, getRefFn SchemaFromRefFn) PropertyMap {
@@ -134,7 +133,6 @@ func propertiesFor(schema *spec.Schema, getRefFn SchemaFromRefFn) PropertyMap {
 
 	if schema.Properties != nil {
 		for name, prop := range schema.Properties {
-			prop := prop
 			required := requiredMap[name]
 			props[name] = PropertyDefn{Schema: &prop, Required: required}
 		}

--- a/cmd/swagger/commands/expand.go
+++ b/cmd/swagger/commands/expand.go
@@ -19,12 +19,12 @@ import (
 //
 // There are no specific options for this expansion.
 type ExpandSpec struct {
-	Compact bool           `long:"compact" description:"applies to JSON formatted specs. When present, doesn't prettify the json"`
-	Output  flags.Filename `long:"output" short:"o" description:"the file to write to"`
-	Format  string         `long:"format" description:"the format for the spec document" default:"json" choice:"yaml" choice:"json"`
+	Compact bool           `description:"applies to JSON formatted specs. When present, doesn't prettify the json" long:"compact"`
+	Output  flags.Filename `description:"the file to write to"                                                     long:"output"  short:"o"`
+	Format  string         `choice:"yaml"                                                                          choice:"json"  default:"json" description:"the format for the spec document" long:"format"`
 }
 
-// Execute expands the spec
+// Execute expands the spec.
 func (c *ExpandSpec) Execute(args []string) error {
 	if len(args) != 1 {
 		return errors.New("expand command requires the single swagger document url to be specified")

--- a/cmd/swagger/commands/expand_test.go
+++ b/cmd/swagger/commands/expand_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Commands requires at least one arg
+// Commands requires at least one arg.
 func TestCmd_Expand(t *testing.T) {
 	v := &ExpandSpec{}
 	testRequireParam(t, v)
@@ -18,8 +18,7 @@ func TestCmd_Expand(t *testing.T) {
 
 func TestCmd_Expand_NoError(t *testing.T) {
 	specDoc := filepath.Join(fixtureBase(), "bugs", "1536", "fixture-1536.yaml")
-	outDir, output := getOutput(t, specDoc, "flatten", "fixture-1536-flat-expand.json")
-	defer os.RemoveAll(outDir)
+	output := filepath.Join(t.TempDir(), "fixture-1536-flat-expand.json")
 	v := &ExpandSpec{
 		Format:  "json",
 		Compact: false,

--- a/cmd/swagger/commands/flatten.go
+++ b/cmd/swagger/commands/flatten.go
@@ -13,15 +13,16 @@ import (
 
 // FlattenSpec is a command that flattens a swagger document
 // which will expand the remote references in a spec and move inline schemas to definitions
-// after flattening there are no complex inlined anymore
+// after flattening there are no complex inlined anymore.
 type FlattenSpec struct {
-	Compact bool           `long:"compact" description:"applies to JSON formatted specs. When present, doesn't prettify the json"`
-	Output  flags.Filename `long:"output" short:"o" description:"the file to write to"`
-	Format  string         `long:"format" description:"the format for the spec document" default:"json" choice:"yaml" choice:"json"`
 	generate.FlattenCmdOptions
+
+	Compact bool           `description:"applies to JSON formatted specs. When present, doesn't prettify the json" long:"compact"`
+	Output  flags.Filename `description:"the file to write to"                                                     long:"output"  short:"o"`
+	Format  string         `choice:"yaml"                                                                          choice:"json"  default:"json" description:"the format for the spec document" long:"format"`
 }
 
-// Execute flattens the spec
+// Execute flattens the spec.
 func (c *FlattenSpec) Execute(args []string) error {
 	if len(args) != 1 {
 		return errors.New("flatten command requires the single swagger document url to be specified")

--- a/cmd/swagger/commands/flatten_test.go
+++ b/cmd/swagger/commands/flatten_test.go
@@ -16,7 +16,7 @@ type executable interface {
 	Execute([]string) error
 }
 
-// Commands requires at least one arg
+// Commands requires at least one arg.
 func TestCmd_Flatten(t *testing.T) {
 	v := &FlattenSpec{}
 	testRequireParam(t, v)
@@ -24,13 +24,13 @@ func TestCmd_Flatten(t *testing.T) {
 
 func TestCmd_Flatten_Default(t *testing.T) {
 	specDoc := filepath.Join(fixtureBase(), "bugs", "1536", "fixture-1536.yaml")
-	outDir, output := getOutput(t, specDoc, "flatten", "fixture-1536-flat-minimal.json")
-	defer os.RemoveAll(outDir)
+	output := filepath.Join(t.TempDir(), "fixture-1536-flat-minimal.json")
 	v := &FlattenSpec{
 		Format:  "json",
 		Compact: true,
 		Output:  flags.Filename(output),
 	}
+
 	testProduceOutput(t, v, specDoc, output)
 }
 
@@ -41,8 +41,7 @@ func TestCmd_Flatten_Error(t *testing.T) {
 
 func TestCmd_Flatten_Issue2919(t *testing.T) {
 	specDoc := filepath.Join(fixtureBase(), "bugs", "2919", "edge-api", "client.yml")
-	outDir, output := getOutput(t, specDoc, "flatten", "fixture-2919-flat-minimal.yml")
-	defer os.RemoveAll(outDir)
+	output := filepath.Join(t.TempDir(), "fixture-2919-flat-minimal.yml")
 
 	v := &FlattenSpec{
 		Format:  "yaml",
@@ -54,8 +53,7 @@ func TestCmd_Flatten_Issue2919(t *testing.T) {
 
 func TestCmd_FlattenKeepNames_Issue2334(t *testing.T) {
 	specDoc := filepath.Join(fixtureBase(), "bugs", "2334", "swagger.yaml")
-	outDir, output := getOutput(t, specDoc, "flatten", "fixture-2334-flat-keep-names.yaml")
-	defer os.RemoveAll(outDir)
+	output := filepath.Join(t.TempDir(), "fixture-2334-flat-keep-names.yaml")
 
 	v := &FlattenSpec{
 		Format:  "yaml",
@@ -65,6 +63,7 @@ func TestCmd_FlattenKeepNames_Issue2334(t *testing.T) {
 			WithFlatten: []string{"keep-names"},
 		},
 	}
+
 	testProduceOutput(t, v, specDoc, output)
 	buf, err := os.ReadFile(output)
 	require.NoError(t, err)
@@ -76,12 +75,16 @@ func TestCmd_FlattenKeepNames_Issue2334(t *testing.T) {
 }
 
 func testValidRefs(t *testing.T, v executable) {
+	t.Helper()
+
 	specDoc := filepath.Join(fixtureBase(), "expansion", "invalid-refs.json")
 	result := v.Execute([]string{specDoc})
 	require.Error(t, result)
 }
 
 func testRequireParam(t *testing.T, v executable) {
+	t.Helper()
+
 	result := v.Execute([]string{})
 	require.Error(t, result)
 
@@ -89,13 +92,9 @@ func testRequireParam(t *testing.T, v executable) {
 	require.Error(t, result)
 }
 
-func getOutput(t *testing.T, specDoc, _, filename string) (string, string) {
-	outDir, err := os.MkdirTemp(filepath.Dir(specDoc), "flatten")
-	require.NoError(t, err)
-	return outDir, filepath.Join(outDir, filename)
-}
-
 func testProduceOutput(t *testing.T, v executable, specDoc, output string) {
+	t.Helper()
+
 	require.NoError(t, v.Execute([]string{specDoc}))
 	_, exists := os.Stat(output)
 	assert.False(t, os.IsNotExist(exists))

--- a/cmd/swagger/commands/generate.go
+++ b/cmd/swagger/commands/generate.go
@@ -16,7 +16,7 @@ package commands
 
 import "github.com/go-swagger/go-swagger/cmd/swagger/commands/generate"
 
-// Generate command to group all generator commands together
+// Generate command to group all generator commands together.
 type Generate struct {
 	Model     *generate.Model     `command:"model"`
 	Operation *generate.Operation `command:"operation"`

--- a/cmd/swagger/commands/generate/cli.go
+++ b/cmd/swagger/commands/generate/cli.go
@@ -5,9 +5,10 @@ import "github.com/go-swagger/go-swagger/generator"
 type Cli struct {
 	// generate a cli includes all client code
 	Client
+
 	// cmd/<cli-app-name>/main.go will be generated. This ensures that go install will compile the app with desired name.
-	CliAppName string `long:"cli-app-name" description:"the app name for the cli executable. useful for go install." default:"cli"`
-	CliPackage string `long:"cli-package" description:"the package to save the cli specific code" default:"cli"`
+	CliAppName string `default:"cli" description:"the app name for the cli executable. useful for go install." long:"cli-app-name"`
+	CliPackage string `default:"cli" description:"the package to save the cli specific code"                   long:"cli-package"`
 }
 
 func (c Cli) apply(opts *generator.GenOpts) {
@@ -21,7 +22,7 @@ func (c *Cli) generate(opts *generator.GenOpts) error {
 	return c.Client.generate(opts)
 }
 
-// Execute runs this command
+// Execute runs this command.
 func (c *Cli) Execute(_ []string) error {
 	return createSwagger(c)
 }

--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -21,14 +21,14 @@ import (
 )
 
 type clientOptions struct {
-	ClientPackage string `long:"client-package" short:"c" description:"the package to save the client specific code" default:"client"`
+	ClientPackage string `default:"client" description:"the package to save the client specific code" long:"client-package" short:"c"`
 }
 
 func (co clientOptions) apply(opts *generator.GenOpts) {
 	opts.ClientPackage = co.ClientPackage
 }
 
-// Client the command to generate a swagger client
+// Client the command to generate a swagger client.
 type Client struct {
 	WithShared
 	WithModels
@@ -38,10 +38,10 @@ type Client struct {
 	schemeOptions
 	mediaOptions
 
-	SkipModels     bool `long:"skip-models" description:"no models will be generated when this flag is specified"`
-	SkipOperations bool `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
+	SkipModels     bool `description:"no models will be generated when this flag is specified"     long:"skip-models"`
+	SkipOperations bool `description:"no operations will be generated when this flag is specified" long:"skip-operations"`
 
-	Name string `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
+	Name string `description:"the name of the application, defaults to a mangled value of info.title" long:"name" short:"A"`
 }
 
 func (c Client) apply(opts *generator.GenOpts) {
@@ -79,7 +79,7 @@ For this generation to compile you need to have some packages in your go.mod:
 You can get these now with: go mod tidy`)
 }
 
-// Execute runs this command
+// Execute runs this command.
 func (c *Client) Execute(_ []string) error {
 	return createSwagger(c)
 }

--- a/cmd/swagger/commands/generate/contrib.go
+++ b/cmd/swagger/commands/generate/contrib.go
@@ -4,9 +4,8 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
-// contribOptionsOverride gives contributed templates the ability to override the options if they need
+// contribOptionsOverride gives contributed templates the ability to override the options if they need.
 func contribOptionsOverride(opts *generator.GenOpts) {
-	// nolint: gocritic
 	switch opts.Template {
 	case "stratoscale":
 		// Stratoscale template needs to regenerate the configureapi on every run.

--- a/cmd/swagger/commands/generate/markdown.go
+++ b/cmd/swagger/commands/generate/markdown.go
@@ -6,13 +6,13 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
-// Markdown generates a markdown representation of the spec
+// Markdown generates a markdown representation of the spec.
 type Markdown struct {
 	WithShared
 	WithModels
 	WithOperations
 
-	Output flags.Filename `long:"output" short:"" description:"the file to write the generated markdown." default:"markdown.md"`
+	Output flags.Filename `default:"markdown.md" description:"the file to write the generated markdown." long:"output" short:""`
 }
 
 func (m Markdown) apply(opts *generator.GenOpts) {
@@ -28,7 +28,7 @@ func (m *Markdown) generate(opts *generator.GenOpts) error {
 func (m Markdown) log(_ string) {
 }
 
-// Execute runs this command
+// Execute runs this command.
 func (m *Markdown) Execute(_ []string) error {
 	return createSwagger(m)
 }

--- a/cmd/swagger/commands/generate/markdown_test.go
+++ b/cmd/swagger/commands/generate/markdown_test.go
@@ -11,13 +11,12 @@ import (
 )
 
 func TestMarkdown(t *testing.T) {
-	path := filepath.Join(".", "test-markdown")
-	generated, cleanup := testTempDir(t, path)
-	t.Cleanup(cleanup)
+	generated := t.TempDir()
 
 	m := &generate.Markdown{}
 	_, _ = flags.ParseArgs(m, []string{"--skip-validation"})
 	m.Shared.Spec = flags.Filename(filepath.Join(testBase(), "fixtures", "enhancements", "184", "fixture-184.yaml"))
-	m.Output = flags.Filename(filepath.Join(generated, "markdown.md"))
+	m.Shared.Target = flags.Filename(generated)
+	m.Output = flags.Filename("markdown.md")
 	require.NoError(t, m.Execute([]string{}))
 }

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -22,14 +22,14 @@ import (
 )
 
 type modelOptions struct {
-	ModelPackage               string   `long:"model-package" short:"m" description:"the package to save the models" default:"models"`
-	Models                     []string `long:"model" short:"M" description:"specify a model to include in generation, repeat for multiple (defaults to all)"`
-	ExistingModels             string   `long:"existing-models" description:"use pre-generated models e.g. github.com/foobar/model"`
-	StrictAdditionalProperties bool     `long:"strict-additional-properties" description:"disallow extra properties when additionalProperties is set to false"`
-	KeepSpecOrder              bool     `long:"keep-spec-order" description:"keep schema properties order identical to spec file"`
-	AllDefinitions             bool     `long:"all-definitions" description:"generate all model definitions regardless of usage in operations" hidden:"deprecated"`
-	StructTags                 []string `long:"struct-tags" description:"the struct tags to generate, repeat for multiple (defaults to json)"`
-	RootedErrorPath            bool     `long:"rooted-error-path" description:"extends validation errors with the type name instead of an empty path, in the case of arrays and maps"`
+	ModelPackage               string   `default:"models"                                                                                                    description:"the package to save the models" long:"model-package"   short:"m"`
+	Models                     []string `description:"specify a model to include in generation, repeat for multiple (defaults to all)"                       long:"model"                                 short:"M"`
+	ExistingModels             string   `description:"use pre-generated models e.g. github.com/foobar/model"                                                 long:"existing-models"`
+	StrictAdditionalProperties bool     `description:"disallow extra properties when additionalProperties is set to false"                                   long:"strict-additional-properties"`
+	KeepSpecOrder              bool     `description:"keep schema properties order identical to spec file"                                                   long:"keep-spec-order"`
+	AllDefinitions             bool     `description:"generate all model definitions regardless of usage in operations"                                      hidden:"deprecated"                          long:"all-definitions"`
+	StructTags                 []string `description:"the struct tags to generate, repeat for multiple (defaults to json)"                                   long:"struct-tags"`
+	RootedErrorPath            bool     `description:"extends validation errors with the type name instead of an empty path, in the case of arrays and maps" long:"rooted-error-path"`
 }
 
 func (mo modelOptions) apply(opts *generator.GenOpts) {
@@ -57,9 +57,9 @@ type Model struct {
 	WithShared
 	WithModels
 
-	NoStruct              bool     `long:"skip-struct" description:"when present will not generate the model struct" hidden:"deprecated"`
-	Name                  []string `long:"name" short:"n" description:"the model to generate, repeat for multiple (defaults to all). Same as --models"`
-	AcceptDefinitionsOnly bool     `long:"accept-definitions-only" description:"accepts a partial swagger spec with only the definitions key"`
+	NoStruct              bool     `description:"when present will not generate the model struct"                                hidden:"deprecated"            long:"skip-struct"`
+	Name                  []string `description:"the model to generate, repeat for multiple (defaults to all). Same as --models" long:"name"                    short:"n"`
+	AcceptDefinitionsOnly bool     `description:"accepts a partial swagger spec with only the definitions key"                   long:"accept-definitions-only"`
 }
 
 func (m Model) apply(opts *generator.GenOpts) {
@@ -86,7 +86,7 @@ func (m *Model) generate(opts *generator.GenOpts) error {
 	return generator.GenerateModels(append(m.Name, m.Models.Models...), opts)
 }
 
-// Execute generates a model file
+// Execute generates a model file.
 func (m *Model) Execute(_ []string) error {
 	if m.Shared.DumpData && len(append(m.Name, m.Models.Models...)) > 1 {
 		return errors.New("only 1 model at a time is supported for dumping data")

--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -22,13 +22,13 @@ import (
 )
 
 type operationOptions struct {
-	Operations []string `long:"operation" short:"O" description:"specify an operation to include, repeat for multiple (defaults to all)"`
-	Tags       []string `long:"tags" description:"the tags to include, if not specified defaults to all" group:"operations"`
-	APIPackage string   `long:"api-package" short:"a" description:"the package to save the operations" default:"operations"`
-	WithEnumCI bool     `long:"with-enum-ci" description:"allow case-insensitive enumerations"`
+	Operations []string `description:"specify an operation to include, repeat for multiple (defaults to all)" long:"operation"                                 short:"O"`
+	Tags       []string `description:"the tags to include, if not specified defaults to all"                  group:"operations"                               long:"tags"`
+	APIPackage string   `default:"operations"                                                                 description:"the package to save the operations" long:"api-package" short:"a"`
+	WithEnumCI bool     `description:"allow case-insensitive enumerations"                                    long:"with-enum-ci"`
 
 	// tags handling
-	SkipTagPackages bool `long:"skip-tag-packages" description:"skips the generation of tag-based operation packages, resulting in a flat generation"`
+	SkipTagPackages bool `description:"skips the generation of tag-based operation packages, resulting in a flat generation" long:"skip-tag-packages"`
 }
 
 func (oo operationOptions) apply(opts *generator.GenOpts) {
@@ -39,12 +39,12 @@ func (oo operationOptions) apply(opts *generator.GenOpts) {
 	opts.SkipTagPackages = oo.SkipTagPackages
 }
 
-// WithOperations adds the operations options group
+// WithOperations adds the operations options group.
 type WithOperations struct {
 	Operations operationOptions `group:"Options for operation generation"`
 }
 
-// Operation the generate operation files command
+// Operation the generate operation files command.
 type Operation struct {
 	WithShared
 	WithOperations
@@ -54,14 +54,14 @@ type Operation struct {
 	schemeOptions
 	mediaOptions
 
-	ModelPackage string `long:"model-package" short:"m" description:"the package to save the models" default:"models"`
+	ModelPackage string `default:"models" description:"the package to save the models" long:"model-package" short:"m"`
 
-	NoHandler    bool `long:"skip-handler" description:"when present will not generate an operation handler"`
-	NoStruct     bool `long:"skip-parameters" description:"when present will not generate the parameter model struct"`
-	NoResponses  bool `long:"skip-responses" description:"when present will not generate the response model struct"`
-	NoURLBuilder bool `long:"skip-url-builder" description:"when present will not generate a URL builder"`
+	NoHandler    bool `description:"when present will not generate an operation handler"       long:"skip-handler"`
+	NoStruct     bool `description:"when present will not generate the parameter model struct" long:"skip-parameters"`
+	NoResponses  bool `description:"when present will not generate the response model struct"  long:"skip-responses"`
+	NoURLBuilder bool `description:"when present will not generate a URL builder"              long:"skip-url-builder"`
 
-	Name []string `long:"name" short:"n" description:"the operations to generate, repeat for multiple (defaults to all). Same as --operations"`
+	Name []string `description:"the operations to generate, repeat for multiple (defaults to all). Same as --operations" long:"name" short:"n"`
 }
 
 func (o Operation) apply(opts *generator.GenOpts) {
@@ -93,7 +93,7 @@ For this generation to compile you need to have some packages in your go.mod:
 You can get these now with: go mod tidy`)
 }
 
-// Execute generates a model file
+// Execute generates a model file.
 func (o *Operation) Execute(_ []string) error {
 	if o.Shared.DumpData && len(append(o.Name, o.Operations.Operations...)) > 1 {
 		return errors.New("only 1 operation at a time is supported for dumping data")

--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -22,16 +22,16 @@ import (
 )
 
 type serverOptions struct {
-	ServerPackage         string `long:"server-package" short:"s" description:"the package to save the server specific code" default:"restapi"`
-	MainTarget            string `long:"main-package" short:"" description:"the location of the generated main. Defaults to cmd/{name}-server" default:""`
-	ImplementationPackage string `long:"implementation-package" short:"" description:"the location of the backend implementation of the server, which will be autowired with api" default:""`
+	ServerPackage         string `default:"restapi" description:"the package to save the server specific code"                                               long:"server-package"         short:"s"`
+	MainTarget            string `default:""        description:"the location of the generated main. Defaults to cmd/{name}-server"                          long:"main-package"           short:""`
+	ImplementationPackage string `default:""        description:"the location of the backend implementation of the server, which will be autowired with api" long:"implementation-package" short:""`
 }
 
 func (cs serverOptions) apply(opts *generator.GenOpts) {
 	opts.ServerPackage = cs.ServerPackage
 }
 
-// Server the command to generate an entire server application
+// Server the command to generate an entire server application.
 type Server struct {
 	WithShared
 	WithModels
@@ -41,20 +41,20 @@ type Server struct {
 	schemeOptions
 	mediaOptions
 
-	SkipModels             bool   `long:"skip-models" description:"no models will be generated when this flag is specified"`
-	SkipOperations         bool   `long:"skip-operations" description:"no operations will be generated when this flag is specified"`
-	SkipSupport            bool   `long:"skip-support" description:"no supporting files will be generated when this flag is specified"`
-	ExcludeMain            bool   `long:"exclude-main" description:"exclude main function, so just generate the library"`
-	ExcludeSpec            bool   `long:"exclude-spec" description:"don't embed the swagger specification"`
-	FlagStrategy           string `long:"flag-strategy" description:"the strategy to provide flags for the server" default:"go-flags" choice:"go-flags" choice:"pflag" choice:"flag"` // nolint: staticcheck
-	CompatibilityMode      string `long:"compatibility-mode" description:"the compatibility mode for the tls server" default:"modern" choice:"modern" choice:"intermediate"`          // nolint: staticcheck
-	RegenerateConfigureAPI bool   `long:"regenerate-configureapi" description:"Force regeneration of configureapi.go"`
+	SkipModels             bool   `description:"no models will be generated when this flag is specified"           long:"skip-models"`
+	SkipOperations         bool   `description:"no operations will be generated when this flag is specified"       long:"skip-operations"`
+	SkipSupport            bool   `description:"no supporting files will be generated when this flag is specified" long:"skip-support"`
+	ExcludeMain            bool   `description:"exclude main function, so just generate the library"               long:"exclude-main"`
+	ExcludeSpec            bool   `description:"don't embed the swagger specification"                             long:"exclude-spec"`
+	FlagStrategy           string `choice:"go-flags"                                                               choice:"pflag"                 choice:"flag"    default:"go-flags"                                      description:"the strategy to provide flags for the server" long:"flag-strategy"`
+	CompatibilityMode      string `choice:"modern"                                                                 choice:"intermediate"          default:"modern" description:"the compatibility mode for the tls server" long:"compatibility-mode"`
+	RegenerateConfigureAPI bool   `description:"Force regeneration of configureapi.go"                             long:"regenerate-configureapi"`
 
-	Name string `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
+	Name string `description:"the name of the application, defaults to a mangled value of info.title" long:"name" short:"A"`
 	// TODO(fredbi): CmdName string `long:"cmd-name" short:"A" description:"the name of the server command, when main is generated (defaults to {name}-server)"`
 
 	// deprecated flags
-	WithContext bool `long:"with-context" description:"handlers get a context as first arg (deprecated)"`
+	WithContext bool `description:"handlers get a context as first arg (deprecated)" long:"with-context"`
 }
 
 func (s *Server) apply(opts *generator.GenOpts) {
@@ -114,7 +114,7 @@ For this generation to compile you need to have some packages in your go.mod:
 You can get these now with: go mod tidy`)
 }
 
-// Execute runs this command
+// Execute runs this command.
 func (s *Server) Execute(_ []string) error {
 	return createSwagger(s)
 }

--- a/cmd/swagger/commands/generate/server_test.go
+++ b/cmd/swagger/commands/generate/server_test.go
@@ -1,8 +1,10 @@
 package generate_test
 
 import (
-	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/jessevdk/go-flags"
@@ -33,18 +35,20 @@ func TestRegressionIssue2601(t *testing.T) {
 		"impl.yml",
 	}
 
+	base := t.TempDir()
+
 	for i, spec := range specs {
-		t.Run(fmt.Sprintf("should generate server from spec %s", spec), func(t *testing.T) {
-			path := filepath.Join(testBase(), "fixtures/codegen", spec)
-			generated, cleanup := testTempDir(t, path)
-			t.Cleanup(cleanup)
+		t.Run("should generate server from spec "+spec, func(t *testing.T) {
+			pth := filepath.Join(testBase(), "fixtures/codegen", spec)
+			generated := filepath.Join(base, "codegen-"+strconv.Itoa(i))
+			require.NoError(t, os.MkdirAll(generated, fs.ModePerm))
 
 			m := &generate.Server{}
 			_, _ = flags.Parse(m)
 			if i == 0 {
 				m.Shared.CopyrightFile = flags.Filename(filepath.Join(testBase(), "LICENSE"))
 			}
-			m.Shared.Spec = flags.Filename(path)
+			m.Shared.Spec = flags.Filename(pth)
 			m.Shared.Target = flags.Filename(generated)
 
 			// Error was coming from these two being set together
@@ -54,6 +58,8 @@ func TestRegressionIssue2601(t *testing.T) {
 			// Load new copy of template
 			m.Shared.AllowTemplateOverride = true
 			m.Shared.TemplateDir = flags.Filename(filepath.Join(testBase(), "generator/templates"))
+
+			t.Run("go mod", gomodinit(generated))
 
 			require.NoError(t, m.Execute([]string{}))
 		})
@@ -68,10 +74,9 @@ func testGenerateServer(t *testing.T, strict bool) {
 	}
 
 	for i, spec := range specs {
-		t.Run(fmt.Sprintf("should generate server from spec %s", spec), func(t *testing.T) {
-			path := filepath.Join(testBase(), "fixtures/codegen", spec)
-			generated, cleanup := testTempDir(t, path)
-			t.Cleanup(cleanup)
+		t.Run("should generate server from spec "+spec, func(t *testing.T) {
+			pth := filepath.Join(testBase(), "fixtures/codegen", spec)
+			generated := t.TempDir()
 
 			m := &generate.Server{}
 			_, _ = flags.Parse(m)
@@ -84,9 +89,11 @@ func testGenerateServer(t *testing.T, strict bool) {
 			case 2:
 				m.FlagStrategy = "flag"
 			}
-			m.Shared.Spec = flags.Filename(path)
+			m.Shared.Spec = flags.Filename(pth)
 			m.Shared.Target = flags.Filename(generated)
 			m.Shared.StrictResponders = strict
+
+			t.Run("go mod", gomodinit(generated))
 
 			require.NoError(t, m.Execute([]string{}))
 		})

--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -16,13 +16,13 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
-// FlattenCmdOptions determines options to the flatten spec preprocessing
+// FlattenCmdOptions determines options to the flatten spec preprocessing.
 type FlattenCmdOptions struct {
-	WithExpand  bool     `long:"with-expand" description:"expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)"  group:"shared"`
-	WithFlatten []string `long:"with-flatten" description:"flattens all $ref's in spec prior to generation" choice:"minimal" choice:"full" choice:"expand" choice:"verbose" choice:"noverbose" choice:"remove-unused" choice:"keep-names" default:"minimal" default:"verbose" group:"shared"`
+	WithExpand  bool     `description:"expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)" group:"shared" long:"with-expand"`
+	WithFlatten []string `choice:"minimal"                                                                                  choice:"full"  choice:"expand"    choice:"verbose" choice:"noverbose" choice:"remove-unused" choice:"keep-names" default:"minimal" default:"verbose" description:"flattens all $ref's in spec prior to generation" group:"shared" long:"with-flatten"`
 }
 
-// SetFlattenOptions builds flatten options from command line args
+// SetFlattenOptions builds flatten options from command line args.
 func (f *FlattenCmdOptions) SetFlattenOptions(dflt *analysis.FlattenOpts) (res *analysis.FlattenOpts) {
 	res = &analysis.FlattenOpts{}
 	if dflt != nil {
@@ -81,10 +81,10 @@ type sharedCommand interface {
 }
 
 type schemeOptions struct {
-	Principal     string `short:"P" long:"principal" description:"the model to use for the security principal"`
-	DefaultScheme string `long:"default-scheme" description:"the default scheme for this API" default:"http"`
+	Principal     string `description:"the model to use for the security principal" long:"principal"                              short:"P"`
+	DefaultScheme string `default:"http"                                            description:"the default scheme for this API" long:"default-scheme"`
 
-	PrincipalIface bool `long:"principal-is-interface" description:"the security principal provided is an interface, not a struct"`
+	PrincipalIface bool `description:"the security principal provided is an interface, not a struct" long:"principal-is-interface"`
 }
 
 func (so schemeOptions) apply(opts *generator.GenOpts) {
@@ -94,8 +94,8 @@ func (so schemeOptions) apply(opts *generator.GenOpts) {
 }
 
 type mediaOptions struct {
-	DefaultProduces string `long:"default-produces" description:"the default mime type that API operations produce" default:"application/json"`
-	DefaultConsumes string `long:"default-consumes" description:"the default mime type that API operations consume" default:"application/json"`
+	DefaultProduces string `default:"application/json" description:"the default mime type that API operations produce" long:"default-produces"`
+	DefaultConsumes string `default:"application/json" description:"the default mime type that API operations consume" long:"default-consumes"`
 }
 
 func (m mediaOptions) apply(opts *generator.GenOpts) {
@@ -106,7 +106,7 @@ func (m mediaOptions) apply(opts *generator.GenOpts) {
 	opts.WithXML = strings.Contains(opts.DefaultProduces, xmlIdentifier) || strings.Contains(opts.DefaultConsumes, xmlIdentifier)
 }
 
-// WithShared adds the shared options group
+// WithShared adds the shared options group.
 type WithShared struct {
 	Shared sharedOptions `group:"Options common to all code generation commands"`
 }
@@ -116,19 +116,20 @@ func (w WithShared) getConfigFile() string {
 }
 
 type sharedOptionsCommon struct {
-	Spec                  flags.Filename `long:"spec" short:"f" description:"the spec file to use (default swagger.{json,yml,yaml})" group:"shared"`
-	Target                flags.Filename `long:"target" short:"t" default:"./" description:"the base directory for generating the files" group:"shared"`
-	Template              string         `long:"template" description:"load contributed templates" choice:"stratoscale" group:"shared"`
-	TemplateDir           flags.Filename `long:"template-dir" short:"T" description:"alternative template override directory" group:"shared"`
-	ConfigFile            flags.Filename `long:"config-file" short:"C" description:"configuration file to use for overriding template options" group:"shared"`
-	CopyrightFile         flags.Filename `long:"copyright-file" short:"r" description:"copyright file used to add copyright header" group:"shared"`
-	AdditionalInitialisms []string       `long:"additional-initialism" description:"consecutive capitals that should be considered intialisms" group:"shared"`
-	AllowTemplateOverride bool           `long:"allow-template-override" description:"allows overriding protected templates" group:"shared"`
-	SkipValidation        bool           `long:"skip-validation" description:"skips validation of spec prior to generation" group:"shared"`
-	DumpData              bool           `long:"dump-data" description:"when present dumps the json for the template generator instead of generating files" group:"shared"`
-	StrictResponders      bool           `long:"strict-responders" description:"Use strict type for the handler return value"`
-	ReturnErrors          bool           `long:"return-errors" short:"e" description:"handlers explicitly return an error as the second value" group:"shared"`
 	FlattenCmdOptions
+
+	Spec                  flags.Filename `description:"the spec file to use (default swagger.{json,yml,yaml})"                             group:"shared"                                            long:"spec"                    short:"f"`
+	Target                flags.Filename `default:"./"                                                                                     description:"the base directory for generating the files" group:"shared"                 long:"target"   short:"t"`
+	Template              string         `choice:"stratoscale"                                                                             description:"load contributed templates"                  group:"shared"                 long:"template"`
+	TemplateDir           flags.Filename `description:"alternative template override directory"                                            group:"shared"                                            long:"template-dir"            short:"T"`
+	ConfigFile            flags.Filename `description:"configuration file to use for overriding template options"                          group:"shared"                                            long:"config-file"             short:"C"`
+	CopyrightFile         flags.Filename `description:"copyright file used to add copyright header"                                        group:"shared"                                            long:"copyright-file"          short:"r"`
+	AdditionalInitialisms []string       `description:"consecutive capitals that should be considered intialisms"                          group:"shared"                                            long:"additional-initialism"`
+	AllowTemplateOverride bool           `description:"allows overriding protected templates"                                              group:"shared"                                            long:"allow-template-override"`
+	SkipValidation        bool           `description:"skips validation of spec prior to generation"                                       group:"shared"                                            long:"skip-validation"`
+	DumpData              bool           `description:"when present dumps the json for the template generator instead of generating files" group:"shared"                                            long:"dump-data"`
+	StrictResponders      bool           `description:"Use strict type for the handler return value"                                       long:"strict-responders"`
+	ReturnErrors          bool           `description:"handlers explicitly return an error as the second value"                            group:"shared"                                            long:"return-errors"           short:"e"`
 }
 
 func (s sharedOptionsCommon) apply(opts *generator.GenOpts) {

--- a/cmd/swagger/commands/generate/shared_test.go
+++ b/cmd/swagger/commands/generate/shared_test.go
@@ -110,11 +110,8 @@ func Test_Shared_SetFlattenOptions(t *testing.T) {
 }
 
 func Test_Shared_ReadConfig(t *testing.T) {
-	tmpFile, errio := os.CreateTemp("", "tmp-config*.yaml")
+	tmpFile, errio := os.CreateTemp(t.TempDir(), "tmp-config*.yaml")
 	require.NoError(t, errio)
-	t.Cleanup(func() {
-		_ = os.Remove(tmpFile.Name())
-	})
 	tmpConfig := tmpFile.Name()
 	require.NoError(t,
 		os.WriteFile(tmpConfig, []byte(`param: 123

--- a/cmd/swagger/commands/generate/sharedopts_nonwin.go
+++ b/cmd/swagger/commands/generate/sharedopts_nonwin.go
@@ -11,7 +11,9 @@ import (
 
 type sharedOptions struct {
 	sharedOptionsCommon
-	TemplatePlugin flags.Filename `long:"template-plugin" short:"p" description:"the template plugin to use" group:"shared"`
+
+	// TemplatePlugin option is not available on windows, since it relies on go plugins.
+	TemplatePlugin flags.Filename `description:"the template plugin to use" group:"shared" long:"template-plugin" short:"p"`
 }
 
 func (s sharedOptions) apply(opts *generator.GenOpts) {

--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -30,26 +30,26 @@ import (
 	"github.com/go-openapi/spec"
 )
 
-// SpecFile command to generate a swagger spec from a go application
+// SpecFile command to generate a swagger spec from a go application.
 type SpecFile struct {
-	WorkDir                 string         `long:"work-dir" short:"w" description:"the base path to use" default:"."`
-	BuildTags               string         `long:"tags" short:"t" description:"build tags" default:""`
-	ScanModels              bool           `long:"scan-models" short:"m" description:"includes models that were annotated with 'swagger:model'"`
-	Compact                 bool           `long:"compact" description:"when present, doesn't prettify the json"`
-	Output                  flags.Filename `long:"output" short:"o" description:"the file to write to"`
-	Input                   flags.Filename `long:"input" short:"i" description:"an input swagger file with which to merge"`
-	Include                 []string       `long:"include" short:"c" description:"include packages matching pattern"`
-	Exclude                 []string       `long:"exclude" short:"x" description:"exclude packages matching pattern"`
-	IncludeTags             []string       `long:"include-tag" short:"" description:"include routes having specified tags (can be specified many times)"`
-	ExcludeTags             []string       `long:"exclude-tag" short:"" description:"exclude routes having specified tags (can be specified many times)"`
-	ExcludeDeps             bool           `long:"exclude-deps" short:"" description:"exclude all dependencies of project"`
-	SetXNullableForPointers bool           `long:"nullable-pointers" short:"n" description:"set x-nullable extension to true automatically for fields of pointer types without 'omitempty'"`
-	RefAliases              bool           `long:"ref-aliases" short:"r" description:"transform aliased types into $ref rather than expanding their definition"`
-	DescWithRef             bool           `long:"allow-desc-with-ref" short:"" description:"allow descriptions to flow alongside $ref"`
-	Format                  string         `long:"format" description:"the format for the spec document" default:"json" choice:"yaml" choice:"json"`
+	WorkDir                 string         `default:"."                                                                                                  description:"the base path to use" long:"work-dir" short:"w"`
+	BuildTags               string         `default:""                                                                                                   description:"build tags"           long:"tags"     short:"t"`
+	ScanModels              bool           `description:"includes models that were annotated with 'swagger:model'"                                       long:"scan-models"                 short:"m"`
+	Compact                 bool           `description:"when present, doesn't prettify the json"                                                        long:"compact"`
+	Output                  flags.Filename `description:"the file to write to"                                                                           long:"output"                      short:"o"`
+	Input                   flags.Filename `description:"an input swagger file with which to merge"                                                      long:"input"                       short:"i"`
+	Include                 []string       `description:"include packages matching pattern"                                                              long:"include"                     short:"c"`
+	Exclude                 []string       `description:"exclude packages matching pattern"                                                              long:"exclude"                     short:"x"`
+	IncludeTags             []string       `description:"include routes having specified tags (can be specified many times)"                             long:"include-tag"                 short:""`
+	ExcludeTags             []string       `description:"exclude routes having specified tags (can be specified many times)"                             long:"exclude-tag"                 short:""`
+	ExcludeDeps             bool           `description:"exclude all dependencies of project"                                                            long:"exclude-deps"                short:""`
+	SetXNullableForPointers bool           `description:"set x-nullable extension to true automatically for fields of pointer types without 'omitempty'" long:"nullable-pointers"           short:"n"`
+	RefAliases              bool           `description:"transform aliased types into $ref rather than expanding their definition"                       long:"ref-aliases"                 short:"r"`
+	DescWithRef             bool           `description:"allow descriptions to flow alongside $ref"                                                      long:"allow-desc-with-ref"         short:""`
+	Format                  string         `choice:"yaml"                                                                                                choice:"json"                      default:"json"  description:"the format for the spec document" long:"format"`
 }
 
-// Execute runs this command
+// Execute runs this command.
 func (s *SpecFile) Execute(args []string) error {
 	if len(args) == 0 { // by default consider all the paths under the working directory
 		args = []string{"./..."}

--- a/cmd/swagger/commands/generate/spec_test.go
+++ b/cmd/swagger/commands/generate/spec_test.go
@@ -42,7 +42,7 @@ func TestSpecFileExecute(t *testing.T) {
 			name = "to stdout"
 		}
 
-		t.Run(fmt.Sprintf("should produce spec file %s", name), func(t *testing.T) {
+		t.Run("should produce spec file "+name, func(t *testing.T) {
 			spec := &SpecFile{
 				WorkDir: basePath,
 				Output:  flags.Filename(outputFile),

--- a/cmd/swagger/commands/generate/support.go
+++ b/cmd/swagger/commands/generate/support.go
@@ -20,7 +20,7 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
-// Support generates the supporting files
+// Support generates the supporting files.
 type Support struct {
 	WithShared
 	WithModels
@@ -31,7 +31,7 @@ type Support struct {
 	schemeOptions
 	mediaOptions
 
-	Name string `long:"name" short:"A" description:"the name of the application, defaults to a mangled value of info.title"`
+	Name string `description:"the name of the application, defaults to a mangled value of info.title" long:"name" short:"A"`
 }
 
 func (s *Support) apply(opts *generator.GenOpts) {
@@ -60,7 +60,7 @@ For this generation to compile you need to have some packages in go.mod:
 You can get these now with: go mod tidy`)
 }
 
-// Execute generates the supporting files file
+// Execute generates the supporting files file.
 func (s *Support) Execute(_ []string) error {
 	return createSwagger(s)
 }

--- a/cmd/swagger/commands/generate/support_test.go
+++ b/cmd/swagger/commands/generate/support_test.go
@@ -1,7 +1,10 @@
 package generate_test
 
 import (
+	"io/fs"
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	flags "github.com/jessevdk/go-flags"
@@ -14,7 +17,7 @@ func TestGenerateSupport(t *testing.T) {
 	testGenerateSupport(t, false)
 }
 
-func TestGenerateSupportStrict(t *testing.T) {
+func TestGenerateSupportWithStrictResponders(t *testing.T) {
 	testGenerateSupport(t, true)
 }
 
@@ -23,20 +26,24 @@ func testGenerateSupport(t *testing.T, strict bool) {
 		"tasklist.basic.yml",
 	}
 
+	base := t.TempDir()
+
 	for i, spec := range specs {
 		t.Run(spec, func(t *testing.T) {
-			path := filepath.Join(testBase(), "fixtures/codegen", spec)
-			generated, cleanup := testTempDir(t, path)
-			t.Cleanup(cleanup)
+			pth := filepath.Join(testBase(), "fixtures/codegen", spec)
+			generated := filepath.Join(base, "codegen-"+strconv.Itoa(i))
+			require.NoError(t, os.MkdirAll(generated, fs.ModePerm))
 
 			m := &generate.Support{}
 			if i == 0 {
 				m.Shared.CopyrightFile = flags.Filename(filepath.Join(testBase(), "LICENSE"))
 			}
 			_, _ = flags.Parse(m)
-			m.Shared.Spec = flags.Filename(path)
+			m.Shared.Spec = flags.Filename(pth)
 			m.Shared.Target = flags.Filename(generated)
 			m.Shared.StrictResponders = strict
+
+			t.Run("go mod", gomodinit(generated))
 
 			require.NoError(t, m.Execute([]string{}))
 		})

--- a/cmd/swagger/commands/generate/utils_test.go
+++ b/cmd/swagger/commands/generate/utils_test.go
@@ -1,0 +1,71 @@
+package generate_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var enableGoVet bool
+
+func init() {
+	enableGoVet = os.Getenv("GOVET_TEST") != "" // enable go vet to run on generated CLI code - can't do this with args as the flags parser doesn't like it
+}
+
+func testBase() string {
+	return filepath.FromSlash("../../../../")
+}
+
+const minute = 60 * time.Second
+
+func gomodinit(pth string) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("should initialize go.mod", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), minute)
+			defer cancel()
+
+			mod := exec.CommandContext(ctx, "go", "mod", "init", filepath.FromSlash(filepath.Base(pth))) //nolint:gosec // "tainted" args exec is actually okay
+			mod.Dir = pth
+			output, err := mod.CombinedOutput()
+			require.NoErrorf(t, err, "go mod init returned: %s", string(output))
+		})
+	}
+}
+
+func govet(pth string, expectError bool) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("should pass go vet", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), minute)
+			defer cancel()
+
+			vet := exec.CommandContext(ctx, "go", "vet", "./...")
+			vet.Dir = pth
+			output, err := vet.CombinedOutput()
+			if expectError {
+				require.Errorf(t, err, string(output))
+
+				return
+			}
+			require.NoError(t, err, string(output))
+		})
+	}
+}
+
+func gomodtidy(pth string) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("should tidy go.mod", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), minute)
+			defer cancel()
+
+			vet := exec.CommandContext(ctx, "go", "mod", "tidy")
+			vet.Dir = pth
+			output, err := vet.CombinedOutput()
+			require.NoError(t, err, string(output))
+		})
+	}
+}

--- a/cmd/swagger/commands/initcmd.go
+++ b/cmd/swagger/commands/initcmd.go
@@ -7,7 +7,7 @@ type InitCmd struct {
 	Model *initcmd.Spec `command:"spec"`
 }
 
-// Execute provides default empty implementation
+// Execute provides default empty implementation.
 func (i *InitCmd) Execute(_ []string) error {
 	return nil
 }

--- a/cmd/swagger/commands/initcmd/spec.go
+++ b/cmd/swagger/commands/initcmd/spec.go
@@ -15,26 +15,26 @@ import (
 
 // Spec a command struct for initializing a new swagger application.
 type Spec struct {
-	Format      string   `long:"format" description:"the format for the spec document" default:"yaml" choice:"yaml" choice:"json"` //nolint:staticcheck
-	Title       string   `long:"title" description:"the title of the API"`
-	Description string   `long:"description" description:"the description of the API"`
-	Version     string   `long:"version" description:"the version of the API" default:"0.1.0"`
-	Terms       string   `long:"terms" description:"the terms of services"`
-	Consumes    []string `long:"consumes" description:"add a content type to the global consumes definitions, can repeat" default:"application/json"`
-	Produces    []string `long:"produces" description:"add a content type to the global produces definitions, can repeat" default:"application/json"`
-	Schemes     []string `long:"scheme" description:"add a scheme to the global schemes definition, can repeat" default:"http"`
+	Format      string   `choice:"yaml"                            choice:"json"                                                                   default:"yaml"  description:"the format for the spec document" long:"format"` //nolint:staticcheck
+	Title       string   `description:"the title of the API"       long:"title"`
+	Description string   `description:"the description of the API" long:"description"`
+	Version     string   `default:"0.1.0"                          description:"the version of the API"                                            long:"version"`
+	Terms       string   `description:"the terms of services"      long:"terms"`
+	Consumes    []string `default:"application/json"               description:"add a content type to the global consumes definitions, can repeat" long:"consumes"`
+	Produces    []string `default:"application/json"               description:"add a content type to the global produces definitions, can repeat" long:"produces"`
+	Schemes     []string `default:"http"                           description:"add a scheme to the global schemes definition, can repeat"         long:"scheme"`
 	Contact     struct {
-		Name  string `long:"contact.name" description:"name of the primary contact for the API"`
-		URL   string `long:"contact.url" description:"url of the primary contact for the API"`
-		Email string `long:"contact.email" description:"email of the primary contact for the API"`
+		Name  string `description:"name of the primary contact for the API"  long:"contact.name"`
+		URL   string `description:"url of the primary contact for the API"   long:"contact.url"`
+		Email string `description:"email of the primary contact for the API" long:"contact.email"`
 	}
 	License struct {
-		Name string `long:"license.name" description:"name of the license for the API"`
-		URL  string `long:"license.url" description:"url of the license for the API"`
+		Name string `description:"name of the license for the API" long:"license.name"`
+		URL  string `description:"url of the license for the API"  long:"license.url"`
 	}
 }
 
-// Execute this command
+// Execute this command.
 func (s *Spec) Execute(args []string) error {
 	targetPath := "."
 	if len(args) > 0 {

--- a/cmd/swagger/commands/internal/cmdtest/output.go
+++ b/cmd/swagger/commands/internal/cmdtest/output.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// AssertReadersContent compares the contents from io.Readers, optionally stripping blanks
+// AssertReadersContent compares the contents from io.Readers, optionally stripping blanks.
 func AssertReadersContent(t testing.TB, noBlanks bool, expected, actual io.Reader) bool {
 	t.Helper()
 

--- a/cmd/swagger/commands/mixin.go
+++ b/cmd/swagger/commands/mixin.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// Output messages
+	// Output messages.
 	nothingToDo                           = "nothing to do. Need some swagger files to merge.\nUSAGE: swagger mixin [-c <expected#Collisions>] <primary-swagger-file> <mixin-swagger-file...>"
 	ignoreConflictsAndCollisionsSpecified = "both the flags ignore conflicts and collisions were specified. These have conflicting meaning so please only specify one"
 )
@@ -25,12 +25,12 @@ const (
 // command. The flags are defined using struct field tags with the
 // "github.com/jessevdk/go-flags" format.
 type MixinSpec struct {
-	ExpectedCollisionCount uint           `short:"c" description:"expected # of rejected mixin paths, defs, etc due to existing key. Non-zero exit if does not match actual."`
-	Compact                bool           `long:"compact" description:"applies to JSON formatted specs. When present, doesn't prettify the json"`
-	Output                 flags.Filename `long:"output" short:"o" description:"the file to write to"`
-	KeepSpecOrder          bool           `long:"keep-spec-order" description:"Keep schema properties order identical to spec file"`
-	Format                 string         `long:"format" description:"the format for the spec document" default:"json" choice:"yaml" choice:"json"`
-	IgnoreConflicts        bool           `long:"ignore-conflicts" description:"Ignore conflict"`
+	ExpectedCollisionCount uint           `description:"expected # of rejected mixin paths, defs, etc due to existing key. Non-zero exit if does not match actual." short:"c"`
+	Compact                bool           `description:"applies to JSON formatted specs. When present, doesn't prettify the json"                                   long:"compact"`
+	Output                 flags.Filename `description:"the file to write to"                                                                                       long:"output"           short:"o"`
+	KeepSpecOrder          bool           `description:"Keep schema properties order identical to spec file"                                                        long:"keep-spec-order"`
+	Format                 string         `choice:"yaml"                                                                                                            choice:"json"           default:"json" description:"the format for the spec document" long:"format"`
+	IgnoreConflicts        bool           `description:"Ignore conflict"                                                                                            long:"ignore-conflicts"`
 }
 
 // Execute runs the mixin command which merges Swagger 2.0 specs into
@@ -97,7 +97,7 @@ func (c *MixinSpec) MixinFiles(primaryFile string, mixinFiles []string, _ io.Wri
 	}
 	primary := primaryDoc.Spec()
 
-	var mixins []*spec.Swagger
+	mixins := make([]*spec.Swagger, 0, len(mixinFiles))
 	for _, mixinFile := range mixinFiles {
 		if c.KeepSpecOrder {
 			mixinFile = generator.WithAutoXOrder(mixinFile)

--- a/cmd/swagger/commands/mixin_test.go
+++ b/cmd/swagger/commands/mixin_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Commands requires at least one arg
+// Commands requires at least one arg.
 func TestCmd_Mixin(t *testing.T) {
 	var v MixinSpec
 	result := v.Execute([]string{})
@@ -30,18 +30,16 @@ func TestCmd_Mixin(t *testing.T) {
 func TestCmd_Mixin_NoError(t *testing.T) {
 	specDoc1 := filepath.Join(fixtureBase(), "bugs", "1536", "fixture-1536.yaml")
 	specDoc2 := filepath.Join(fixtureBase(), "bugs", "1536", "fixture-1536-2.yaml")
-	outDir, err := os.MkdirTemp(filepath.Dir(specDoc1), "mixed")
-	require.NoError(t, err)
-	defer os.RemoveAll(outDir)
+	output := filepath.Join(t.TempDir(), "fixture-1536-mixed.yaml")
+
 	v := MixinSpec{
 		ExpectedCollisionCount: 3,
 		Format:                 "yaml",
-		Output:                 flags.Filename(filepath.Join(outDir, "fixture-1536-mixed.yaml")),
+		Output:                 flags.Filename(output),
 	}
 
-	result := v.Execute([]string{specDoc1, specDoc2})
-	require.NoError(t, result)
-	_, exists := os.Stat(filepath.Join(outDir, "fixture-1536-mixed.yaml"))
+	require.NoError(t, v.Execute([]string{specDoc1, specDoc2}))
+	_, exists := os.Stat(output)
 	assert.False(t, os.IsNotExist(exists))
 }
 
@@ -50,6 +48,7 @@ func TestCmd_Mixin_BothConflictsAndIgnoreConflictsSpecified(t *testing.T) {
 		ExpectedCollisionCount: 1,
 		IgnoreConflicts:        true,
 	}
+
 	err := v.Execute([]string{"test.json", "test2.json"})
 	require.Error(t, err)
 	assert.Equal(t, ignoreConflictsAndCollisionsSpecified, err.Error())
@@ -58,17 +57,16 @@ func TestCmd_Mixin_BothConflictsAndIgnoreConflictsSpecified(t *testing.T) {
 func TestCmd_Mixin_IgnoreConflicts(t *testing.T) {
 	specDoc1 := filepath.Join(fixtureBase(), "bugs", "1536", "fixture-1536.yaml")
 	specDoc2 := filepath.Join(fixtureBase(), "bugs", "1536", "fixture-1536-2.yaml")
-	outDir, err := os.MkdirTemp(filepath.Dir(specDoc1), "mixed")
-	require.NoError(t, err)
-	defer os.RemoveAll(outDir)
+	output := filepath.Join(t.TempDir(), "fixture-1536-mixed.yaml")
+
 	v := MixinSpec{
 		IgnoreConflicts: true,
 		Format:          "yaml",
-		Output:          flags.Filename(filepath.Join(outDir, "fixture-1536-mixed.yaml")),
+		Output:          flags.Filename(output),
 	}
 
 	result := v.Execute([]string{specDoc1, specDoc2})
 	require.NoError(t, result)
-	_, exists := os.Stat(filepath.Join(outDir, "fixture-1536-mixed.yaml"))
+	_, exists := os.Stat(output)
 	assert.False(t, os.IsNotExist(exists))
 }

--- a/cmd/swagger/commands/serve.go
+++ b/cmd/swagger/commands/serve.go
@@ -19,20 +19,20 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// ServeCmd to serve a swagger spec with docs ui
+// ServeCmd to serve a swagger spec with docs ui.
 type ServeCmd struct {
-	BasePath string `long:"base-path" description:"the base path to serve the spec and UI at"`
-	Flavor   string `short:"F" long:"flavor" description:"the flavor of docs, can be swagger or redoc" default:"redoc" choice:"redoc" choice:"swagger"`
-	DocURL   string `long:"doc-url" description:"override the url which takes a url query param to render the doc ui"`
-	NoOpen   bool   `long:"no-open" description:"when present won't open the browser to show the url"`
-	NoUI     bool   `long:"no-ui" description:"when present, only the swagger spec will be served"`
-	Flatten  bool   `long:"flatten" description:"when present, flatten the swagger spec before serving it"`
-	Port     int    `long:"port" short:"p" description:"the port to serve this site" env:"PORT"`
-	Host     string `long:"host" description:"the interface to serve this site, defaults to 0.0.0.0" default:"0.0.0.0" env:"HOST"`
-	Path     string `long:"path" description:"the uri path at which the docs will be served" default:"docs"`
+	BasePath string `description:"the base path to serve the spec and UI at"                           long:"base-path"`
+	Flavor   string `choice:"redoc"                                                                    choice:"swagger"                                                    default:"redoc" description:"the flavor of docs, can be swagger or redoc" long:"flavor" short:"F"`
+	DocURL   string `description:"override the url which takes a url query param to render the doc ui" long:"doc-url"`
+	NoOpen   bool   `description:"when present won't open the browser to show the url"                 long:"no-open"`
+	NoUI     bool   `description:"when present, only the swagger spec will be served"                  long:"no-ui"`
+	Flatten  bool   `description:"when present, flatten the swagger spec before serving it"            long:"flatten"`
+	Port     int    `description:"the port to serve this site"                                         env:"PORT"                                                          long:"port"     short:"p"`
+	Host     string `default:"0.0.0.0"                                                                 description:"the interface to serve this site, defaults to 0.0.0.0" env:"HOST"      long:"host"`
+	Path     string `default:"docs"                                                                    description:"the uri path at which the docs will be served"         long:"path"`
 }
 
-// Execute the serve command
+// Execute the serve command.
 func (s *ServeCmd) Execute(args []string) error {
 	if len(args) == 0 {
 		return errors.New("specify the spec to serve as argument to the serve command")
@@ -64,7 +64,7 @@ func (s *ServeCmd) Execute(args []string) error {
 		basePath = "/"
 	}
 
-	listener, err := net.Listen("tcp4", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)))
+	listener, err := net.Listen("tcp4", net.JoinHostPort(s.Host, strconv.Itoa(s.Port))) //nolint:noctx // that's ok for a demo server
 	if err != nil {
 		return err
 	}
@@ -85,14 +85,14 @@ func (s *ServeCmd) Execute(args []string) error {
 				SpecURL:  path.Join(basePath, "swagger.json"),
 				Path:     s.Path,
 			}, handler)
-			visit = fmt.Sprintf("http://%s:%d%s", sh, sp, path.Join(basePath, "docs"))
+			visit = fmt.Sprintf("http://%s%s", net.JoinHostPort(sh, strconv.Itoa(sp)), path.Join(basePath, "docs"))
 		} else if visit != "" || s.Flavor == "swagger" {
 			handler = middleware.SwaggerUI(middleware.SwaggerUIOpts{
 				BasePath: basePath,
 				SpecURL:  path.Join(basePath, "swagger.json"),
 				Path:     s.Path,
 			}, handler)
-			visit = fmt.Sprintf("http://%s:%d%s", sh, sp, path.Join(basePath, s.Path))
+			visit = fmt.Sprintf("http://%s%s", net.JoinHostPort(sh, strconv.Itoa(sp)), path.Join(basePath, s.Path))
 		}
 	}
 

--- a/cmd/swagger/commands/validate.go
+++ b/cmd/swagger/commands/validate.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	// Output messages
+	// Output messages.
 	missingArgMsg  = "the validate command requires the swagger document url to be specified"
 	validSpecMsg   = "\nThe swagger spec at %q is valid against swagger specification %s\n"
 	invalidSpecMsg = "\nThe swagger spec at %q is invalid against swagger specification %s.\nSee errors below:\n"
@@ -33,14 +33,14 @@ const (
 )
 
 // ValidateSpec is a command that validates a swagger document
-// against the swagger specification
+// against the swagger specification.
 type ValidateSpec struct {
 	// SchemaURL string `long:"schema" description:"The schema url to use" default:"http://swagger.io/v2/schema.json"`
-	SkipWarnings bool `long:"skip-warnings" description:"when present will not show up warnings upon validation"`
-	StopOnError  bool `long:"stop-on-error" description:"when present will not continue validation after critical errors are found"`
+	SkipWarnings bool `description:"when present will not show up warnings upon validation"                    long:"skip-warnings"`
+	StopOnError  bool `description:"when present will not continue validation after critical errors are found" long:"stop-on-error"`
 }
 
-// Execute validates the spec
+// Execute validates the spec.
 func (c *ValidateSpec) Execute(args []string) error {
 	if len(args) == 0 {
 		return errors.New(missingArgMsg)

--- a/cmd/swagger/commands/validate_test.go
+++ b/cmd/swagger/commands/validate_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Commands requires at least one arg
+// Commands requires at least one arg.
 func TestCmd_Validate_MissingArgs(t *testing.T) {
 	var v ValidateSpec
 	require.Error(t, v.Execute([]string{}))
 	require.Error(t, v.Execute([]string{"nowhere.json"}))
 }
 
-// Test proper validation: items in object error
+// Test proper validation: items in object error.
 func TestCmd_Validate_Issue1238(t *testing.T) {
 	var v ValidateSpec
 	specDoc := filepath.Join(fixtureBase(), "bugs", "1238", "swagger.yaml")
@@ -29,14 +29,14 @@ func TestCmd_Validate_Issue1238(t *testing.T) {
 	assert.Contains(t, result.Error(), "definitions.RRSets in body must be of type array")
 }
 
-// Test proper validation: missing items in array error
+// Test proper validation: missing items in array error.
 func TestCmd_Validate_Issue1171(t *testing.T) {
 	var v ValidateSpec
 	specDoc := filepath.Join(fixtureBase(), "bugs", "1171", "swagger.yaml")
 	require.Error(t, v.Execute([]string{specDoc}))
 }
 
-// Test proper validation: reference to inner property in schema
+// Test proper validation: reference to inner property in schema.
 func TestCmd_Validate_Issue342_ForbiddenProperty(t *testing.T) {
 	var v ValidateSpec
 	specDoc := filepath.Join(fixtureBase(), "bugs", "342", "fixture-342.yaml")
@@ -64,7 +64,7 @@ func TestCmd_Validate_Issue342_CannotUnmarshal(t *testing.T) {
 	assert.Contains(t, result.Error(), "of type []spec.Parameter")
 }
 
-// This one is a correct version of issue#342 and it validates
+// This one is a correct version of issue#342 and it validates.
 func TestCmd_Validate_Issue342_Correct(t *testing.T) {
 	var v ValidateSpec
 	specDoc := filepath.Join(fixtureBase(), "bugs", "342", "fixture-342-3.yaml")

--- a/cmd/swagger/commands/version.go
+++ b/cmd/swagger/commands/version.go
@@ -6,16 +6,16 @@ import (
 )
 
 var (
-	// Version for the swagger command
+	// Version for the swagger command.
 	Version string
-	// Commit for the swagger command
+	// Commit for the swagger command.
 	Commit string
 )
 
-// PrintVersion the command
+// PrintVersion the command.
 type PrintVersion struct{}
 
-// Execute this command
+// Execute this command.
 func (p *PrintVersion) Execute(_ []string) error {
 	if Version == "" {
 		if info, available := debug.ReadBuildInfo(); available && info.Main.Version != "(devel)" {

--- a/cmd/swagger/swagger.go
+++ b/cmd/swagger/swagger.go
@@ -26,8 +26,8 @@ import (
 
 var opts struct {
 	// General options applicable to all commands
-	Quiet   func()       `long:"quiet" short:"q" description:"silence logs"`
-	LogFile func(string) `long:"log-output" description:"redirect logs to file" value-name:"LOG-FILE"`
+	Quiet   func()       `description:"silence logs"          long:"quiet"      short:"q"`
+	LogFile func(string) `description:"redirect logs to file" long:"log-output" value-name:"LOG-FILE"`
 	// Version bool `long:"version" short:"v" description:"print the version of the command"`
 }
 

--- a/codescan/application.go
+++ b/codescan/application.go
@@ -25,7 +25,7 @@ func safeConvert(str string) bool {
 	return b
 }
 
-// Debug is true when process is run with DEBUG=1 env var
+// Debug is true when process is run with DEBUG=1 env var.
 var Debug = safeConvert(os.Getenv("DEBUG"))
 
 type node uint32
@@ -39,7 +39,7 @@ const (
 	responseNode
 )
 
-// Options for the scanner
+// Options for the scanner.
 type Options struct {
 	Packages                []string
 	InputSpec               *spec.Swagger
@@ -71,7 +71,7 @@ func sliceToSet(names []string) map[string]bool {
 	return result
 }
 
-// Run the scanner to produce a spec with the options provided
+// Run the scanner to produce a spec with the options provided.
 func Run(opts *Options) (*spec.Swagger, error) {
 	sc, err := newScanCtx(opts)
 	if err != nil {

--- a/codescan/application_test.go
+++ b/codescan/application_test.go
@@ -129,7 +129,7 @@ func verifyParsedPetStore(t testing.TB, doc *spec.Swagger) {
 	if assert.NotNil(t, doc.Paths) {
 		assert.Len(t, doc.Paths.Paths, 5)
 	}
-	var keys []string
+	keys := make([]string, 0, len(doc.Definitions))
 	for k := range doc.Definitions {
 		keys = append(keys, k)
 	}

--- a/codescan/meta.go
+++ b/codescan/meta.go
@@ -232,7 +232,7 @@ func safeInfo(swspec *spec.Swagger) *spec.Info {
 	return swspec.Info
 }
 
-// httpFTPScheme matches http://, https://, ws://, wss://
+// httpFTPScheme matches http://, https://, ws://, wss://.
 var httpFTPScheme = regexp.MustCompile("(?:(?:ht|f)tp|ws)s?://")
 
 func splitURL(line string) (notURL, url string) {

--- a/codescan/meta_test.go
+++ b/codescan/meta_test.go
@@ -172,7 +172,6 @@ func TestMoreParseMeta(t *testing.T) {
 		"../fixtures/goparsing/meta/v3/doc.go",
 		"../fixtures/goparsing/meta/v4/doc.go",
 	} {
-
 		swspec := new(spec.Swagger)
 		parser := newMetaParser(swspec)
 		fileSet := token.NewFileSet()

--- a/codescan/parameters.go
+++ b/codescan/parameters.go
@@ -642,7 +642,6 @@ func (p *parameterBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, 
 				}
 				sp.taggers = append(taggers, sp.taggers...)
 			}
-
 		} else {
 			sp.taggers = []tagParser{
 				newSingleLineTagParser("in", &matchOnlyParam{&ps, rxIn}),

--- a/codescan/parameters_test.go
+++ b/codescan/parameters_test.go
@@ -270,7 +270,7 @@ func TestParamsParser(t *testing.T) {
 			assert.Equal(t, 3, iprop.Default, "Items.ID default value is incorrect")
 
 			assertRef(t, itprop, "pet", "Pet", "#/definitions/pet")
-			iprop, ok = itprop.Properties["pet"]
+			_, ok = itprop.Properties["pet"]
 			assert.True(t, ok)
 			// if itprop.Ref.String() == "" {
 			// 	assert.Equal(t, "The Pet to add to this NoModel items bucket.\nPets can appear more than once in the bucket", iprop.Description)

--- a/codescan/parser.go
+++ b/codescan/parser.go
@@ -337,7 +337,7 @@ func (y *yamlParser) Matches(line string) bool {
 }
 
 // aggregates lines in header until it sees `---`,
-// the beginning of a YAML spec
+// the beginning of a YAML spec.
 type yamlSpecScanner struct {
 	header         []string
 	yamlSpec       []string
@@ -348,24 +348,29 @@ type yamlSpecScanner struct {
 	skipHeader     bool
 }
 
-func cleanupScannerLines(lines []string, ur *regexp.Regexp, yamlBlock *regexp.Regexp) []string {
+func cleanupScannerLines(lines []string, ur *regexp.Regexp, yamlBlock *regexp.Regexp) []string { //nolint:unparam
 	// bail early when there is nothing to parse
 	if len(lines) == 0 {
 		return lines
 	}
 	seenLine := -1
-	var lastContent int
-	var uncommented []string
-	var startBlock bool
-	var yamlLines []string
+	var (
+		lastContent int
+		startBlock  bool
+		yamlLines   []string
+	)
+	uncommented := make([]string, 0, len(lines))
+
 	for i, v := range lines {
 		if yamlBlock != nil && yamlBlock.MatchString(v) && !startBlock {
 			startBlock = true
 			if seenLine < 0 {
 				seenLine = i
 			}
+
 			continue
 		}
+
 		if startBlock {
 			if yamlBlock != nil && yamlBlock.MatchString(v) {
 				startBlock = false
@@ -379,8 +384,10 @@ func cleanupScannerLines(lines []string, ur *regexp.Regexp, yamlBlock *regexp.Re
 				}
 				lastContent = i
 			}
+
 			continue
 		}
+
 		str := ur.ReplaceAllString(v, "")
 		uncommented = append(uncommented, str)
 		if str != "" {
@@ -506,7 +513,7 @@ func (sp *yamlSpecScanner) UnmarshalSpec(u func([]byte) error) (err error) {
 	return nil
 }
 
-// removes indent base on the first line
+// removes indent base on the first line.
 func removeIndent(spec []string) []string {
 	loc := rxIndent.FindStringIndex(spec[0])
 	if loc[1] == 0 {
@@ -526,7 +533,7 @@ func removeIndent(spec []string) []string {
 	return spec
 }
 
-// removes indent base on the first line
+// removes indent base on the first line.
 func removeYamlIndent(spec []string) []string {
 	loc := rxIndent.FindStringIndex(spec[0])
 	if loc[1] == 0 {
@@ -1291,13 +1298,13 @@ func (ss *setOpResponses) Matches(line string) bool {
 	return ss.rx.MatchString(line)
 }
 
-// ResponseTag used when specifying a response to point to a defined swagger:response
+// ResponseTag used when specifying a response to point to a defined swagger:response.
 const ResponseTag = "response"
 
-// BodyTag used when specifying a response to point to a model/schema
+// BodyTag used when specifying a response to point to a model/schema.
 const BodyTag = "body"
 
-// DescriptionTag used when specifying a response that gives a description of the response
+// DescriptionTag used when specifying a response that gives a description of the response.
 const DescriptionTag = "description"
 
 func parseTags(line string) (modelOrResponse string, arrays int, isDefinitionRef bool, description string, err error) {
@@ -1440,7 +1447,7 @@ func (ss *setOpResponses) Parse(lines []string) error {
 					resp.Schema.Ref = ref
 				} else {
 					cs := resp.Schema
-					for i := 0; i < arrays; i++ {
+					for range arrays {
 						cs.Typed("array", "")
 						cs.Items = new(spec.SchemaOrArray)
 						cs.Items.Schema = new(spec.Schema)
@@ -1497,7 +1504,6 @@ func parseEnum(val string, s *spec.SimpleSchema) []interface{} {
 	interfaceSlice := make([]interface{}, len(rawElements))
 
 	for i, d := range rawElements {
-
 		ds, err := strconv.Unquote(string(d))
 		if err != nil {
 			ds = string(d)
@@ -1515,7 +1521,7 @@ func parseEnum(val string, s *spec.SimpleSchema) []interface{} {
 	return interfaceSlice
 }
 
-// AlphaChars used when parsing for Vendor Extensions
+// AlphaChars used when parsing for Vendor Extensions.
 const AlphaChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 func newSetExtensions(setter func(*spec.Extensions)) *setOpExtensions {
@@ -1537,7 +1543,7 @@ type extensionObject struct {
 
 type extensionParsingStack []interface{}
 
-// Helper function to walk back through extensions until the proper nest level is reached
+// Helper function to walk back through extensions until the proper nest level is reached.
 func (stack *extensionParsingStack) walkBack(rawLines []string, lineIndex int) {
 	indent := strings.IndexAny(rawLines[lineIndex], AlphaChars)
 	nextIndent := strings.IndexAny(rawLines[lineIndex+1], AlphaChars)

--- a/codescan/parser_helpers.go
+++ b/codescan/parser_helpers.go
@@ -5,7 +5,7 @@ import (
 )
 
 // a shared function that can be used to split given headers
-// into a title and description
+// into a title and description.
 func collectScannerTitleDescription(headers []string) (title, desc []string) {
 	hdrs := cleanupScannerLines(headers, rxUncommentHeaders, nil)
 

--- a/codescan/regexprs.go
+++ b/codescan/regexprs.go
@@ -92,5 +92,5 @@ var (
 	rxExtensions      = regexp.MustCompile(`[Ee]xtensions\p{Zs}*:`)
 	rxInfoExtensions  = regexp.MustCompile(`[In]nfo\p{Zs}*[Ee]xtensions:`)
 	rxDeprecated      = regexp.MustCompile(`[Dd]eprecated\p{Zs}*:\p{Zs}*(true|false)$`)
-	// currently unused: rxExample         = regexp.MustCompile(`[Ex]ample\p{Zs}*:\p{Zs}*(.*)$`)
+	// currently unused: rxExample         = regexp.MustCompile(`[Ex]ample\p{Zs}*:\p{Zs}*(.*)$`).
 )

--- a/codescan/regexprs_test.go
+++ b/codescan/regexprs_test.go
@@ -123,7 +123,7 @@ func TestSchemaValueExtractors(t *testing.T) {
 
 func makeMinMax(lower string) (res []string) {
 	for _, a := range []string{"", "imum"} {
-		res = append(res, lower+a, strings.Title(lower)+a) //nolint:staticcheck
+		res = append(res, lower+a, strings.Title(lower)+a) //nolint:staticcheck // Title is deprecated, yet still useful here. The replacement is bit heavy for just this test
 	}
 	return res
 }
@@ -133,12 +133,12 @@ func verifyBoolean(t *testing.T, matcher *regexp.Regexp, names, names2 []string)
 	prefixes := []string{"//", "*", ""}
 	validArgs := []string{"true", "false"}
 	invalidArgs := []string{"TRUE", "FALSE", "t", "f", "1", "0", "True", "False", "true*", "false*"}
-	var nms []string
+	nms := make([]string, 0, len(names))
 	for _, nm := range names {
 		nms = append(nms, nm, strings.Title(nm)) //nolint:staticcheck
 	}
 
-	var nms2 []string
+	nms2 := make([]string, 0, len(names2))
 	for _, nm := range names2 {
 		nms2 = append(nms2, nm, strings.Title(nm)) //nolint:staticcheck
 	}
@@ -180,6 +180,7 @@ func verifyBoolean(t *testing.T, matcher *regexp.Regexp, names, names2 []string)
 			}
 		}
 	}
+
 	var nm2 string
 	if len(names2) > 0 {
 		nm2 = " " + names2[0]
@@ -196,7 +197,7 @@ func verifyIntegerMinMaxManyWords(t *testing.T, matcher *regexp.Regexp, name1 st
 	validNumericArgs := []string{"0", "1234"}
 	invalidNumericArgs := []string{"1A3F", "2e10", "*12", "12*", "-1235", "0.0", "1234.0394", "-2948.484"}
 
-	var names []string
+	names := make([]string, 0, len(words))
 	for _, w := range words {
 		names = append(names, w, strings.Title(w)) //nolint:staticcheck
 	}
@@ -352,9 +353,9 @@ func verifySwaggerOneArgSwaggerTag(t *testing.T, matcher *regexp.Regexp, prefixe
 
 func verifySwaggerMultiArgSwaggerTag(t *testing.T, matcher *regexp.Regexp, prefixes, validParams, invalidParams []string) {
 	var actualParams []string
-	for i := 0; i < len(validParams); i++ {
+	for i := range validParams {
 		var vp []string
-		for j := 0; j < (i + 1); j++ {
+		for j := range i + 1 {
 			vp = append(vp, validParams[j])
 		}
 		actualParams = append(actualParams, strings.Join(vp, " "))

--- a/codescan/responses.go
+++ b/codescan/responses.go
@@ -83,7 +83,7 @@ func (ht responseTypable) AddExtension(key string, value interface{}) {
 }
 
 func (ht responseTypable) WithEnum(values ...interface{}) {
-	ht.header.WithEnum(values)
+	ht.header.WithEnum(values) //nolint:asasalint
 }
 
 func (ht responseTypable) WithEnumDescription(_ string) {
@@ -418,7 +418,6 @@ func (r *responseBuilder) buildFromStruct(decl *entityDecl, tpe *types.Struct, r
 	for i := 0; i < tpe.NumFields(); i++ {
 		fld := tpe.Field(i)
 		if fld.Embedded() {
-
 			if err := r.buildFromType(fld.Type(), resp, seen); err != nil {
 				return err
 			}

--- a/codescan/responses_test.go
+++ b/codescan/responses_test.go
@@ -227,7 +227,7 @@ func TestParseResponses(t *testing.T) {
 	assert.True(t, iprop.ExclusiveMinimum, "'id' should have had an exclusive minimum")
 
 	assertRef(t, itprop, "pet", "Pet", "#/definitions/pet")
-	iprop, ok = itprop.Properties["pet"]
+	_, ok = itprop.Properties["pet"]
 	assert.True(t, ok)
 	// if itprop.Ref.String() == "" {
 	// 	assert.Equal(t, "The Pet to add to this NoModel items bucket.\nPets can appear more than once in the bucket", iprop.Description)

--- a/codescan/route_params.go
+++ b/codescan/route_params.go
@@ -9,47 +9,47 @@ import (
 )
 
 const (
-	// ParamDescriptionKey indicates the tag used to define a parameter description in swagger:route
+	// ParamDescriptionKey indicates the tag used to define a parameter description in swagger:route.
 	ParamDescriptionKey = "description"
-	// ParamNameKey indicates the tag used to define a parameter name in swagger:route
+	// ParamNameKey indicates the tag used to define a parameter name in swagger:route.
 	ParamNameKey = "name"
-	// ParamInKey indicates the tag used to define a parameter location in swagger:route
+	// ParamInKey indicates the tag used to define a parameter location in swagger:route.
 	ParamInKey = "in"
-	// ParamRequiredKey indicates the tag used to declare whether a parameter is required in swagger:route
+	// ParamRequiredKey indicates the tag used to declare whether a parameter is required in swagger:route.
 	ParamRequiredKey = "required"
-	// ParamTypeKey indicates the tag used to define the parameter type in swagger:route
+	// ParamTypeKey indicates the tag used to define the parameter type in swagger:route.
 	ParamTypeKey = "type"
-	// ParamAllowEmptyKey indicates the tag used to indicate whether a parameter allows empty values in swagger:route
+	// ParamAllowEmptyKey indicates the tag used to indicate whether a parameter allows empty values in swagger:route.
 	ParamAllowEmptyKey = "allowempty"
 
-	// SchemaMinKey indicates the tag used to indicate the minimum value allowed for this type in swagger:route
+	// SchemaMinKey indicates the tag used to indicate the minimum value allowed for this type in swagger:route.
 	SchemaMinKey = "min"
-	// SchemaMaxKey indicates the tag used to indicate the maximum value allowed for this type in swagger:route
+	// SchemaMaxKey indicates the tag used to indicate the maximum value allowed for this type in swagger:route.
 	SchemaMaxKey = "max"
-	// SchemaEnumKey indicates the tag used to specify the allowed values for this type in swagger:route
+	// SchemaEnumKey indicates the tag used to specify the allowed values for this type in swagger:route.
 	SchemaEnumKey = "enum"
-	// SchemaFormatKey indicates the expected format for this field in swagger:route
+	// SchemaFormatKey indicates the expected format for this field in swagger:route.
 	SchemaFormatKey = "format"
-	// SchemaDefaultKey indicates the default value for this field in swagger:route
+	// SchemaDefaultKey indicates the default value for this field in swagger:route.
 	SchemaDefaultKey = "default"
-	// SchemaMinLenKey indicates the minimum length this field in swagger:route
+	// SchemaMinLenKey indicates the minimum length this field in swagger:route.
 	SchemaMinLenKey = "minlength"
-	// SchemaMaxLenKey indicates the minimum length this field in swagger:route
+	// SchemaMaxLenKey indicates the minimum length this field in swagger:route.
 	SchemaMaxLenKey = "maxlength"
 
-	// TypeArray is the identifier for an array type in swagger:route
+	// TypeArray is the identifier for an array type in swagger:route.
 	TypeArray = "array"
-	// TypeNumber is the identifier for a number type in swagger:route
+	// TypeNumber is the identifier for a number type in swagger:route.
 	TypeNumber = "number"
-	// TypeInteger is the identifier for an integer type in swagger:route
+	// TypeInteger is the identifier for an integer type in swagger:route.
 	TypeInteger = "integer"
-	// TypeBoolean is the identifier for a boolean type in swagger:route
+	// TypeBoolean is the identifier for a boolean type in swagger:route.
 	TypeBoolean = "boolean"
-	// TypeBool is the identifier for a boolean type in swagger:route
+	// TypeBool is the identifier for a boolean type in swagger:route.
 	TypeBool = "bool"
-	// TypeObject is the identifier for an object type in swagger:route
+	// TypeObject is the identifier for an object type in swagger:route.
 	TypeObject = "object"
-	// TypeString is the identifier for a string type in swagger:route
+	// TypeString is the identifier for a string type in swagger:route.
 	TypeString = "string"
 )
 

--- a/codescan/routes_test.go
+++ b/codescan/routes_test.go
@@ -335,6 +335,8 @@ func validateRoutesParameters(t *testing.T, ops spec.Paths) {
 }
 
 func assertOperation(t *testing.T, op *spec.Operation, id, summary, description string, tags, scopes []string, extensions spec.Extensions) {
+	t.Helper()
+
 	assert.NotNil(t, op)
 	assert.Equal(t, summary, op.Summary)
 	assert.Equal(t, description, op.Description)

--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -263,7 +263,7 @@ func (s *schemaBuilder) buildDeclNamed(tpe *types.Named, schema *spec.Schema) er
 	return s.buildFromType(ti.Type, ps)
 }
 
-// buildFromTextMarshal renders a type that marshals as text as a string
+// buildFromTextMarshal renders a type that marshals as text as a string.
 func (s *schemaBuilder) buildFromTextMarshal(tpe types.Type, tgt swaggerTypable) error {
 	if typePtr, ok := tpe.(*types.Pointer); ok {
 		return s.buildFromTextMarshal(typePtr.Elem(), tgt)
@@ -506,7 +506,6 @@ func (s *schemaBuilder) buildNamedType(titpe *types.Named, tgt swaggerTypable) e
 		if typeName, ok := typeName(cmt); ok {
 			_ = swaggerSchemaForType(typeName, tgt)
 			return nil
-
 		}
 
 		if isAliasParam(tgt) || aliasParam(cmt) {

--- a/codescan/schema_test.go
+++ b/codescan/schema_test.go
@@ -2160,7 +2160,6 @@ func TestInterfaceDiscriminators(t *testing.T) {
 
 	schema, ok = models["modelA"]
 	if assert.True(t, ok) {
-
 		cl, _ := schema.Extensions.GetString("x-go-name")
 		assert.Equal(t, "ModelA", cl)
 
@@ -2185,13 +2184,13 @@ func TestAddExtension(t *testing.T) {
 
 	key2 := "x-go-package"
 	value2 := "schema"
-	_ = os.Setenv("SWAGGER_GENERATE_EXTENSION", "true")
+	t.Setenv("SWAGGER_GENERATE_EXTENSION", "true")
 	addExtension(ve, key2, value2)
 	assert.Equal(t, value2, ve.Extensions[key2].(string))
 
 	key3 := "x-go-class"
 	value3 := "Spec"
-	_ = os.Setenv("SWAGGER_GENERATE_EXTENSION", "false")
+	t.Setenv("SWAGGER_GENERATE_EXTENSION", "false")
 	addExtension(ve, key3, value3)
 	assert.Nil(t, ve.Extensions[key3])
 }

--- a/generator/build_test.go
+++ b/generator/build_test.go
@@ -1,6 +1,8 @@
 package generator_test
 
 import (
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,23 +58,32 @@ func TestGenerateAndBuild(t *testing.T) {
 	}
 
 	t.Run("build client", func(t *testing.T) {
+		// This test builds a client as a go module outside of the go source tree.
+		// It needs a go mod initialized and a go mod tidy sync, which slows down the test
+		// a bit but is quite realistic of a full-fledged build with modules.
 		for name, toPin := range cases {
 			cas := toPin
 
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
-				spec := filepath.FromSlash(cas.spec)
 
-				generated, err := os.MkdirTemp(filepath.Dir(spec), "generated")
-				require.NoErrorf(t, err, "TempDir()=%s", generated)
-				t.Cleanup(func() { _ = os.RemoveAll(generated) })
+				specPath := filepath.Clean(filepath.FromSlash(cas.spec))
+				generatedLocation := filepath.Join(t.TempDir(), filepath.Base(specPath), "generated")
+				t.Logf("building client in %q", generatedLocation)
+				require.NoError(t, os.MkdirAll(generatedLocation, fs.ModePerm))
 
-				require.NoErrorf(t, newTestClient(spec, generated).Execute(nil), "Execute()=%s", err)
+				module := gentest.SanitizeGoModPath(generatedLocation)
+				t.Run(fmt.Sprintf("should initialize module %q", module),
+					gentest.GoExecInDir(generatedLocation, "mod", "init", module),
+				)
 
-				packages := filepath.Join(generated, "...")
+				t.Run("should build client", func(t *testing.T) {
+					require.NoError(t, newTestClient(specPath, generatedLocation).Execute(nil))
+				})
 
-				t.Run("should go get imports", gentest.GoExecInDir("", "get"))
-				t.Run("should build client", gentest.GoExecInDir("", "build", packages))
+				t.Run("should go get imports", gentest.GoExecInDir(generatedLocation, "get", "./..."))
+				t.Run("should go mod tidy", gentest.GoExecInDir(generatedLocation, "mod", "tidy"))
+				t.Run("should build client", gentest.GoExecInDir(generatedLocation, "build", "./..."))
 			})
 		}
 	})
@@ -80,6 +91,7 @@ func TestGenerateAndBuild(t *testing.T) {
 
 func newTestClient(input, output string) *generate.Client {
 	c := &generate.Client{}
+
 	c.DefaultScheme = "http"
 	c.DefaultProduces = "application/json"
 	c.Shared.Spec = flags.Filename(input)
@@ -87,5 +99,6 @@ func newTestClient(input, output string) *generate.Client {
 	c.Operations.APIPackage = defaultAPIPackage
 	c.Models.ModelPackage = defaultModelPackage
 	c.ClientPackage = defaultClientPackage
+
 	return c
 }

--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -130,7 +130,7 @@ func Test_GenerateClient(t *testing.T) {
 			opts := testClientGenOpts()
 			opts.Spec = "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/old-v3.2.0-dev/examples/v2.0/yaml/petstore.yaml"
 
-			tft, err := os.MkdirTemp(cwd, "generated")
+			tft, err := os.MkdirTemp(cwd, "generated") //nolint:usetesting // want to be able to retrieve generate code and debug
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				_ = os.RemoveAll(tft)
@@ -152,7 +152,7 @@ func Test_GenerateClient(t *testing.T) {
 			opts := testClientGenOpts()
 			opts.Spec = filepath.Join("..", "fixtures", "bugs", "2527", "swagger-fixed.yml")
 
-			tft, err := os.MkdirTemp(cwd, "generated")
+			tft, err := os.MkdirTemp(cwd, "generated") //nolint:usetesting // want to be able to retrieve generated code and debug
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				_ = os.RemoveAll(tft)
@@ -434,7 +434,7 @@ func TestGenClient_1518(t *testing.T) {
 			`case *GetRecords4Created:`,
 			`return nil, value, nil`,
 			`unexpectedSuccess := result.(*GetRecords4Default)`,
-			`return nil, nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())`,
+			`return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())`,
 		},
 	}
 

--- a/generator/config.go
+++ b/generator/config.go
@@ -14,7 +14,7 @@ type LanguageDefinition struct {
 	Layout SectionOpts `mapstructure:"layout"`
 }
 
-// ConfigureOpts for generation
+// ConfigureOpts for generation.
 func (d *LanguageDefinition) ConfigureOpts(opts *GenOpts) error {
 	opts.Sections = d.Layout
 	if opts.LanguageOpts == nil {
@@ -23,12 +23,12 @@ func (d *LanguageDefinition) ConfigureOpts(opts *GenOpts) error {
 	return nil
 }
 
-// LanguageConfig structure that is obtained from parsing a config file
+// LanguageConfig structure that is obtained from parsing a config file.
 type LanguageConfig map[string]LanguageDefinition
 
 // ReadConfig at the specified path, when no path is specified it will look into
 // the current directory and load a .swagger.{yml,json,hcl,toml,properties} file
-// Returns a viper config or an error
+// Returns a viper config or an error.
 func ReadConfig(fpath string) (*viper.Viper, error) {
 	v := viper.New()
 	if fpath != "" {

--- a/generator/debug.go
+++ b/generator/debug.go
@@ -25,9 +25,9 @@ import (
 
 var (
 	// Debug when the env var DEBUG or SWAGGER_DEBUG is not empty
-	// the generators will be very noisy about what they are doing
+	// the generators will be very noisy about what they are doing.
 	Debug = os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != ""
-	// generatorLogger is a debug logger for this package
+	// generatorLogger is a debug logger for this package.
 	generatorLogger *log.Logger
 )
 
@@ -35,7 +35,7 @@ func debugOptions() {
 	generatorLogger = log.New(os.Stdout, "generator:", log.LstdFlags)
 }
 
-// debugLog wraps log.Printf with a debug-specific logger
+// debugLog wraps log.Printf with a debug-specific logger.
 func debugLog(frmt string, args ...any) {
 	if Debug {
 		_, file, pos, _ := runtime.Caller(1)
@@ -44,21 +44,23 @@ func debugLog(frmt string, args ...any) {
 	}
 }
 
-// debugLogAsJSON unmarshals its last arg as pretty JSON
+// debugLogAsJSON unmarshals its last arg as pretty JSON.
 func debugLogAsJSON(frmt string, args ...any) {
 	if Debug {
 		var dfrmt string
 		_, file, pos, _ := runtime.Caller(1)
 		dargs := make([]any, 0, len(args)+2)
 		dargs = append(dargs, filepath.Base(file), pos)
+
 		if len(args) > 0 {
 			dfrmt = "%s:%d: " + frmt + "\n%s"
-			bbb, _ := json.MarshalIndent(args[len(args)-1], "", " ")
+			bbb, _ := json.MarshalIndent(args[len(args)-1], "", " ") //nolint:errchkjson // it's okay for debug
 			dargs = append(dargs, args[0:len(args)-1]...)
 			dargs = append(dargs, string(bbb))
 		} else {
 			dfrmt = "%s:%d: " + frmt
 		}
+
 		generatorLogger.Printf(dfrmt, dargs...)
 	}
 }

--- a/generator/debug_test.go
+++ b/generator/debug_test.go
@@ -22,18 +22,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// mutex for -race because this test alters a global
+// mutex for -race because this test alters a global.
 var logMutex = &sync.Mutex{}
 
 func TestDebugLog(t *testing.T) {
-	tmpFile, _ := os.CreateTemp("", "debug-test")
+	tmpFile, _ := os.CreateTemp(t.TempDir(), "debug-test")
 	tmpName := tmpFile.Name()
 	logMutex.Lock()
 	defer func() {
 		Debug = false
 		// mutex for -race
 		logMutex.Unlock()
-		_ = os.Remove(tmpName)
 	}()
 
 	// mutex for -race
@@ -54,11 +53,8 @@ func TestDebugLog(t *testing.T) {
 	_ = flushed.Close()
 
 	// test debugLogAsJSON()
-	tmpJSONFile, _ := os.CreateTemp("", "debug-test")
+	tmpJSONFile, _ := os.CreateTemp(t.TempDir(), "debug-test")
 	tmpJSONName := tmpJSONFile.Name()
-	defer func() {
-		_ = os.Remove(tmpJSONName)
-	}()
 	generatorLogger.SetOutput(tmpJSONFile)
 	debugLogAsJSON("A short debug")
 

--- a/generator/formats.go
+++ b/generator/formats.go
@@ -16,7 +16,7 @@ package generator
 
 // TODO: we may probably find a way to register most of this dynamically from strfmt
 
-// map of function calls to be generated to get the zero value of a given type
+// map of function calls to be generated to get the zero value of a given type.
 var zeroes = map[string]string{
 	"bool":    "false",
 	"float32": "0",
@@ -62,7 +62,7 @@ var zeroes = map[string]string{
 }
 
 // conversion functions from string representation to a numerical or boolean
-// primitive type
+// primitive type.
 var stringConverters = map[string]string{
 	"bool":    "swag.ConvertBool",
 	"float32": "swag.ConvertFloat32",
@@ -78,7 +78,7 @@ var stringConverters = map[string]string{
 }
 
 // formatting (string representation) functions from a native representation
-// of a numerical or boolean primitive type
+// of a numerical or boolean primitive type.
 var stringFormatters = map[string]string{
 	"bool":    "swag.FormatBool",
 	"float32": "swag.FormatFloat32",
@@ -93,7 +93,7 @@ var stringFormatters = map[string]string{
 	"uint64":  "swag.FormatUint64",
 }
 
-// typeMapping contains a mapping of type name to go type
+// typeMapping contains a mapping of type name to go type.
 var typeMapping = map[string]string{
 	// Standard formats with native, straightforward, mapping
 	"string":  "string",
@@ -104,7 +104,7 @@ var typeMapping = map[string]string{
 	"file": "runtime.File",
 }
 
-// formatMapping contains a type-specific version of mapping of format to go type
+// formatMapping contains a type-specific version of mapping of format to go type.
 var formatMapping = map[string]map[string]string{
 	"number": {
 		"double": "float64",
@@ -172,7 +172,7 @@ var formatMapping = map[string]map[string]string{
 	},
 }
 
-// go primitive types
+// go primitive types.
 var primitives = map[string]struct{}{
 	"bool":       {},
 	"byte":       {},
@@ -196,7 +196,7 @@ var primitives = map[string]struct{}{
 }
 
 // Formats with a custom formatter.
-// Currently, 23 such formats are supported
+// Currently, 23 such formats are supported.
 var customFormatters = map[string]struct{}{
 	"strfmt.Base64":     {},
 	"strfmt.CreditCard": {},

--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -43,7 +42,7 @@ func TestGenerateAndTest(t *testing.T) {
 					thisCas.prepare(t, opts)
 				}
 
-				t.Run(fmt.Sprintf("generating test server from %s", opts.Spec), func(t *testing.T) {
+				t.Run("generating test server from "+opts.Spec, func(t *testing.T) {
 					err := GenerateServer("", nil, nil, opts)
 					if thisCas.wantError {
 						require.Errorf(t, err, "expected an error for server build fixture: %s", opts.Spec)
@@ -84,7 +83,7 @@ func TestGenerateAndTest(t *testing.T) {
 					thisCas.prepare(t, opts)
 				}
 
-				t.Run(fmt.Sprintf("generating test client from %s", opts.Spec), func(t *testing.T) {
+				t.Run("generating test client from "+opts.Spec, func(t *testing.T) {
 					err := GenerateClient(thisName, nil, nil, opts)
 					if thisCas.wantError {
 						require.Errorf(t, err, "expected an error for client build fixture: %s", opts.Spec)
@@ -260,7 +259,7 @@ func generateFixtures(_ testing.TB) map[string]generateFixture {
 				assertInCode(t, `APIGetConflictHandler apiops.GetConflictHandler`, api)
 				assertInCode(t, `CustomGetCustomHandler custom.GetCustomHandler`, api)
 				assertInCode(t, `AbcLinuxGetMultipleHandler abc_linux.GetMultipleHandler`, api)
-				assertInCode(t, `GetNotagHandler GetNotagHandler`, api)
+				assertInCode(t, `GetNotagHandler`, api)
 				assertInCode(t, `AbcLinuxGetOtherReservedHandler abc_linux.GetOtherReservedHandler`, api)
 				assertInCode(t, `PlusDonutsGetOtherUnsafeHandler plus_donuts.GetOtherUnsafeHandler`, api)
 				assertInCode(t, `AbcTestGetReservedHandler abc_test.GetReservedHandler`, api)
@@ -326,21 +325,21 @@ func generateFixtures(_ testing.TB) map[string]generateFixture {
 				assertInCode(t, `GetAnotherConflictHandler: GetAnotherConflictHandlerFunc(func(params GetAnotherConflictParams) middleware.Responder {`, api)
 				assertInCode(t, `NotagHandler: GetNotagHandlerFunc(func(params GetNotagParams) middleware.Responder {`, api)
 
-				assertInCode(t, `DeleteTestOverrideHandler DeleteTestOverrideHandler`, api)
-				assertInCode(t, `GetAnotherConflictHandler GetAnotherConflictHandler`, api)
-				assertInCode(t, `GetConflictHandler GetConflictHandler`, api)
-				assertInCode(t, `GetCustomHandler GetCustomHandler`, api)
-				assertInCode(t, `GetMultipleHandler GetMultipleHandler`, api)
-				assertInCode(t, `GetNotagHandler GetNotagHandler`, api)
-				assertInCode(t, `GetOtherReservedHandler GetOtherReservedHandler`, api)
-				assertInCode(t, `GetOtherUnsafeHandler GetOtherUnsafeHandler`, api)
-				assertInCode(t, `GetReservedHandler GetReservedHandler`, api)
-				assertInCode(t, `GetTestOverrideHandler GetTestOverrideHandler`, api)
-				assertInCode(t, `GetUnsafeHandler GetUnsafeHandler`, api)
-				assertInCode(t, `GetYetAnotherUnsafeHandler GetYetAnotherUnsafeHandler`, api)
-				assertInCode(t, `PostTestOverrideHandler PostTestOverrideHandler`, api)
-				assertInCode(t, `PutTestOverrideHandler PutTestOverrideHandler`, api)
-				assertInCode(t, `TestIDHandler TestIDHandler`, api)
+				assertInCode(t, `DeleteTestOverrideHandler`, api)
+				assertInCode(t, `GetAnotherConflictHandler`, api)
+				assertInCode(t, `GetConflictHandler`, api)
+				assertInCode(t, `GetCustomHandler`, api)
+				assertInCode(t, `GetMultipleHandler`, api)
+				assertInCode(t, `GetNotagHandler`, api)
+				assertInCode(t, `GetOtherReservedHandler`, api)
+				assertInCode(t, `GetOtherUnsafeHandler`, api)
+				assertInCode(t, `GetReservedHandler`, api)
+				assertInCode(t, `GetTestOverrideHandler`, api)
+				assertInCode(t, `GetUnsafeHandler`, api)
+				assertInCode(t, `GetYetAnotherUnsafeHandler`, api)
+				assertInCode(t, `PostTestOverrideHandler`, api)
+				assertInCode(t, `PutTestOverrideHandler`, api)
+				assertInCode(t, `TestIDHandler`, api)
 			},
 		},
 		"main_package": {

--- a/generator/genopts_nonwin.go
+++ b/generator/genopts_nonwin.go
@@ -11,6 +11,7 @@ import (
 
 type GenOpts struct {
 	GenOptsCommon
+
 	TemplatePlugin string
 }
 

--- a/generator/language.go
+++ b/generator/language.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	// DefaultLanguageFunc defines the default generation language
+	// DefaultLanguageFunc defines the default generation language.
 	DefaultLanguageFunc func() *LanguageOpts
 
 	moduleRe *regexp.Regexp
@@ -31,15 +31,16 @@ func initLanguage() {
 	moduleRe = regexp.MustCompile(`module[ \t]+([^\s]+)`)
 }
 
-// FormatOption allows for more flexible code formatting settings
+// FormatOption allows for more flexible code formatting settings.
 type FormatOption func(*formatOptions)
 
 type formatOptions struct {
 	imports.Options
+
 	localPrefixes []string
 }
 
-// WithFormatLocalPrefixes adds local prefixes to group imports
+// WithFormatLocalPrefixes adds local prefixes to group imports.
 func WithFormatLocalPrefixes(prefixes ...string) FormatOption {
 	return func(o *formatOptions) {
 		o.localPrefixes = append(o.localPrefixes, prefixes...)
@@ -66,7 +67,7 @@ func formatOptionsWithDefault(opts []FormatOption) formatOptions {
 	return o
 }
 
-// LanguageOpts to describe a language to the code generator
+// LanguageOpts to describe a language to the code generator.
 type LanguageOpts struct {
 	ReservedWords        []string
 	BaseImportFunc       func(string) string            `json:"-"`
@@ -79,7 +80,7 @@ type LanguageOpts struct {
 	dirNameFunc          func(string) string // language specific directory naming rules
 }
 
-// Init the language option
+// Init the language option.
 func (l *LanguageOpts) Init() {
 	if l.initialized {
 		return
@@ -91,7 +92,7 @@ func (l *LanguageOpts) Init() {
 	}
 }
 
-// MangleName makes sure a reserved word gets a safe name
+// MangleName makes sure a reserved word gets a safe name.
 func (l *LanguageOpts) MangleName(name, suffix string) string {
 	if _, ok := l.reservedWordsSet[swag.ToFileName(name)]; !ok {
 		return name
@@ -99,7 +100,7 @@ func (l *LanguageOpts) MangleName(name, suffix string) string {
 	return strings.Join([]string{name, suffix}, "_")
 }
 
-// MangleVarName makes sure a reserved word gets a safe name
+// MangleVarName makes sure a reserved word gets a safe name.
 func (l *LanguageOpts) MangleVarName(name string) string {
 	nm := swag.ToVarName(name)
 	if _, ok := l.reservedWordsSet[nm]; !ok {
@@ -108,7 +109,7 @@ func (l *LanguageOpts) MangleVarName(name string) string {
 	return nm + "Var"
 }
 
-// MangleFileName makes sure a file name gets a safe name
+// MangleFileName makes sure a file name gets a safe name.
 func (l *LanguageOpts) MangleFileName(name string) string {
 	if l.fileNameFunc != nil {
 		return l.fileNameFunc(name)
@@ -142,7 +143,7 @@ func (l *LanguageOpts) ManglePackagePath(name string, suffix string) string {
 	return strings.Join(parts, "/")
 }
 
-// FormatContent formats a file with a language specific formatter
+// FormatContent formats a file with a language specific formatter.
 func (l *LanguageOpts) FormatContent(name string, content []byte, opts ...FormatOption) ([]byte, error) {
 	if l.formatFunc != nil {
 		return l.formatFunc(name, content, opts...)
@@ -152,7 +153,7 @@ func (l *LanguageOpts) FormatContent(name string, content []byte, opts ...Format
 	return content, nil
 }
 
-// imports generate the code to import some external packages, possibly aliased
+// imports generate the code to import some external packages, possibly aliased.
 func (l *LanguageOpts) imports(imports map[string]string) string {
 	if l.ImportsFunc != nil {
 		return l.ImportsFunc(imports)
@@ -160,7 +161,7 @@ func (l *LanguageOpts) imports(imports map[string]string) string {
 	return ""
 }
 
-// arrayInitializer builds a litteral array
+// arrayInitializer builds a litteral array.
 func (l *LanguageOpts) arrayInitializer(data any) (string, error) {
 	if l.ArrayInitializerFunc != nil {
 		return l.ArrayInitializerFunc(data)
@@ -168,7 +169,7 @@ func (l *LanguageOpts) arrayInitializer(data any) (string, error) {
 	return "", nil
 }
 
-// baseImport figures out the base path to generate import statements
+// baseImport figures out the base path to generate import statements.
 func (l *LanguageOpts) baseImport(tgt string) string {
 	if l.BaseImportFunc != nil {
 		return l.BaseImportFunc(tgt)
@@ -177,7 +178,7 @@ func (l *LanguageOpts) baseImport(tgt string) string {
 	return ""
 }
 
-// GoLangOpts for rendering items as golang code
+// GoLangOpts for rendering items as golang code.
 func GoLangOpts() *LanguageOpts {
 	goOtherReservedSuffixes := map[string]bool{
 		// see:
@@ -378,7 +379,6 @@ func GoLangOpts() *LanguageOpts {
 				pth = relativepath
 				break
 			}
-
 		}
 
 		mod, goModuleAbsPath, err := tryResolveModule(tgtAbsPath)
@@ -438,6 +438,9 @@ func tryResolveModule(baseTargetPath string) (string, string, error) {
 	case err != nil:
 		return "", "", err
 	}
+	defer func() {
+		_ = f.Close()
+	}()
 
 	src, err := io.ReadAll(f)
 	if err != nil {
@@ -454,7 +457,7 @@ func tryResolveModule(baseTargetPath string) (string, string, error) {
 
 // 1. Checks if the child path and parent path coincide.
 // 2. If they do return child path  relative to parent path.
-// 3. Everything else return false
+// 3. Everything else return false.
 func checkPrefixAndFetchRelativePath(childpath string, parentpath string) (bool, string) {
 	// Windows (local) file systems - NTFS, as well as FAT and variants
 	// are case insensitive.

--- a/generator/language_test.go
+++ b/generator/language_test.go
@@ -49,7 +49,7 @@ func TestGolang_ManglePackage(t *testing.T) {
 	}
 }
 
-// Go literal initializer func
+// Go literal initializer func.
 func TestGolang_SliceInitializer(t *testing.T) {
 	o := GoLangOpts()
 	goSliceInitializer := o.ArrayInitializerFunc

--- a/generator/media_test.go
+++ b/generator/media_test.go
@@ -19,7 +19,7 @@ func TestMediaWellKnownMime(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "yaml", w)
 
-	w, ok = wellKnownMime(runtime.JSONMime + "+version=1;param=1") //nolint:testifylint // This is not a json value, this is a mime type
+	w, ok = wellKnownMime(runtime.JSONMime + "+version=1;param=1")
 	assert.True(t, ok)
 	assert.Equal(t, jsonSerializer, w) //nolint:testifylint
 

--- a/generator/model.go
+++ b/generator/model.go
@@ -47,7 +47,7 @@ Every action that happens tracks the path which is a linked list of refs
 
 */
 
-// GenerateModels generates all model files for some schema definitions
+// GenerateModels generates all model files for some schema definitions.
 func GenerateModels(modelNames []string, opts *GenOpts) error {
 	// overide any default or incompatible options setting
 	opts.IncludeModel = true
@@ -63,7 +63,7 @@ func GenerateModels(modelNames []string, opts *GenOpts) error {
 	return generator.Generate()
 }
 
-// GenerateDefinition generates a single model file for some schema definitions
+// GenerateDefinition generates a single model file for some schema definitions.
 func GenerateDefinition(modelNames []string, opts *GenOpts) error {
 	if err := opts.CheckOpts(); err != nil {
 		return err
@@ -350,7 +350,6 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 			}
 			pg.GenSchema.AllOf[i].Properties = remainingProperties
 		}
-
 	}
 
 	defaultImports := map[string]string{
@@ -772,7 +771,7 @@ func (sg *schemaGenContext) buildProperties() error {
 
 		var hasValidation bool
 		if tpe.IsComplexObject && tpe.IsAnonymous && len(v.Properties) > 0 {
-			// this is an anonymous complex construct: build a new new type for it
+			// this is an anonymous complex construct: build a new type for it
 			pg := sg.makeNewStruct(sg.makeRefName()+swag.ToGoName(k), v)
 			pg.IsTuple = sg.IsTuple
 			if sg.Path != "" {
@@ -1088,7 +1087,7 @@ func newMapStack(context *schemaGenContext) (first, last *mapStack, err error) {
 	return ms, l, nil
 }
 
-// Build rewinds the stack of additional properties, building schemas from bottom to top
+// Build rewinds the stack of additional properties, building schemas from bottom to top.
 func (mt *mapStack) Build() error {
 	if mt.NewObj == nil && mt.ValueRef == nil && mt.Next == nil && mt.Previous == nil {
 		csch := mt.Type.AdditionalProperties.Schema
@@ -2078,7 +2077,7 @@ func (sg *schemaGenContext) makeGenSchema() error {
 			return nil
 		}
 		// TODO: case for embedded types as anonymous definitions
-		return fmt.Errorf("ERROR: inline definitions embedded types are not supported")
+		return errors.New("ERROR: inline definitions embedded types are not supported")
 	}
 
 	debugLog("gschema nullable: %t", sg.GenSchema.IsNullable)

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -1602,7 +1602,7 @@ func TestGenModel_Issue222(t *testing.T) {
 
 	res := string(ct)
 	assertInCode(t, "Price) Validate(formats strfmt.Registry) error", res)
-	assertInCode(t, "Currency Currency `json:\"currency,omitempty\"`", res)
+	assertInCode(t, "Currency `json:\"currency,omitempty\"`", res)
 	assertInCode(t, "m.Currency.Validate(formats); err != nil", res)
 }
 
@@ -2071,7 +2071,7 @@ func TestGenModel_Issue1341(t *testing.T) {
 	assertInCode(t, "Test: m.Test(),", res)
 }
 
-// This tests to check that format validation is performed on non required schema properties
+// This tests to check that format validation is performed on non required schema properties.
 func TestGenModel_Issue1347(t *testing.T) {
 	specDoc, err := loads.Spec("../fixtures/bugs/1347/fixture-1347.yaml")
 	require.NoError(t, err)
@@ -2093,7 +2093,7 @@ func TestGenModel_Issue1347(t *testing.T) {
 	assertInCode(t, `validate.FormatOf("config1", "body", "hostname", m.Config1.String(), formats)`, res)
 }
 
-// This tests to check that format validation is performed on MAC format
+// This tests to check that format validation is performed on MAC format.
 func TestGenModel_Issue1348(t *testing.T) {
 	specDoc, err := loads.Spec("../fixtures/bugs/1348/fixture-1348.yaml")
 	require.NoError(t, err)
@@ -2239,7 +2239,7 @@ func TestGenModel_Issue2911(t *testing.T) {
 	}`, res)
 }
 
-// This tests makes sure model definitions from inline schema in response are properly flattened and get validation
+// This tests makes sure model definitions from inline schema in response are properly flattened and get validation.
 func TestGenModel_Issue866(t *testing.T) {
 	defer discardOutput()()
 
@@ -2272,7 +2272,7 @@ func TestGenModel_Issue866(t *testing.T) {
 	}
 }
 
-// This tests makes sure marshalling and validation is generated in aliased formatted definitions
+// This tests makes sure marshalling and validation is generated in aliased formatted definitions.
 func TestGenModel_Issue946(t *testing.T) {
 	specDoc, err := loads.Spec("../fixtures/bugs/946/fixture-946.yaml")
 	require.NoError(t, err)
@@ -2299,7 +2299,7 @@ func TestGenModel_Issue946(t *testing.T) {
 	assertInCode(t, `if err := validate.FormatOf("", "body", "date", strfmt.Date(m).String(), formats); err != nil {`, res)
 }
 
-// This tests makes sure that docstring in inline schema in response properly reflect the Required property
+// This tests makes sure that docstring in inline schema in response properly reflect the Required property.
 func TestGenModel_Issue910(t *testing.T) {
 	specDoc, err := loads.Spec("../fixtures/bugs/910/fixture-910.yaml")
 	require.NoError(t, err)
@@ -2693,7 +2693,7 @@ func TestGenerateModels(t *testing.T) {
 					thisCas.prepare(t, opts)
 				}
 
-				t.Run(fmt.Sprintf("generating test models from: %s", opts.Spec), func(t *testing.T) {
+				t.Run("generating test models from: "+opts.Spec, func(t *testing.T) {
 					err := GenerateModels([]string{"", ""}, opts) // NOTE: generate all models, ignore ""
 					if thisCas.wantError {
 						require.Errorf(t, err, "expected an error for models build fixture: %s", opts.Spec)

--- a/generator/moreschemavalidation_test.go
+++ b/generator/moreschemavalidation_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// modelExpectations is a test structure to capture expected codegen lines of code
+// modelExpectations is a test structure to capture expected codegen lines of code.
 type modelExpectations struct {
 	GeneratedFile    string
 	ExpectedLines    []string
@@ -84,13 +84,13 @@ func (m modelExpectations) AssertModelCodegen(t testing.TB, msg, definitionName,
 	}
 }
 
-// modelTestRun is a test structure to configure generations options to test a spec
+// modelTestRun is a test structure to configure generations options to test a spec.
 type modelTestRun struct {
 	FixtureOpts *GenOpts
 	Definitions map[string]*modelExpectations
 }
 
-// AddExpectations adds expected / not expected sets of lines of code to the current run
+// AddExpectations adds expected / not expected sets of lines of code to the current run.
 func (r *modelTestRun) AddExpectations(file string, expectedCode, notExpectedCode, expectedLogs, notExpectedLogs []string) {
 	k := strings.ToLower(swag.ToJSONName(strings.TrimSuffix(file, ".go")))
 	if def, ok := r.Definitions[k]; ok {
@@ -110,7 +110,7 @@ func (r *modelTestRun) AddExpectations(file string, expectedCode, notExpectedCod
 	}
 }
 
-// ExpectedFor returns the map of model expectations from the run for a given model definition
+// ExpectedFor returns the map of model expectations from the run for a given model definition.
 func (r *modelTestRun) ExpectedFor(definition string) *modelExpectations {
 	if def, ok := r.Definitions[strings.ToLower(definition)]; ok {
 		return def
@@ -123,14 +123,14 @@ func (r *modelTestRun) WithMinimalFlatten(minimal bool) *modelTestRun {
 	return r
 }
 
-// modelFixture is a test structure to launch configurable test runs on a given spec
+// modelFixture is a test structure to launch configurable test runs on a given spec.
 type modelFixture struct {
 	SpecFile    string
 	Description string
 	Runs        []*modelTestRun
 }
 
-// Add adds a new run to the provided model fixture
+// Add adds a new run to the provided model fixture.
 func (f *modelFixture) AddRun(expandSpec bool) *modelTestRun {
 	opts := &GenOpts{}
 	opts.IncludeValidator = true
@@ -154,7 +154,7 @@ func (f *modelFixture) AddRun(expandSpec bool) *modelTestRun {
 	return run
 }
 
-// ExpectedBy returns the expectations from another run of the current fixture, recalled by its index in the list of planned runs
+// ExpectedBy returns the expectations from another run of the current fixture, recalled by its index in the list of planned runs.
 func (f *modelFixture) ExpectedFor(index int, definition string) *modelExpectations {
 	if index > len(f.Runs)-1 {
 		return nil
@@ -190,7 +190,7 @@ var (
 	modelTestMutex = &sync.Mutex{} // mutex to protect log capture
 	testedModels   []*modelFixture
 
-	// convenient vars for (not) matching some lines
+	// convenient vars for (not) matching some lines.
 	noLines     []string
 	todo        []string
 	validatable []string
@@ -205,7 +205,7 @@ func initSchemaValidationTest() {
 	warning = []string{`warning`}
 }
 
-// initModelFixtures loads all tests to be performed
+// initModelFixtures loads all tests to be performed.
 func initModelFixtures() {
 	initFixtureSimpleAllOf()
 	initFixtureComplexAllOf()

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -43,7 +43,7 @@ func (s responses) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s responses) Less(i, j int) bool { return s[i].Code < s[j].Code }
 
 // sortedResponses produces a sorted list of responses.
-// TODO: this is redundant with the definition given in struct.go
+// TODO: this is redundant with the definition given in struct.go.
 func sortedResponses(input map[int]spec.Response) responses {
 	var res responses
 	for k, v := range input {
@@ -58,7 +58,7 @@ func sortedResponses(input map[int]spec.Response) responses {
 // GenerateServerOperation generates a parameter model, parameter validator, http handler implementations for a given operation.
 //
 // It also generates an operation handler interface that uses the parameter model for handling a valid request.
-// Allows for specifying a list of tags to include only certain tags for the generation
+// Allows for specifying a list of tags to include only certain tags for the generation.
 func GenerateServerOperation(operationNames []string, opts *GenOpts) error {
 	if err := opts.CheckOpts(); err != nil {
 		return err
@@ -149,7 +149,7 @@ type operationGenerator struct {
 	GenOpts              *GenOpts
 }
 
-// Generate a single operation
+// Generate a single operation.
 func (o *operationGenerator) Generate() error {
 	defaultImports := o.GenOpts.defaultImports()
 
@@ -238,7 +238,7 @@ type codeGenOpBuilder struct {
 	GenOpts             *GenOpts
 }
 
-// paramMappings yields a map of safe parameter names for an operation
+// paramMappings yields a map of safe parameter names for an operation.
 func paramMappings(params map[string]spec.Parameter) (map[string]map[string]string, string) {
 	idMapping := map[string]map[string]string{
 		"query":    make(map[string]string, len(params)),
@@ -670,7 +670,7 @@ func (b *codeGenOpBuilder) MakeHeaderItem(receiver, paramName, indexVar, path, v
 	return res, nil
 }
 
-// HasValidations resolves the validation status for simple schema objects
+// HasValidations resolves the validation status for simple schema objects.
 func (b *codeGenOpBuilder) HasValidations(sh spec.CommonValidations, rt resolvedType) (hasValidations bool, hasSliceValidations bool) {
 	hasSliceValidations = sh.HasArrayValidations() || sh.HasEnum()
 	hasValidations = sh.HasNumberValidations() || sh.HasStringValidations() || hasSliceValidations || hasFormatValidation(rt)
@@ -808,7 +808,7 @@ func (b *codeGenOpBuilder) MakeParameter(receiver string, resolver *typeResolver
 	return res, nil
 }
 
-// MakeBodyParameter constructs a body parameter schema
+// MakeBodyParameter constructs a body parameter schema.
 func (b *codeGenOpBuilder) MakeBodyParameter(res *GenParameter, resolver *typeResolver, sch *spec.Schema) error {
 	// resolve schema model
 	schema, ers := b.buildOperationSchema(res.Path, b.Operation.ID+"ParamsBody", swag.ToGoName(b.Operation.ID+" Body"), res.ReceiverName, res.IndexVar, sch, resolver)
@@ -846,7 +846,7 @@ func (b *codeGenOpBuilder) MakeBodyParameter(res *GenParameter, resolver *typeRe
 // MakeBodyParameterItemsAndMaps clones the .Items schema structure (resp. .AdditionalProperties) as a .GenItems structure
 // for compatibility with simple param templates.
 //
-// Constructed children assume simple structures: any complex object is assumed to be resolved by a model or extra schema definition
+// Constructed children assume simple structures: any complex object is assumed to be resolved by a model or extra schema definition.
 func (b *codeGenOpBuilder) MakeBodyParameterItemsAndMaps(res *GenParameter, it *GenSchema) *GenItems {
 	items := new(GenItems)
 	if it != nil {
@@ -994,7 +994,7 @@ func (b *codeGenOpBuilder) setBodyParamValidation(p *GenParameter) {
 	}
 }
 
-// makeSecuritySchemes produces a sorted list of security schemes for this operation
+// makeSecuritySchemes produces a sorted list of security schemes for this operation.
 func (b *codeGenOpBuilder) makeSecuritySchemes(receiver string) GenSecuritySchemes {
 	return gatherSecuritySchemes(b.SecurityDefinitions, b.Name, b.Principal, receiver, b.GenOpts.PrincipalIsNullable())
 }
@@ -1027,11 +1027,19 @@ func (b *codeGenOpBuilder) makeSecurityRequirements(_ string) []GenSecurityRequi
 	return securityRequirements
 }
 
-// cloneSchema returns a deep copy of a schema
+// cloneSchema returns a deep copy of a schema.
 func (b *codeGenOpBuilder) cloneSchema(schema *spec.Schema) *spec.Schema {
 	savedSchema := &spec.Schema{}
-	schemaRep, _ := json.Marshal(schema)
-	_ = json.Unmarshal(schemaRep, savedSchema)
+	schemaRep, err := json.Marshal(schema)
+	if err != nil {
+		panic(err)
+	}
+
+	err = json.Unmarshal(schemaRep, savedSchema)
+	if err != nil {
+		panic(err)
+	}
+
 	return savedSchema
 }
 
@@ -1211,7 +1219,7 @@ func intersectTags(left, right []string) []string {
 	return filtered
 }
 
-// analyze tags for an operation
+// analyze tags for an operation.
 func (b *codeGenOpBuilder) analyzeTags() (string, []string, bool) {
 	var (
 		filter         []string
@@ -1271,13 +1279,13 @@ func maxInt(a, b int) int {
 }
 
 // deconflictTag ensures generated packages for operations based on tags do not conflict
-// with other imports
+// with other imports.
 func deconflictTag(seenTags []string, pkg string) string {
 	return deconflictPkg(pkg, func(pkg string) string { return renameOperationPackage(seenTags, pkg) })
 }
 
 // deconflictPrincipal ensures that whenever an external principal package is added, it doesn't conflict
-// with standard imports
+// with standard imports.
 func deconflictPrincipal(pkg string) string {
 	switch pkg {
 	case "principal":
@@ -1287,7 +1295,7 @@ func deconflictPrincipal(pkg string) string {
 	}
 }
 
-// deconflictPkg renames package names which conflict with standard imports
+// deconflictPkg renames package names which conflict with standard imports.
 func deconflictPkg(pkg string, renamer func(string) string) string {
 	switch pkg {
 	// package conflict with variables

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -307,7 +307,7 @@ func methodPathOpBuilder(method, path, fname string) (codeGenOpBuilder, error) {
 	}, nil
 }
 
-// methodPathOpBuilderWithFlatten prepares an operation build based on method and path, with spec full flattening
+// methodPathOpBuilderWithFlatten prepares an operation build based on method and path, with spec full flattening.
 func methodPathOpBuilderWithFlatten(method, path, fname string) (codeGenOpBuilder, error) {
 	defer discardOutput()()
 
@@ -343,7 +343,7 @@ func methodPathOpBuilderWithFlatten(method, path, fname string) (codeGenOpBuilde
 	}, nil
 }
 
-// opBuilderWithOpts prepares the making of an operation with spec flattening options
+// opBuilderWithOpts prepares the making of an operation with spec flattening options.
 func opBuilderWithOpts(name, fname string, o *GenOpts) (codeGenOpBuilder, error) {
 	defer discardOutput()()
 
@@ -396,7 +396,7 @@ func opBuildGetOpts(specName string, withFlatten bool, withMinimalFlatten bool) 
 	return opts
 }
 
-// opBuilderWithFlatten prepares the making of an operation with spec full flattening prior to rendering
+// opBuilderWithFlatten prepares the making of an operation with spec full flattening prior to rendering.
 func opBuilderWithFlatten(name, fname string) (codeGenOpBuilder, error) {
 	o := opBuildGetOpts(fname, true, false) // flatten: true, minimal: false
 	return opBuilderWithOpts(name, fname, o)
@@ -410,13 +410,13 @@ func opBuilderWithMinimalFlatten(name, fname string) (codeGenOpBuilder, error) {
 }
 */
 
-// opBuilderWithExpand prepares the making of an operation with spec expansion prior to rendering
+// opBuilderWithExpand prepares the making of an operation with spec expansion prior to rendering.
 func opBuilderWithExpand(name, fname string) (codeGenOpBuilder, error) {
 	o := opBuildGetOpts(fname, false, false) // flatten: false => expand
 	return opBuilderWithOpts(name, fname, o)
 }
 
-// opBuilder prepares the making of an operation with spec minimal flattening (default for CLI)
+// opBuilder prepares the making of an operation with spec minimal flattening (default for CLI).
 func opBuilder(name, fname string) (codeGenOpBuilder, error) {
 	o := opBuildGetOpts(fname, true, true) // flatten:true, minimal: true
 	// some fixtures do not fully validate - skip this
@@ -1009,7 +1009,7 @@ func TestGenClientIssue890_ValidationTrueFlattenFalse(t *testing.T) {
 	require.NoError(t, GenerateClient("foo", nil, nil, opts))
 }
 
-// This tests that securityDefinitions generate stable code
+// This tests that securityDefinitions generate stable code.
 func TestBuilder_Issue1214(t *testing.T) {
 	defer discardOutput()()
 
@@ -1040,7 +1040,7 @@ func TestBuilder_Issue1214(t *testing.T) {
 	op, e := appGen.makeCodegenApp()
 	require.NoError(t, e)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		buf := bytes.NewBuffer(nil)
 		err := templates.MustGet("serverConfigureapi").Execute(buf, op)
 		require.NoError(t, err)
@@ -1093,7 +1093,7 @@ func TestBuilder_Issue1214(t *testing.T) {
 }
 
 func TestGenSecurityRequirements(t *testing.T) {
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		operation := "asecOp"
 		b, err := opBuilder(operation, "../fixtures/bugs/1214/fixture-1214.yaml")
 		require.NoError(t, err)
@@ -1241,7 +1241,7 @@ func TestGenerateServerOperation(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// This tests that mimetypes generate stable code
+// This tests that mimetypes generate stable code.
 func TestBuilder_Issue1646(t *testing.T) {
 	defer discardOutput()()
 
@@ -1272,7 +1272,7 @@ func TestBuilder_Issue1646(t *testing.T) {
 	preProds, preProdj := appGen.makeProduces()
 	assert.True(t, preConj)
 	assert.True(t, preProdj)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		cons, conj := appGen.makeConsumes()
 		prods, prodj := appGen.makeProduces()
 		assert.True(t, conj)

--- a/generator/parameter_test.go
+++ b/generator/parameter_test.go
@@ -1452,7 +1452,7 @@ func TestGenParameter_Issue909(t *testing.T) {
 	}
 }
 
-// verifies that validation method is called on body param with $ref
+// Verifies that validation method is called on body param with $ref.
 func TestGenParameter_Issue1237(t *testing.T) {
 	defer discardOutput()()
 
@@ -1714,7 +1714,7 @@ func TestGenParameter_Issue1513(t *testing.T) {
 	assertInCode(t, assertion, res)
 }
 
-// Body param validation on empty objects
+// Body param validation on empty objects.
 func TestGenParameter_Issue1536(t *testing.T) {
 	defer discardOutput()()
 

--- a/generator/response_test.go
+++ b/generator/response_test.go
@@ -319,7 +319,7 @@ func TestGenResponses_Issue718_Required(t *testing.T) {
 	assertInCode(t, "payload = make([]models.Foo, 0, 50)", string(ff))
 }
 
-// Issue776 includes references that span multiple files. Flattening or Expanding is required
+// Issue776 includes references that span multiple files. Flattening or Expanding is required.
 func TestGenResponses_Issue776_Spec(t *testing.T) {
 	defer discardOutput()()
 
@@ -360,7 +360,7 @@ func TestGenResponses_Issue776_SwaggerTemplate(t *testing.T) {
 
 func TestIssue846(t *testing.T) {
 	// do it 8 times, to ensure it's always in the same order
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		b, err := opBuilder("getFoo", "../fixtures/bugs/846/swagger.yml")
 		require.NoError(t, err)
 		op, err := b.MakeOperation()

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	// default generation targets structure
+	// default generation targets structure.
 	defaultModelsTarget         = "models"
 	defaultServerTarget         = "restapi"
 	defaultClientTarget         = "client"
@@ -57,7 +57,7 @@ func init() {
 }
 
 // DefaultSectionOpts for a given opts, this is used when no config file is passed
-// and uses the embedded templates when no local override can be found
+// and uses the embedded templates when no local override can be found.
 func DefaultSectionOpts(gen *GenOpts) {
 	sec := gen.Sections
 	if len(sec.Models) == 0 {
@@ -250,7 +250,7 @@ func DefaultSectionOpts(gen *GenOpts) {
 	gen.Sections = sec
 }
 
-// MarkdownOpts for rendering a spec as markdown
+// MarkdownOpts for rendering a spec as markdown.
 func MarkdownOpts() *LanguageOpts {
 	opts := &LanguageOpts{}
 	opts.Init()
@@ -274,7 +274,7 @@ func MarkdownSectionOpts(gen *GenOpts, output string) {
 	}
 }
 
-// TemplateOpts allows for codegen customization
+// TemplateOpts allows for codegen customization.
 type TemplateOpts struct {
 	Name       string `mapstructure:"name"`
 	Source     string `mapstructure:"source"`
@@ -284,7 +284,7 @@ type TemplateOpts struct {
 	SkipFormat bool   `mapstructure:"skip_format"` // not a feature, but for debugging. generated code before formatting might not work because of unused imports.
 }
 
-// SectionOpts allows for specifying options to customize the templates used for generation
+// SectionOpts allows for specifying options to customize the templates used for generation.
 type SectionOpts struct {
 	Application     []TemplateOpts `mapstructure:"application"`
 	Operations      []TemplateOpts `mapstructure:"operations"`
@@ -293,7 +293,7 @@ type SectionOpts struct {
 	PostModels      []TemplateOpts `mapstructure:"post_models"`
 }
 
-// GenOptsCommon the options for the generator
+// GenOptsCommon the options for the generator.
 type GenOptsCommon struct {
 	IncludeModel               bool
 	IncludeValidator           bool
@@ -401,7 +401,7 @@ func (g *GenOpts) CheckOpts() error {
 // ServerPackage: abc/efg
 //
 // Server is generated in ${PWD}/tmp/abc/efg
-// relative TargetPath returned: ../../../tmp
+// relative TargetPath returned: ../../../tmp.
 func (g *GenOpts) TargetPath() string {
 	var tgt string
 	if g.Target == "" {
@@ -449,13 +449,13 @@ func (g *GenOpts) SpecPath() string {
 }
 
 // PrincipalIsNullable indicates whether the principal type used for authentication
-// may be used as a pointer
+// may be used as a pointer.
 func (g *GenOpts) PrincipalIsNullable() bool {
 	debugLog("Principal: %s, %t, isnullable: %t", g.Principal, g.PrincipalCustomIface, g.Principal != iface && !g.PrincipalCustomIface)
 	return g.Principal != iface && !g.PrincipalCustomIface
 }
 
-// EnsureDefaults for these gen opts
+// EnsureDefaults for these gen opts.
 func (g *GenOpts) EnsureDefaults() error {
 	if g.defaultsEnsured {
 		return nil
@@ -804,7 +804,7 @@ func (g *GenOptsCommon) setTemplates() error {
 	return nil
 }
 
-// defaultImports produces a default map for imports with models
+// defaultImports produces a default map for imports with models.
 func (g *GenOpts) defaultImports() map[string]string {
 	baseImport := g.LanguageOpts.baseImport(g.Target)
 	defaultImports := make(map[string]string, 50)
@@ -840,7 +840,7 @@ func (g *GenOpts) defaultImports() map[string]string {
 	return defaultImports
 }
 
-// initImports produces a default map for import with the specified root for operations
+// initImports produces a default map for import with the specified root for operations.
 func (g *GenOpts) initImports(operationsPackage string) map[string]string {
 	baseImport := g.LanguageOpts.baseImport(g.Target)
 
@@ -851,7 +851,7 @@ func (g *GenOpts) initImports(operationsPackage string) map[string]string {
 	return imports
 }
 
-// PrincipalAlias returns an aliased type to the principal
+// PrincipalAlias returns an aliased type to the principal.
 func (g *GenOpts) PrincipalAlias() string {
 	_, principal, _ := g.resolvePrincipal()
 	return principal
@@ -910,7 +910,7 @@ func gatherModels(specDoc *loads.Document, modelNames []string) (map[string]spec
 	return models, nil
 }
 
-// titleOrDefault infers a name for the app from the title of the spec
+// titleOrDefault infers a name for the app from the title of the spec.
 func titleOrDefault(specDoc *loads.Document, name, defaultName string) string {
 	if strings.TrimSpace(name) == "" {
 		if specDoc.Spec().Info != nil && strings.TrimSpace(specDoc.Spec().Info.Title) != "" {
@@ -1010,7 +1010,7 @@ const (
 	securitySchemeOAuth2 = "oauth2"
 )
 
-// gatherSecuritySchemes produces a sorted representation from a map of spec security schemes
+// gatherSecuritySchemes produces a sorted representation from a map of spec security schemes.
 func gatherSecuritySchemes(securitySchemes map[string]spec.SecurityScheme, appName, principal, receiver string, nullable bool) (security GenSecuritySchemes) {
 	for scheme, req := range securitySchemes {
 		isOAuth2 := strings.EqualFold(req.Type, securitySchemeOAuth2)
@@ -1115,7 +1115,7 @@ func importAlias(pkg string) string {
 	return k
 }
 
-// concatUnique concatenate collections of strings with deduplication
+// concatUnique concatenate collections of strings with deduplication.
 func concatUnique(collections ...[]string) []string {
 	resultSet := make(map[string]struct{})
 	for _, c := range collections {

--- a/generator/shared_test.go
+++ b/generator/shared_test.go
@@ -1,7 +1,7 @@
 package generator
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"os"
 	"path"
@@ -77,7 +77,7 @@ func testGenOpts() *GenOpts {
 // Errors in CheckOpts are hard to simulate since
 // they occur only on os.Getwd() errors
 // Windows style path is difficult to test on unix
-// since the filepath pkg is platform dependent
+// since the filepath pkg is platform dependent.
 func TestShared_CheckOpts(t *testing.T) {
 	defer discardOutput()()
 	testPath := filepath.Join("a", "b", "b")
@@ -182,7 +182,7 @@ func TestShared_TargetPath(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-// NOTE: file://url is not supported
+// NOTE: file://url is not supported.
 func TestShared_SpecPath(t *testing.T) {
 	defer discardOutput()()
 
@@ -267,7 +267,7 @@ func TestShared_SpecPath(t *testing.T) {
 	}
 }
 
-// Low level testing: templates not found (higher level calls raise panic(), see above)
+// Low level testing: templates not found (higher level calls raise panic(), see above).
 func TestShared_NotFoundTemplate(t *testing.T) {
 	defer discardOutput()()
 
@@ -287,7 +287,7 @@ func TestShared_NotFoundTemplate(t *testing.T) {
 }
 
 // Low level testing: invalid template => Get() returns not found (higher level calls raise panic(), see above)
-// TODO: better error discrimination between absent definition and non-parsing template
+// TODO: better error discrimination between absent definition and non-parsing template.
 func TestShared_GarbledTemplate(t *testing.T) {
 	defer discardOutput()()
 
@@ -310,11 +310,11 @@ func TestShared_GarbledTemplate(t *testing.T) {
 	assert.Nilf(t, buf, "Upon error, GenOpts.render() should return nil buffer")
 }
 
-// Template execution failure
+// Template execution failure.
 type myTemplateData struct{}
 
 func (*myTemplateData) MyFaultyMethod() (string, error) {
-	return "", fmt.Errorf("myFaultyError")
+	return "", errors.New("myFaultyError")
 }
 
 func TestShared_ExecTemplate(t *testing.T) {
@@ -359,7 +359,7 @@ func TestShared_ExecTemplate(t *testing.T) {
 	assert.Nil(t, buf2, "Upon error, GenOpts.render() should return nil buffer")
 }
 
-// Test correctly parsed templates, with bad formatting
+// Test correctly parsed templates, with bad formatting.
 func TestShared_BadFormatTemplate(t *testing.T) {
 	// TODO: fred refact
 	defer discardOutput()()
@@ -429,7 +429,7 @@ func TestShared_BadFormatTemplate(t *testing.T) {
 	// os.RemoveAll(filepath.Join(filepath.FromSlash(dr),"restapi"))
 }
 
-// Test dir creation
+// Test dir creation.
 func TestShared_DirectoryTemplate(t *testing.T) {
 	defer discardOutput()()
 
@@ -470,7 +470,7 @@ func TestShared_DirectoryTemplate(t *testing.T) {
 }
 
 // Test templates which are not assets (open in file)
-// Low level testing: templates loaded from file
+// Low level testing: templates loaded from file.
 func TestShared_LoadTemplate(t *testing.T) {
 	defer discardOutput()()
 
@@ -765,7 +765,7 @@ func TestDefaultImports(t *testing.T) {
 		},
 	} {
 		fixture := toPin
-		i := i
+
 		t.Run(fixture.Title, func(t *testing.T) {
 			t.Parallel()
 			err := fixture.Opts.EnsureDefaults()

--- a/generator/spec.go
+++ b/generator/spec.go
@@ -136,7 +136,7 @@ func (g *GenOpts) printFlattenOpts() {
 	log.Printf("preprocessing spec with option:  %s", preprocessingOption)
 }
 
-// findSwaggerSpec fetches a default swagger spec if none is provided
+// findSwaggerSpec fetches a default swagger spec if none is provided.
 func findSwaggerSpec(nm string) (string, error) {
 	specs := []string{"swagger.json", "swagger.yml", "swagger.yaml"}
 	if nm != "" {
@@ -248,7 +248,7 @@ func WithAutoXOrder(specPath string) string {
 	return tmpFile
 }
 
-// BytesToYAMLDoc converts a byte slice into a YAML document
+// BytesToYAMLv2Doc converts a byte slice into a YAML document.
 func BytesToYAMLv2Doc(data []byte) (any, error) {
 	var canary map[any]any // validate this is an object and not a different type
 	if err := yamlv2.Unmarshal(data, &canary); err != nil {

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -24,10 +24,11 @@ type GenCommon struct {
 }
 
 // GenDefinition contains all the properties to generate a
-// definition from a swagger spec
+// definition from a swagger spec.
 type GenDefinition struct {
 	GenCommon
 	GenSchema
+
 	Package        string
 	CliPackage     string
 	Imports        map[string]string
@@ -38,7 +39,7 @@ type GenDefinition struct {
 }
 
 // GenDefinitions represents a list of operations to generate
-// this implements a sort by operation id
+// this implements a sort by operation id.
 type GenDefinitions []GenDefinition
 
 func (g GenDefinitions) Len() int           { return len(g) }
@@ -48,14 +49,15 @@ func (g GenDefinitions) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 // GenSchemaList is a list of schemas for generation.
 //
 // It can be sorted by name to get a stable struct layout for
-// version control and such
+// version control and such.
 type GenSchemaList []GenSchema
 
 // GenSchema contains all the information needed to generate the code
-// for a schema
+// for a schema.
 type GenSchema struct {
 	resolvedType
 	sharedValidations
+
 	Example                    string
 	OriginalName               string
 	Name                       string
@@ -123,7 +125,7 @@ func (g GenSchema) renderMarshalTag() string {
 	return result.String()
 }
 
-// PrintTags takes care of rendering tags for a struct field
+// PrintTags takes care of rendering tags for a struct field.
 func (g GenSchema) PrintTags() string {
 	tags := make(map[string]string, 3)
 	orderedTags := make([]string, 0, 3)
@@ -192,7 +194,7 @@ func (g GenSchema) PrintTags() string {
 	return strconv.Quote(completeTag)
 }
 
-// UnderlyingType tells the go type or the aliased go type
+// UnderlyingType tells the go type or the aliased go type.
 func (g GenSchema) UnderlyingType() string {
 	if g.IsAliased {
 		return g.AliasedType
@@ -200,7 +202,7 @@ func (g GenSchema) UnderlyingType() string {
 	return g.GoType
 }
 
-// ToString returns a string conversion expression for the schema
+// ToString returns a string conversion expression for the schema.
 func (g GenSchema) ToString() string {
 	return g.resolvedType.ToString(g.ValueExpression)
 }
@@ -242,7 +244,7 @@ type sharedValidations struct {
 	// NOTE: "patternProperties" and "dependencies" not supported by Swagger 2.0
 }
 
-// GenResponse represents a response object for code generation
+// GenResponse represents a response object for code generation.
 type GenResponse struct {
 	Package       string
 	ModelsPackage string
@@ -270,20 +272,20 @@ type GenResponse struct {
 	ReturnErrors     bool
 }
 
-// GenResponseExamples is a sortable collection []GenResponseExample
+// GenResponseExamples is a sortable collection []GenResponseExample.
 type GenResponseExamples []GenResponseExample
 
 func (g GenResponseExamples) Len() int           { return len(g) }
 func (g GenResponseExamples) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 func (g GenResponseExamples) Less(i, j int) bool { return g[i].MediaType < g[j].MediaType }
 
-// GenResponseExample captures an example provided for a response for some mime type
+// GenResponseExample captures an example provided for a response for some mime type.
 type GenResponseExample struct {
 	MediaType string
 	Example   any
 }
 
-// GenHeader represents a header on a response for code generation
+// GenHeader represents a header on a response for code generation.
 type GenHeader struct {
 	resolvedType
 	sharedValidations
@@ -320,19 +322,19 @@ func (h *GenHeader) ItemsDepth() string {
 	return ""
 }
 
-// ToString returns a string conversion expression for the header
+// ToString returns a string conversion expression for the header.
 func (h GenHeader) ToString() string {
 	return h.resolvedType.ToString(h.ValueExpression)
 }
 
-// GenHeaders is a sorted collection of headers for codegen
+// GenHeaders is a sorted collection of headers for codegen.
 type GenHeaders []GenHeader
 
 func (g GenHeaders) Len() int           { return len(g) }
 func (g GenHeaders) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 func (g GenHeaders) Less(i, j int) bool { return g[i].Name < g[j].Name }
 
-// HasSomeDefaults returns true is at least one header has a default value set
+// HasSomeDefaults returns true is at least one header has a default value set.
 func (g GenHeaders) HasSomeDefaults() bool {
 	// NOTE: this is currently used by templates to avoid empty constructs
 	for _, header := range g {
@@ -398,32 +400,32 @@ type GenParameter struct {
 	Extensions map[string]any
 }
 
-// IsQueryParam returns true when this parameter is a query param
+// IsQueryParam returns true when this parameter is a query param.
 func (g *GenParameter) IsQueryParam() bool {
 	return g.Location == "query"
 }
 
-// IsPathParam returns true when this parameter is a path param
+// IsPathParam returns true when this parameter is a path param.
 func (g *GenParameter) IsPathParam() bool {
 	return g.Location == "path"
 }
 
-// IsFormParam returns true when this parameter is a form param
+// IsFormParam returns true when this parameter is a form param.
 func (g *GenParameter) IsFormParam() bool {
 	return g.Location == "formData"
 }
 
-// IsHeaderParam returns true when this parameter is a header param
+// IsHeaderParam returns true when this parameter is a header param.
 func (g *GenParameter) IsHeaderParam() bool {
 	return g.Location == "header"
 }
 
-// IsBodyParam returns true when this parameter is a body param
+// IsBodyParam returns true when this parameter is a body param.
 func (g *GenParameter) IsBodyParam() bool {
 	return g.Location == "body"
 }
 
-// IsFileParam returns true when this parameter is a file param
+// IsFileParam returns true when this parameter is a file param.
 func (g *GenParameter) IsFileParam() bool {
 	return g.SwaggerType == "file"
 }
@@ -435,24 +437,24 @@ func (g *GenParameter) ItemsDepth() string {
 	return ""
 }
 
-// UnderlyingType tells the go type or the aliased go type
+// UnderlyingType tells the go type or the aliased go type.
 func (g GenParameter) UnderlyingType() string {
 	return g.GoType
 }
 
-// ToString returns a string conversion expression for the parameter
+// ToString returns a string conversion expression for the parameter.
 func (g GenParameter) ToString() string {
 	return g.resolvedType.ToString(g.ValueExpression)
 }
 
-// GenParameters represents a sorted parameter collection
+// GenParameters represents a sorted parameter collection.
 type GenParameters []GenParameter
 
 func (g GenParameters) Len() int           { return len(g) }
 func (g GenParameters) Less(i, j int) bool { return g[i].Name < g[j].Name }
 func (g GenParameters) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 
-// HasSomeDefaults returns true is at least one parameter has a default value set
+// HasSomeDefaults returns true is at least one parameter has a default value set.
 func (g GenParameters) HasSomeDefaults() bool {
 	// NOTE: this is currently used by templates to avoid empty constructs
 	for _, param := range g {
@@ -463,7 +465,7 @@ func (g GenParameters) HasSomeDefaults() bool {
 	return false
 }
 
-// GenItems represents the collection items for a collection parameter
+// GenItems represents the collection items for a collection parameter.
 type GenItems struct {
 	sharedValidations
 	resolvedType
@@ -499,19 +501,20 @@ func (g *GenItems) ItemsDepth() string {
 	return strings.Repeat("items.", i)
 }
 
-// UnderlyingType tells the go type or the aliased go type
+// UnderlyingType tells the go type or the aliased go type.
 func (g GenItems) UnderlyingType() string {
 	return g.GoType
 }
 
-// ToString returns a string conversion expression for the item
+// ToString returns a string conversion expression for the item.
 func (g GenItems) ToString() string {
 	return g.resolvedType.ToString(g.ValueExpression)
 }
 
-// GenOperationGroup represents a named (tagged) group of operations
+// GenOperationGroup represents a named (tagged) group of operations.
 type GenOperationGroup struct {
 	GenCommon
+
 	Name       string
 	Operations GenOperations
 
@@ -526,14 +529,14 @@ type GenOperationGroup struct {
 	ClientOptions *GenClientOptions
 }
 
-// GenOperationGroups is a sorted collection of operation groups
+// GenOperationGroups is a sorted collection of operation groups.
 type GenOperationGroups []GenOperationGroup
 
 func (g GenOperationGroups) Len() int           { return len(g) }
 func (g GenOperationGroups) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 func (g GenOperationGroups) Less(i, j int) bool { return g[i].Name < g[j].Name }
 
-// GenStatusCodeResponses a container for status code responses
+// GenStatusCodeResponses a container for status code responses.
 type GenStatusCodeResponses []GenResponse
 
 func (g GenStatusCodeResponses) Len() int           { return len(g) }
@@ -569,7 +572,7 @@ func (g GenStatusCodeResponses) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// UnmarshalJSON unmarshals this GenStatusCodeResponses from json
+// UnmarshalJSON unmarshals this GenStatusCodeResponses from json.
 func (g *GenStatusCodeResponses) UnmarshalJSON(data []byte) error {
 	var dd map[string]GenResponse
 	if err := json.Unmarshal(data, &dd); err != nil {
@@ -584,9 +587,10 @@ func (g *GenStatusCodeResponses) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// GenOperation represents an operation for code generation
+// GenOperation represents an operation for code generation.
 type GenOperation struct {
 	GenCommon
+
 	Package      string
 	ReceiverName string
 	Name         string
@@ -648,7 +652,7 @@ type GenOperation struct {
 }
 
 // GenOperations represents a list of operations to generate
-// this implements a sort by operation id
+// this implements a sort by operation id.
 type GenOperations []GenOperation
 
 func (g GenOperations) Len() int           { return len(g) }
@@ -656,9 +660,10 @@ func (g GenOperations) Less(i, j int) bool { return g[i].Name < g[j].Name }
 func (g GenOperations) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 
 // GenApp represents all the meta data needed to generate an application
-// from a swagger spec
+// from a swagger spec.
 type GenApp struct {
 	GenCommon
+
 	APIPackage                 string
 	ServerPackageAlias         string
 	ImplementationPackageAlias string
@@ -698,7 +703,7 @@ type GenApp struct {
 	GenOpts         *GenOpts
 }
 
-// UseGoStructFlags returns true when no strategy is specified or it is set to "go-flags"
+// UseGoStructFlags returns true when no strategy is specified or it is set to "go-flags".
 func (g *GenApp) UseGoStructFlags() bool {
 	if g.GenOpts == nil {
 		return true
@@ -706,12 +711,12 @@ func (g *GenApp) UseGoStructFlags() bool {
 	return g.GenOpts.FlagStrategy == "" || g.GenOpts.FlagStrategy == "go-flags"
 }
 
-// UsePFlags returns true when the flag strategy is set to pflag
+// UsePFlags returns true when the flag strategy is set to pflag.
 func (g *GenApp) UsePFlags() bool {
 	return g.GenOpts != nil && strings.HasPrefix(g.GenOpts.FlagStrategy, "pflag")
 }
 
-// UseFlags returns true when the flag strategy is set to flag
+// UseFlags returns true when the flag strategy is set to flag.
 func (g *GenApp) UseFlags() bool {
 	return g.GenOpts != nil && strings.HasPrefix(g.GenOpts.FlagStrategy, "flag")
 }
@@ -726,7 +731,7 @@ func (g *GenApp) UseModernMode() bool {
 	return g.GenOpts == nil || g.GenOpts.CompatibilityMode == "" || g.GenOpts.CompatibilityMode == "modern"
 }
 
-// GenSerGroups sorted representation of serializer groups
+// GenSerGroups sorted representation of serializer groups.
 type GenSerGroups []GenSerGroup
 
 func (g GenSerGroups) Len() int           { return len(g) }
@@ -752,14 +757,14 @@ type GenSerGroup struct {
 	AllSerializers GenSerializers
 }
 
-// GenSerializers sorted representation of serializers
+// GenSerializers sorted representation of serializers.
 type GenSerializers []GenSerializer
 
 func (g GenSerializers) Len() int           { return len(g) }
 func (g GenSerializers) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 func (g GenSerializers) Less(i, j int) bool { return g[i].MediaType < g[j].MediaType }
 
-// GenSerializer represents a single serializer for a particular media type
+// GenSerializer represents a single serializer for a particular media type.
 type GenSerializer struct {
 	AppName        string // Application name
 	ReceiverName   string
@@ -769,7 +774,7 @@ type GenSerializer struct {
 	Parameters     []string // parameters supported by this serializer
 }
 
-// GenSecurityScheme represents a security scheme for code generation
+// GenSecurityScheme represents a security scheme for code generation.
 type GenSecurityScheme struct {
 	AppName             string
 	ID                  string
@@ -794,20 +799,20 @@ type GenSecurityScheme struct {
 	ScopesDesc       []GenSecurityScope
 }
 
-// GenSecuritySchemes sorted representation of serializers
+// GenSecuritySchemes sorted representation of serializers.
 type GenSecuritySchemes []GenSecurityScheme
 
 func (g GenSecuritySchemes) Len() int           { return len(g) }
 func (g GenSecuritySchemes) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
 func (g GenSecuritySchemes) Less(i, j int) bool { return g[i].ID < g[j].ID }
 
-// GenSecurityRequirement represents a security requirement for an operation
+// GenSecurityRequirement represents a security requirement for an operation.
 type GenSecurityRequirement struct {
 	Name   string
 	Scopes []string
 }
 
-// GenSecurityScope represents a scope descriptor for an OAuth2 security scheme
+// GenSecurityScope represents a scope descriptor for an OAuth2 security scheme.
 type GenSecurityScope struct {
 	Name        string
 	Description string

--- a/generator/support.go
+++ b/generator/support.go
@@ -31,7 +31,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// GenerateServer generates a server application
+// GenerateServer generates a server application.
 func GenerateServer(name string, modelNames, operationIDs []string, opts *GenOpts) error {
 	generator, err := newAppGenerator(name, modelNames, operationIDs, opts)
 	if err != nil {
@@ -40,7 +40,7 @@ func GenerateServer(name string, modelNames, operationIDs []string, opts *GenOpt
 	return generator.Generate()
 }
 
-// GenerateSupport generates the supporting files for an API
+// GenerateSupport generates the supporting files for an API.
 func GenerateSupport(name string, modelNames, operationIDs []string, opts *GenOpts) error {
 	generator, err := newAppGenerator(name, modelNames, operationIDs, opts)
 	if err != nil {
@@ -49,7 +49,7 @@ func GenerateSupport(name string, modelNames, operationIDs []string, opts *GenOp
 	return generator.GenerateSupport(nil)
 }
 
-// GenerateMarkdown documentation for a swagger specification
+// GenerateMarkdown documentation for a swagger specification.
 func GenerateMarkdown(output string, modelNames, operationIDs []string, opts *GenOpts) error {
 	if output == "." || output == "" {
 		output = "markdown.md"
@@ -492,8 +492,14 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 		basePath = sw.BasePath
 	}
 
-	jsonb, _ := json.MarshalIndent(a.SpecDoc.OrigSpec(), "", "  ")
-	flatjsonb, _ := json.MarshalIndent(a.SpecDoc.Spec(), "", "  ")
+	jsonb, err := json.MarshalIndent(a.SpecDoc.OrigSpec(), "", "  ")
+	if err != nil {
+		return GenApp{}, err
+	}
+	flatjsonb, err := json.MarshalIndent(a.SpecDoc.Spec(), "", "  ")
+	if err != nil {
+		return GenApp{}, err
+	}
 
 	return GenApp{
 		GenCommon: GenCommon{

--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -30,7 +30,7 @@ var (
 	assets             map[string][]byte
 	protectedTemplates map[string]bool
 
-	// FuncMapFunc yields a map with all functions for templates
+	// FuncMapFunc yields a map with all functions for templates.
 	FuncMapFunc func(*LanguageOpts) template.FuncMap
 
 	templates *Repository
@@ -58,7 +58,7 @@ func initTemplateRepo() {
 }
 
 // DefaultFuncMap yields a map with default functions for use in the templates.
-// These are available in every template
+// These are available in every template.
 func DefaultFuncMap(lang *LanguageOpts) template.FuncMap {
 	f := sprig.TxtFuncMap()
 	extra := template.FuncMap{
@@ -335,12 +335,12 @@ func defaultProtectedTemplates() map[string]bool {
 // directory separators and Camelcase the next letter.
 // e.g validation/primitive.gotmpl will become validationPrimitive
 //
-// If the file contains a definition for a template that is protected the whole file will not be added
+// If the file contains a definition for a template that is protected the whole file will not be added.
 func AddFile(name, data string) error {
 	return templates.addFile(name, data, false)
 }
 
-// NewRepository creates a new template repository with the provided functions defined
+// NewRepository creates a new template repository with the provided functions defined.
 func NewRepository(funcs template.FuncMap) *Repository {
 	repo := Repository{
 		files:     make(map[string]string),
@@ -355,7 +355,7 @@ func NewRepository(funcs template.FuncMap) *Repository {
 	return &repo
 }
 
-// Repository is the repository for the generator templates
+// Repository is the repository for the generator templates.
 type Repository struct {
 	files         map[string]string
 	templates     map[string]*template.Template
@@ -388,7 +388,7 @@ func (t *Repository) ShallowClone() *Repository {
 	return clone
 }
 
-// LoadDefaults will load the embedded templates
+// LoadDefaults will load the embedded templates.
 func (t *Repository) LoadDefaults() {
 	for name, asset := range assets {
 		if err := t.addFile(name, string(asset), true); err != nil {
@@ -397,7 +397,7 @@ func (t *Repository) LoadDefaults() {
 	}
 }
 
-// LoadDir will walk the specified path and add each .gotmpl file it finds to the repository
+// LoadDir will walk the specified path and add each .gotmpl file it finds to the repository.
 func (t *Repository) LoadDir(templatePath string) error {
 	err := filepath.Walk(templatePath, func(path string, _ os.FileInfo, err error) error {
 		if strings.HasSuffix(path, ".gotmpl") {
@@ -424,7 +424,7 @@ func (t *Repository) LoadDir(templatePath string) error {
 	return nil
 }
 
-// LoadContrib loads template from contrib directory
+// LoadContrib loads template from contrib directory.
 func (t *Repository) LoadContrib(name string) error {
 	log.Printf("loading contrib %s", name)
 	const pathPrefix = "templates/contrib/"
@@ -470,7 +470,6 @@ func (t *Repository) addFile(name, data string, allowOverride bool) error {
 
 	// Add each defined template into the cache
 	for _, template := range templ.Templates() {
-
 		t.files[template.Name()] = fileName
 		t.templates[template.Name()] = template.Lookup(template.Name())
 	}
@@ -478,7 +477,7 @@ func (t *Repository) addFile(name, data string, allowOverride bool) error {
 	return nil
 }
 
-// MustGet a template by name, panics when fails
+// MustGet a template by name, panics when fails.
 func (t *Repository) MustGet(name string) *template.Template {
 	tpl, err := t.Get(name)
 	if err != nil {
@@ -492,12 +491,12 @@ func (t *Repository) MustGet(name string) *template.Template {
 // directory separators and Camelcase the next letter.
 // e.g validation/primitive.gotmpl will become validationPrimitive
 //
-// If the file contains a definition for a template that is protected the whole file will not be added
+// If the file contains a definition for a template that is protected the whole file will not be added.
 func (t *Repository) AddFile(name, data string) error {
 	return t.addFile(name, data, false)
 }
 
-// SetAllowOverride allows setting allowOverride after the Repository was initialized
+// SetAllowOverride allows setting allowOverride after the Repository was initialized.
 func (t *Repository) SetAllowOverride(value bool) {
 	t.allowOverride = value
 }
@@ -563,7 +562,6 @@ func (t *Repository) flattenDependencies(templ *template.Template, dependencies 
 
 	for _, d := range deps {
 		if _, found := dependencies[d]; !found {
-
 			dependencies[d] = true
 
 			if tt := t.templates[d]; tt != nil {
@@ -572,7 +570,6 @@ func (t *Repository) flattenDependencies(templ *template.Template, dependencies 
 		}
 
 		dependencies[d] = true
-
 	}
 
 	return dependencies
@@ -584,7 +581,6 @@ func (t *Repository) addDependencies(templ *template.Template) (*template.Templa
 	deps := t.flattenDependencies(templ, nil)
 
 	for dep := range deps {
-
 		if dep == "" {
 			continue
 		}
@@ -606,7 +602,6 @@ func (t *Repository) addDependencies(templ *template.Template) (*template.Templa
 			if err != nil {
 				return templ, fmt.Errorf("dependency error: %w", err)
 			}
-
 		}
 	}
 	return templ.Lookup(name), nil
@@ -672,7 +667,7 @@ func dropPackage(str string) string {
 	return parts[len(parts)-1]
 }
 
-// return true if the GoType str contains pkg. For example "model.MyType" -> true, "MyType" -> false
+// return true if the GoType str contains pkg. For example "model.MyType" -> true, "MyType" -> false.
 func containsPkgStr(str string) bool {
 	dropped := dropPackage(str)
 	return dropped != str
@@ -681,13 +676,13 @@ func containsPkgStr(str string) bool {
 func padSurround(entry, padWith string, i, ln int) string {
 	var res []string
 	if i > 0 {
-		for j := 0; j < i; j++ {
+		for range i {
 			res = append(res, padWith)
 		}
 	}
 	res = append(res, entry)
 	tot := ln - i - 1
-	for j := 0; j < tot; j++ {
+	for range tot {
 		res = append(res, padWith)
 	}
 	return strings.Join(res, ",")

--- a/generator/template_repo_test.go
+++ b/generator/template_repo_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	// Test template environment
+	// Test template environment.
 	singleTemplate        = `test`
 	multipleDefinitions   = `{{ define "T1" }}T1{{end}}{{ define "T2" }}T2{{end}}`
 	dependantTemplate     = `{{ template "T1" }}D1`
@@ -244,7 +244,7 @@ func TestTemplates_RepoRecursiveTemplates(t *testing.T) {
 // Test that definitions are available to templates
 // TODO: should test also with the codeGenApp context
 
-// Test copyright definition
+// Test copyright definition.
 func TestTemplates_DefinitionCopyright(t *testing.T) {
 	defer discardOutput()()
 
@@ -286,7 +286,7 @@ func TestTemplates_DefinitionCopyright(t *testing.T) {
 	assert.Equal(t, expected, rendered.String())
 }
 
-// Test TargetImportPath definition
+// Test TargetImportPath definition.
 func TestTemplates_DefinitionTargetImportPath(t *testing.T) {
 	const targetImportPath = `{{ .TargetImportPath }}`
 	defer discardOutput()()
@@ -329,7 +329,7 @@ func TestTemplates_DefinitionTargetImportPath(t *testing.T) {
 	assert.Equal(t, expected, rendered.String())
 }
 
-// Simulates a definition environment for model templates
+// Simulates a definition environment for model templates.
 func getModelEnvironment(_ string, opts *GenOpts) (*GenDefinition, error) {
 	defer discardOutput()()
 
@@ -350,7 +350,7 @@ func getModelEnvironment(_ string, opts *GenOpts) (*GenDefinition, error) {
 	return nil, nil
 }
 
-// Simulates a definition environment for operation templates
+// Simulates a definition environment for operation templates.
 func getOperationEnvironment(operation string, path string, spec string, opts *GenOpts) (*GenOperation, error) {
 	defer discardOutput()()
 
@@ -444,7 +444,7 @@ func TestTemplates_AddFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot overwrite protected template")
 }
 
-// Test LoadDir
+// Test LoadDir.
 func TestTemplates_LoadDir(t *testing.T) {
 	defer discardOutput()()
 
@@ -474,7 +474,7 @@ func TestTemplates_LoadDir(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Test LoadDir
+// Test LoadDir.
 func TestTemplates_SetAllowOverride(t *testing.T) {
 	defer discardOutput()()
 
@@ -490,7 +490,7 @@ func TestTemplates_SetAllowOverride(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Test LoadContrib
+// Test LoadContrib.
 func TestTemplates_LoadContrib(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -522,7 +522,7 @@ func TestTemplates_LoadContrib(t *testing.T) {
 }
 
 // TODO: test error case in LoadDefaults()
-// test DumpTemplates()
+// test DumpTemplates().
 func TestTemplates_DumpTemplates(t *testing.T) {
 	var buf bytes.Buffer
 	defer captureOutput(&buf)()

--- a/generator/types.go
+++ b/generator/types.go
@@ -43,7 +43,7 @@ const (
 	b64     = "byte"
 )
 
-// Extensions supported by go-swagger
+// Extensions supported by go-swagger.
 const (
 	xClass        = "x-class"         // class name used by discriminator
 	xGoCustomTag  = "x-go-custom-tag" // additional tag for serializers on struct fields
@@ -60,7 +60,7 @@ const (
 	xGoOperationTag = "x-go-operation-tag" // additional tag to override generation in operation groups
 )
 
-// swaggerTypeName contains a mapping from go type to swagger type or format
+// swaggerTypeName contains a mapping from go type to swagger type or format.
 var swaggerTypeName map[string]string
 
 func initTypes() {
@@ -142,7 +142,7 @@ func newTypeResolver(pkg, _ string, doc *loads.Document) *typeResolver {
 	return &resolver
 }
 
-// knownDefGoType returns go type, package and package alias for definition
+// knownDefGoType returns go type, package and package alias for definition.
 func (t typeResolver) knownDefGoType(def string, schema spec.Schema, clearFunc func(string) string) (string, string, string) {
 	debugLog("known def type: %q", def)
 	ext := schema.Extensions
@@ -259,7 +259,7 @@ type typeResolver struct {
 	definitionPkg      string // pkg alias to fill in GenSchema.Pkg
 }
 
-// NewWithModelName clones a type resolver and specifies a new model name
+// NewWithModelName clones a type resolver and specifies a new model name.
 func (t *typeResolver) NewWithModelName(name string) *typeResolver {
 	tt := newTypeResolver(t.ModelsPackage, t.ModelsFullPkg, t.Doc)
 	tt.ModelName = name
@@ -285,7 +285,7 @@ func (t *typeResolver) withKeepDefinitionsPackage(definitionsPackage string) *ty
 // withDefinitionPackage sets the definition pkg that object/struct types to be generated
 // in GenSchema.Pkg field.
 // ModelsPackage field can not replace definitionPkg since ModelsPackage will be prepend to .GoType,
-// while definitionPkg is just used to fill the .Pkg in GenSchema
+// while definitionPkg is just used to fill the .Pkg in GenSchema.
 func (t *typeResolver) withDefinitionPackage(pkg string) *typeResolver {
 	t.definitionPkg = pkg
 	return t
@@ -409,7 +409,7 @@ func (t *typeResolver) isNullable(schema *spec.Schema) bool {
 	return len(schema.Properties) > 0 || len(schema.AllOf) > 0
 }
 
-// isNullableOverride determines a nullable flag forced by an extension
+// isNullableOverride determines a nullable flag forced by an extension.
 func (t *typeResolver) isNullableOverride(schema *spec.Schema) (bool, bool) {
 	check := func(extension string) (bool, bool) {
 		v, found := schema.Extensions[extension]
@@ -670,7 +670,7 @@ func (t *typeResolver) resolveObject(schema *spec.Schema, isAnonymous bool) (res
 // - a x-nullable extension says so in the spec
 // - it is **not** a read-only property
 // - it is a required property
-// - it has a default value
+// - it has a default value.
 func nullableBool(schema *spec.Schema, isRequired bool) bool {
 	if nullable := nullableExtension(schema.Extensions); nullable != nil {
 		return *nullable
@@ -712,7 +712,7 @@ func nullableNumber(schema *spec.Schema, isRequired bool) bool {
 // - it is **not** a read-only property
 // - it is a required property
 // - it has a MinLength property set to 0
-// - it has a default other than "" (the zero for strings) and no MinLength or zero MinLength
+// - it has a default other than "" (the zero for strings) and no MinLength or zero MinLength.
 func nullableString(schema *spec.Schema, isRequired bool) bool {
 	if nullable := nullableExtension(schema.Extensions); nullable != nil {
 		return *nullable
@@ -1071,7 +1071,7 @@ func guardFormatConflicts(format string, schema interface {
 }
 
 // resolvedType is a swagger type that has been resolved and analyzed for usage
-// in a template
+// in a template.
 type resolvedType struct {
 	IsAnonymous       bool
 	IsArray           bool
@@ -1126,7 +1126,7 @@ type resolvedType struct {
 	SkipExternalValidation bool
 }
 
-// Zero returns an initializer for the type
+// Zero returns an initializer for the type.
 func (rt resolvedType) Zero() string {
 	// if type is aliased, provide zero from the aliased type
 	if rt.IsAliased {
@@ -1159,7 +1159,7 @@ func (rt resolvedType) Zero() string {
 	return ""
 }
 
-// ToString returns a string conversion for a type akin to a string
+// ToString returns a string conversion for a type akin to a string.
 func (rt resolvedType) ToString(value string) string {
 	if !rt.IsPrimitive || rt.SwaggerType != "string" || rt.IsStream {
 		return ""
@@ -1168,7 +1168,7 @@ func (rt resolvedType) ToString(value string) string {
 		if rt.IsAliased {
 			return fmt.Sprintf("%s(%s).String()", rt.AliasedType, value)
 		}
-		return fmt.Sprintf("%s.String()", value)
+		return value + ".String()"
 	}
 	var deref string
 	if rt.IsNullable {


### PR DESCRIPTION
This PR modernizes our linter's configuration, with more linters enabled
or configured.

It fixes all issues from the current master, and _most_ issues on the
rest of the code.

Reinstated full CI on windows
================================

* removed existing CI exceptions on Windows for some (older) go
  versions. Now CI runs on the full matrix (stable, oldstable) x (linux,
  macos, windows)

Generalize the use of testing.TempDir()
================================

All tests producing files (e.g. most codegen tests) are now adopting
testing.TempDir() to produce their output. No other local files are
now produced when running tests.

Downside: we no longer have the capability to debug codegen while
testing.

All code generated by tests is now checking builds in module mode,
with a go mod outside the main go source tree.

On windows os, TempDir must not be located on a different drive than the
project (this happens on CI by default), as go-swagger still relies a
lot on filepath.Rel for some stuff.

NOTE: exception in package "generator", we have kept the ability to
inspect generated code during testing (hence not using
testing.TempDir()). Will change this later on.

Summary of changes by package
================================

* cmd
   * various nits (auto-fix by linter)
     * reordered tags
     * godoc comments are sentences ending with a dot
   * preallocated slices which capacity may be determined in advance
   * use of testing.TempDir(). See above.
   * tests: other non pure linting refactoring
     * all codegen testing is now performed in module mode, with a module
       outside the go source tree
     * refactored CLI test cases
     * introduced common function to run go mod commands
     * explicited the intent of (some) tests with named subtests
     * refactored operation test
     * removed useless nolint directives, commented the ones remaining
   * diff tests:
     * added t.Parallel()
     * added t.Helper()

* codescan
   * various nits (auto-fix by linter)
   * preallocated slices which capacity may be determined in advance
   * modernized ranges over integers
   * used testing.Setenv

* generator
   * fixed bug: leaked open file go.mod
   * various nits (auto-fix by linter)
   * use of testing.TempDir(). See above.
   * unhandled unmarshall error now panic (would uncover bugs rather
     than propagating them)
   * simplified unecessary calls fmt.Sprintf

Known outstanding linting issues
================================

Remain unaddressed at this moment:

cmd:

31 issues:
* forcetypeassert: 2
* funcorder: 20
* gocritic: 1
* inamedparam: 3
* mnd: 1
* nilnil: 2
* thelper: 2

codescan:
136 issues:
* forbidigo: 4
* forcetypeassert: 18
* funcorder: 3
* gocognit: 23
* goconst: 20
* gocyclo: 1
* goprintffuncname: 1
* inamedparam: 18
* interfacebloat: 1
* intrange: 2
* maintidx: 2
* mnd: 9
* nilerr: 2
* prealloc: 2
* thelper: 30

generator:

240 issues:
* dupword: 27
* forbidigo: 5
* forcetypeassert: 4
* funcorder: 28
* gocognit: 22
* goconst: 20
* inamedparam: 3
* maintidx: 14
* mnd: 23
* musttag: 2
* nilerr: 2
* nilnil: 1
* prealloc: 4
* thelper: 64
* usetesting: 21

The above will be fixed in several follow-up PRs.

Caveat:
* reverted unwanted auto-fix in string literals (buggy auto-fix from linter)

Signed-off-by: Frederic BIDON <[fredbi](https://github.com/go-swagger/go-swagger/commits?author=fredbi)@yahoo.com>

·