### PR TITLE
try to speed up windows test on go1.25

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -106,9 +106,12 @@ jobs:
           echo "TMP=${TMP}" >> "${GITHUB_ENV}"
 
       - name: Run unit tests with code coverage
+        # disable test cache (windows): https://github.com/golang/go/issues/72992
+        shell: bash
         run: >
           gotestsum --
-          -p 1
+          -p 2
+          -count 1
           -timeout=20m
           -coverprofile='coverage-${{ matrix.os }}-${{ matrix.go }}.txt'
           -covermode=atomic

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -108,9 +108,11 @@ jobs:
           echo "TMP=${TMP}" >> "${GITHUB_ENV}"
 
       - name: Run unit tests with code coverage
+        shell: bash
         run: >
           gotestsum --
-          -p 1
+          -p 2
+          -count 1
           -timeout=20m
           -coverprofile='coverage-${{ matrix.os }}-${{ matrix.go }}.txt'
           -covermode=atomic


### PR DESCRIPTION
Hit go issue https://github.com/golang/go/issues/72992

Applied workaround by disabling cache on tests. Seems to work fine.