### PR TITLE
generate 644 instead of 755 files

### DIFF
--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -110,6 +110,8 @@ func loadSpec(input string) (*spec.Swagger, error) {
 
 var defaultWriter io.Writer = os.Stdout
 
+const generatedFileMode os.FileMode = 0o644
+
 func writeToFile(swspec *spec.Swagger, pretty bool, format string, output string) error {
 	var b []byte
 	var err error
@@ -129,7 +131,7 @@ func writeToFile(swspec *spec.Swagger, pretty bool, format string, output string
 		_, e := fmt.Fprintf(defaultWriter, "%s\n", b)
 		return e
 	default:
-		return os.WriteFile(output, b, 0o644) //#nosec
+		return os.WriteFile(output, b, generatedFileMode) //#nosec
 	}
 
 	// #nosec


### PR DESCRIPTION
In #3240 the function `writeToFile` in `cmd/swagger/commands/generate/spec.go` was changed from
```diff
-		return os.WriteFile(output, b, 0o644) //#nosec
+		return os.WriteFile(output, b, fs.ModePerm) //#nosec
```

This produces files with 755 / `rwxr-xr-x` permissions where before it was 644 / `rw-r--r--`.

Assuming this change was unintentional, this reverts the behavior to remove the executable bits being set.