### PR TITLE
ci: conditional CI runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .git
+.github
 fixtures
 examples
+hack
+notes
+docs

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -2,11 +2,14 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   dependabot:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,261 @@
+name: build-docker
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: |
+          Whether the calling workflow wants to login and push to image registries
+          (implies secrets are accessible).
+        type: boolean
+        required: false
+        default: false
+      tagged:
+        description: |
+          Whether the calling workflow wants to use git tags for tagging images
+        type: boolean
+        required: false
+        default: false
+      tag_sha:
+        description: |
+          Whether the calling workflow wants to use commit sha for tagging images
+        type: boolean
+        required: false
+        default: false
+      latest:
+        description: |
+          Whether the calling workflow wants to tag the image as "latest"
+        type: boolean
+        required: false
+        default: false
+      pr:
+        description: |
+          Whether the calling workflow wants to comment on PR (requires pull_request: write)
+        type: boolean
+        required: false
+        default: false
+      record_retention:
+        description: |
+          How many days does the calling the workflow want to keep the build record artifact?
+        type: number
+        required: false
+        default: 1
+    secrets:
+      CR_PAT:
+        description: token to push to ghcr.io registry
+        required: false
+      QUAY_USERNAME:
+        description: user to push to quay.io registry
+        required: false
+      QUAY_PASS:
+        description: user to push to quay.io registry
+        required: false
+      # GITHUB_TOKEN is implied
+
+jobs:
+  build-docker:
+    name: Docker latest master (dev)
+    runs-on: ubuntu-latest
+    env:
+      SUPPORTED_PLATFORMS: 'linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x'
+      DOCKER_CACHE: '../.docker-cache' # <- out of docker build context
+      DOCKER_DEST: '../.docker-dst/go-swagger-${{ github.sha}}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # will be empty on push to master and default to head from master
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Lint Dockerfiles
+        # NOTE: linting does not account for diff in Dockerfiles. The full Dockerfile is linted and reported.
+        uses: jbergstroem/hadolint-gh-action@2b00b87f8a56783930b6a4749837d7c45c567ff2
+        with:
+          # Dockerfile is the main builder. Other dockerfiles are for dev usage and also subject to linting
+          dockerfile: 'Dockerfile*'
+          error_level: 0 # errors in Dockerfiles are showstoppers
+          annotate: true
+
+      - name: Layout working area
+        # The working area is used:
+        # * to cache layers from the first (pre-scan) build
+        # * to save an image fs locally for a complete scan (docker format doesn't support SBOM and attestations)
+        run: |
+          mkdir -p "${DOCKER_CACHE}"
+          mkdir -p "${DOCKER_DEST}"
+
+      - name: Meta usage
+        id: meta-usage
+        run: |
+          # Determine the docker tagging rules that will be used by docker/metadata-action.
+          #
+          # Example for tagged releases: v0.33, v0.331. We don't tag a v0
+          # Example for dev images: master, edge
+          echo "tags<<EOF" >> "$GITHUB_OUTPUT"
+          BUILD_TAG="dev"
+
+          if [[ "${{ inputs.tagged }}" == "true" ]] ; then
+            # tagging rules for git tag
+            echo "type=ref,event=tag" >> "$GITHUB_OUTPUT"
+            echo "type=semver,pattern={{version}}" >> "$GITHUB_OUTPUT"
+            echo "type=semver,pattern={{major}}.{{minor}}" >> "$GITHUB_OUTPUT"
+            # disabled if major zero
+            echo "type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}" >> "$GITHUB_OUTPUT"
+            BUILD_TAG="${{ github.ref_name }}"
+          else
+            # tagging rules for git branch
+            echo "type=ref,event=branch" >> "$GITHUB_OUTPUT"
+            echo "type=edge" >> "$GITHUB_OUTPUT"
+            echo "type=sha" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "${{ inputs.tag_sha }}" == "true" ]] ; then
+            # tagging rules for commit sha
+            echo "type=sha" >> "$GITHUB_OUTPUT"
+          fi
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          echo "build_tag=${BUILD_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f  # v5.8.0
+        with:
+          images: |
+            quay.io/goswagger/swagger
+            ghcr.io/go-swagger/go-swagger
+          flavor: |
+            latest=${{ inputs.latest }}
+          tags: ${{ steps.meta-usage.outputs.tags }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v 3.6.0
+        with:
+          platforms: ${{ env.SUPPORTED_PLATFORMS }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
+
+      - name: Build to scan
+        id: scan-build
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
+        with:
+          context: .
+          file: Dockerfile
+          cache-to: type=local,dest=${{ env.DOCKER_CACHE }}  # layers from this build may be reused by the next build
+          build-args: |
+            commit_hash=${{ github.sha }}
+            tag_name=${{ steps.meta-usage.outputs.build_tag }}
+          # use OCI format to keep all metadata and help the scanner. Disable tar because trivy doesn't catch OCI tarballs.
+          outputs: type=oci,platform-split=false,tar=false,dest=${{ env.DOCKER_DEST}}
+          push: false
+          tags: go-swagger/go-swagger:sha-${{ github.sha }}  # this is not pushed
+          sbom: true
+          provenance: mode=max
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Scan image for vulnerabilities
+        # scan the fully annotated image
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        with:
+          scan-type: image
+          scanners: vuln
+          input: ${{ env.DOCKER_DEST }}
+          format: sarif
+          hide-progress: false
+          output: /tmp/trivy-image-report.sarif
+          exit-code: 0
+
+      - name: Upload vulnerability report artifacts
+        # another job, with elevated permissions, will upload this to GHAS
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          path: /tmp/trivy-image-report.sarif
+          name: 'trivy-image-report'
+          retention-days: 1
+
+      - name: Produce trivy human-readable report
+        # halts on critical vulnerabilities
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        with:
+          scan-type: image
+          scanners: vuln
+          input: ${{ env.DOCKER_DEST }}
+          format: table
+          hide-progress: false
+          skip-setup-trivy: true
+          severity: CRITICAL
+          exit-code: 1
+
+      - name: Login to Quay Registry
+        if: ${{ inputs.push && !inputs.pr }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASS }}
+        continue-on-error: true # TODO: for testing only
+
+      - name: Login to GitHub Container Registry
+        if: ${{ inputs.push && !inputs.pr }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+        continue-on-error: true # TODO: for testing only
+
+      - name: Build and push
+        if: ${{ inputs.push && !inputs.pr }}
+        env:
+          DOCKER_BUILD_SUMMARY: true
+          DOCKER_BUILD_RECORD_UPLOAD: true
+          DOCKER_BUILD_RECORD_RETENTION_DAYS: ${{ inputs.record_retention }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
+        with:
+          context: .
+          file: Dockerfile
+          cache-from: type=local,src=${{ env.DOCKER_CACHE }}
+          build-args: |
+            commit_hash=${{ github.sha }}
+            tag_name=${{ steps.meta-usage.outputs.build_tag }}
+          platforms: ${{ env.SUPPORTED_PLATFORMS }}
+          push: '${{ inputs.push }}'
+          tags: ${{ steps.meta.outputs.tags }}
+          sbom: true
+          provenance: mode=max
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  upload-sarif:
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    needs: [build-docker]
+    if: ${{ !cancelled() && inputs.push && !inputs.pr }}
+    steps:
+      - name: Download vulnerability report artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          run-id: "${{ github.run_id }}"
+          pattern: 'trivy-image-report'
+          path: sarif/
+      - name: Upload trivy result to GHAS
+        if: ${{ inputs.push }}
+        uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sarif_file: sarif/
+          category: trivy-docker
+        continue-on-error: true

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,5 +1,8 @@
 name: "CodeQL"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]
@@ -8,16 +11,13 @@ on:
   schedule:
     - cron: '31 21 * * 4'
 
-permissions:
-  contents: read
-
 jobs:
   analyze:
     name: Analyze.
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:
-      actions: read
+      # actions: read # needed only for private repositories
       contents: read
       security-events: write
 

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,51 @@
+name: docker-dev
+
+permissions:
+  contents: read
+
+on:
+  workflow_run:
+    workflows:
+      - test
+    types:
+      - completed
+    branches:
+      - master
+      - 'prepare-release/*'
+    paths-ignore:
+      - 'docs/*'
+      - 'hack/hugo/*'
+      - .github/workflows/update-doc.yaml
+      - '**/*.md'
+
+jobs:
+  on-success:
+    name: Ensure triggering workflow was successful
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "The triggering workflow was successful"
+
+  on-failure:
+    name: Triggering workflow was unsuccessful
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "The triggering workflow failed. Stopping here"
+
+  docker-dev:
+    permissions:
+      contents: read
+      security-events: write
+    name: Docker latest master (dev)
+    needs: [on-success]
+    uses: ./.github/workflows/build-docker.yaml
+    with:
+      push: true
+      record_retention: 7
+    secrets:
+      CR_PAT: ${{ secrets.CR_PAT }}
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASS: $${{ secrets.QUAY_PASS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,10 @@
 name: Release
 
+permissions:
+  contents: read
+
+# TODO: sign release artifacts
+
 on:
   workflow_run:
     workflows:
@@ -9,71 +14,48 @@ on:
     tags:
       - 'v*'
     branches:
-      - master
       - 'prepare-release/*'
     paths-ignore:
       - 'docs/*'
       - 'hack/hugo/*'
       - .github/workflows/update-doc.yaml
 
-permissions:
-  contents: write
-
 jobs:
-  docker_dev:
-    name: Docker latest master (dev)
-    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')
+  on-success:
+    name: Ensure triggering workflow was successful
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - run: |
+          echo "The triggering workflow was successful"
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f  # v5.8.0
-        with:
-          images: |
-            quay.io/goswagger/swagger
-            ghcr.io/go-swagger/go-swagger
-          tags: |
-            type=ref,event=branch
-            type=sha
+  on-failure:
+    name: Triggering workflow was unsuccessful
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "The triggering workflow failed. Stopping here"
+          exit 1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v 3.6.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
-
-      - name: Login to Quay Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASS }}
-
-      - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
-        with:
-          context: .
-          build-args: |
-            commit_hash=${{ github.sha }}
-            tag_name=dev
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+  docker-release:
+    name: Docker with release tag
+    needs: [on-success]
+    uses: ./.github/workflows/build-docker.yaml
+    with:
+      push: true
+      tagged: true
+      latest: true
+      record_retention: 90
+    secrets:
+      CR_PAT: ${{ secrets.CR_PAT }}
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASS: $${{ secrets.QUAY_PASS }}
 
   publish_release:
+    # TODO: replace by goreleaser
     name: Publish release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [on-success]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -126,6 +108,7 @@ jobs:
           popd || exit 1
 
       - name: Push RPM
+        if: startsWith(github.ref, 'refs/tags/v')
         id: push_rpm
         uses: cloudsmith-io/action@7af394e0f8add4867bce109385962dafecad1b8d # v0.6.14
         with:
@@ -139,6 +122,7 @@ jobs:
           file: "dist/build/swagger-*.x86_64.rpm"
 
       - name: Push Deb
+        if: startsWith(github.ref, 'refs/tags/v')
         id: push
         uses: cloudsmith-io/action@7af394e0f8add4867bce109385962dafecad1b8d # v0.6.14
         with:
@@ -152,63 +136,8 @@ jobs:
           file: "dist/build/swagger_*_amd64.deb"
 
       - name: Publish Binaries
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: fnkr/github-action-ghr@96b1448dc6162f370067e1de51e856e733a76b4f # v1.3
         env:
           GHR_PATH: dist/bin/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  docker:
-    name: Tagged docker images
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f  # v5.8.0
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            quay.io/goswagger/swagger
-            ghcr.io/go-swagger/go-swagger
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v 3.6.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
-
-      - name: Login to Quay Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASS }}
-
-      - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
-        with:
-          context: .
-          build-args: |
-            commit_hash=${{ github.sha }}
-            tag_name=${{ github.ref_name }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/scanner.yaml
+++ b/.github/workflows/scanner.yaml
@@ -1,0 +1,55 @@
+name: Vulnerability scans
+
+permissions: read-all
+
+# description: |
+#   A fast vulnerability scan on the repo that effectively supplements ossf scorecard and codesql
+#   and may run every day.
+#
+# TODO(fredbi): we may supplement this analysis with snyk (to be experimented with) (requires a token).
+
+on:
+  branch_protection_rule:
+  push:
+    branches: [ "master" ]
+  schedule:
+    - cron: '14 3 * * *'
+
+jobs:
+  analysis:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Vulnerability scan by trivy
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        with:
+          scan-type: repo
+          format: sarif
+          hide-progress: false
+          output: trivy-code-report.sarif
+          scanners: vuln,secret
+          exit-code: 0
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload trivy findings to code-scanning"
+        uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+        with:
+          category: trivy
+          sarif_file: trivy-code-report.sarif
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: trivy-code-report.sarif
+          retention-days: 5

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,5 +1,7 @@
 name: Scorecard supply-chain security
 
+permissions: read-all
+
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
@@ -10,8 +12,6 @@ on:
     - cron: '44 2 * * 1'
   push:
     branches: [ "master" ]
-
-permissions: read-all
 
 jobs:
   analysis:
@@ -32,10 +32,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: "Run analysis"
+      - name: "Run OSSF score card analysis"
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
-          results_file: results.sarif
+          results_file: scorecard.sarif
           results_format: sarif
           publish_results: true
 
@@ -45,11 +45,12 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
-          path: results.sarif
+          path: scorecard.sarif
           retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
         with:
-          sarif_file: results.sarif
+          category: ossf-scorecard
+          sarif_file: scorecard.sarif

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,9 @@
 name: Test
 
+permissions:
+  contents: read
+  pull-requests: read
+
 # description: |
 #   Test suite that runs on every commit (on pull requests, on merges to master).
 
@@ -8,9 +12,6 @@ on:
   push:
     branches:
       - master
-
-permissions:
-  pull-requests: read
 
 jobs:
   code-changed:
@@ -25,12 +26,25 @@ jobs:
     name: Check code changes
     runs-on: ubuntu-latest
     outputs:
-      proceed: ${{ steps.changed-source-files.outputs.any_changed }}
-      all_changed_files: ${{ steps.changed-source-files.outputs.all_changed_files }}
+      proceed_with_tests: >-
+        ${{
+           steps.changed-source-files.outputs.should_run_tests_any_changed == 'true' ||
+           steps.changed-source-files.outputs.should_run_codegen_any_changed == 'true'
+         }}
+      proceed_with_codegen: ${{ steps.changed-source-files.outputs.should_run_codegen_any_changed }}
+      proceed_with_docker: ${{ steps.changed-source-files.outputs.should_build_docker_any_changed }}
+      proceed: >-
+        ${{
+          steps.changed-source-files.outputs.should_run_tests_any_changed == 'true' ||
+          steps.changed-source-files.outputs.should_run_codegen_any_changed == 'true' ||
+          steps.changed-source-files.outputs.should_build_docker_any_changed == 'true'
+        }}
+      other_changed_files: ${{ steps.changed-source-files.outputs.other_changed_files }}
     steps:
     - name: Originating repo checkout (e.g. public fork)
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
+        # will be empty on push to master and default to head from master
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
 
@@ -38,20 +52,49 @@ jobs:
       uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v4.7.0
       id: changed-source-files
       with:
-        # check if anything changed in go source, templates or the way we test those
-        files: |
-          **/*.go
-          **/*.gotmpl
-          .golangci.yml
-          .codecov.yml
-          .github/workflows/test*.yaml
-          fixtures/*
-          hack/*
+        files_yaml: |
+          # Changes to anything in go source, templates or the way we test those.
+          should_run_tests:
+            - '**/go.{mod,sum}'
+            - '**/*.{go,gotmpl}'
+            - 'fixtures/**'
+            - '!**/*.md'
+            - '.github/workflows/test*.yaml'
+            - '.golangci.yml'
+            - '.codecov.yml'
+          # Changes to anything that affects codegen.
+          #
+          # Approximation: some cmd/** commands do not affect codegen, but CLI
+          # is affected and exercised by the codegen testing harness.
+          should_run_codegen:
+            - '**/go.(mod,sum)'
+            - 'cmd/**/*.go'
+            - '!cmd/swagger/commands/generate/spec*.go'
+            - '!cmd/swagger/commands/diff/*.go'
+            - 'generator/**'
+            # codegen test program and configuration
+            - 'hack/codegen*.go'
+            - 'hack/*.yaml'
+            # codegen test data
+            - 'fixtures/**/*.(yaml,yml,json)'
+            # codescan test data
+            - '!fixtures/goparsing/**'
+            - '!**/*.md'
+          # Changes in the way we build and check docker images.
+          # This assumes the repo builds normally and therefore only checks the dockerfile arrangements.
+          should_build_docker:
+            - '**/go.(mod,sum)'
+            - 'Dockerfile'
+            - '.hadolint.yml'
+            - '.github/workflows/*docker*.yaml'
 
     - name: Notify
       run: |
         echo "::notice::Detection of changed source files"
-        echo "${{ steps.changed-source-files.outputs.all_changed_files }}"
+        echo "should_run_tests_changed_files: ${{ steps.changed-source-files.outputs.should_run_tests_all_changed_files }}"
+        echo "should_run_codegen_changed_files: ${{ steps.changed-source-files.outputs.should_run_codegen_all_changed_files }}"
+        echo "should_build_docker_changed_files: ${{ steps.changed-source-files.outputs.should_build_docker_all_changed_files }}"
+        echo "others: ${{ steps.changed-source-files.outputs.other_changed_files }}"
 
     - name: Workflow summary
       run: |
@@ -62,7 +105,10 @@ jobs:
         spew "# Workflow summary"
         spew ""
 
-        if [[ "${{ steps.changed-source-files.outputs.any_changed }}" != "true" ]] ; then
+        if [[ "${{ steps.changed-source-files.outputs.should_run_tests_any_changed }}" != "true" && \
+              "${{ steps.changed-source-files.outputs.should_run_codegen_any_changed }}" != "true" && \
+              "${{ steps.changed-source-files.outputs.should_build_docker_any_changed }}" != "true" \
+           ]] ; then
           spew "1. [ ] Detect a change in source or the way we test it"
           spew "2. [x] All tests are skipped. Other workflows may kick in (e.g. doc update)"
           spew "3. [x] Tests completed: so PR may be approved"
@@ -70,23 +116,49 @@ jobs:
           exit 0
         fi
 
-        spew "1. [x] Detect a change in source or the way we test it"
-        spew "2. [x] Lint go source code, including (generated examples)."
-        spew "3. [x] Run a build (smoke) test (6x matrix)"
-        spew "4. [x] Run unit tests (6x matrix)"
-        spew "5. [x] Run codegen integration tests (2x matrix)"
-        spew "6. [x] Tests completed: so PR may be approved"
-        spew "7. [x] Merge test reports and publish (codecov, github)"
-        spew "8. [x] Merge test coverage reports and publish (codecov)"
+        if [[ "${{ steps.changed-source-files.outputs.should_run_tests_any_changed }}" == "true" ]] ; then
+          spew "1. [x] Detect a change in source or the way we test it"
+          spew "2. [x] Lint go source code, including (generated examples)."
+          spew "3. [x] Run a build (smoke) test (6x matrix)"
+          spew "4. [x] Run unit tests (6x matrix)"
+        else
+          spew "1. [x] Did **not** detect a change in source or the way we test it"
+          spew "2. [ ] Lint go source code, including (generated examples) (skipped)."
+          spew "3. [ ] Run a build (smoke) test (6x matrix) (skipped)"
+          spew "4. [ ] Run unit tests (6x matrix) (skipped)"
+        fi
+
+        if [[ "${{ steps.changed-source-files.outputs.should_run_codegen_any_changed }}" == "true" ]] ; then
+          spew "5. [x] Run codegen integration tests (2x matrix)"
+        else
+          spew "5. [ ] Run codegen integration tests (2x matrix) (skipped)"
+        fi
+
+        if [[ "${{ steps.changed-source-files.outputs.should_build_docker_any_changed }}" == "true" ]] ; then
+          spew "6. [x] Run build docker test"
+        else
+          spew "6. [ ] Run build docker test (skipped)"
+        fi
+
+        spew "7. [x] Tests completed: so PR may be approved"
+
+        if [[ "${{ steps.changed-source-files.outputs.should_run_tests_any_changed }}" == "true" ]] ; then
+          spew "8. [x] Merge test reports and publish (codecov, github)"
+          spew "9. [x] Merge test coverage reports and publish (codecov)"
+        else
+          spew "8. [ ] Merge test reports and publish (codecov, github) (skipped)"
+          spew "9. [ ] Merge test coverage reports and publish (codecov) (skipped)"
+        fi
+
         spew ""
-        spew "Steps (7) and (8) may sometimes fail and are not strictly required by PR check rules"
+        spew "Steps (8) and (9) may sometimes fail and are not strictly required by PR check rules"
 
   lint:
     # description: |
     # Lint go source code.
     name: lint
     needs: [code-changed]
-    if: ${{ needs.code-changed.outputs.proceed == 'true' }}
+    if: ${{ needs.code-changed.outputs.proceed_with_tests == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -117,7 +189,22 @@ jobs:
     - name: Notify
       run: |
         echo "::notice::Linting and tests skipped: this PR doesn't change any code"
-        echo "${{ steps.changed-source-files.outputs.all_changed_files }}"
+        echo "other_changed_files: ${{ needs.code-changed.outputs.other_changed_files }}"
+        echo "procedd_with_tests: ${{ needs.code-changed.outputs.proceed_with_tests }}"
+        echo "procedd_with_codegen: ${{ needs.code-changed.outputs.proceed_with_codegen }}"
+        echo "procedd_with_docker: ${{ needs.code-changed.outputs.proceed_with_docker }}"
+        echo "procedd: ${{ needs.code-changed.outputs.proceed }}"
+
+  docker-test:
+    name: test docker build
+    needs: [code-changed]
+    if: ${{ needs.code-changed.outputs.proceed_with_docker == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/build-docker.yaml
+        with:
+          tag_sha: true
+          pr: true
 
   build-test:
     # description: |
@@ -125,7 +212,7 @@ jobs:
     #   The full test suite warrants support for the 2 latest go minor releases.
     name: build test
     needs: [code-changed, lint]
-    if: ${{ needs.code-changed.outputs.proceed == 'true' }}
+    if: ${{ needs.code-changed.outputs.proceed_with_tests == 'true' }}
     strategy:
       matrix:
         go: ["oldstable", "stable"]
@@ -165,7 +252,7 @@ jobs:
     #   Run unit tests on the 2 most recent go releases and 3 popular platforms.
     name: unit test
     needs: [code-changed, lint]
-    if: ${{ needs.code-changed.outputs.proceed == 'true' }}
+    if: ${{ needs.code-changed.outputs.proceed_with_tests == 'true' }}
     strategy:
       matrix:
         go: ["oldstable", "stable"]
@@ -184,7 +271,7 @@ jobs:
           cache: true
 
       - name: Install Tools
-        # TODO: pin version
+        # TODO: pin version -> fork + update dedicated github action
         run: |
           go install gotest.tools/gotestsum@latest
 
@@ -220,6 +307,7 @@ jobs:
           # *.coverage.* pattern is automatically detected by codecov
           path: '**/*.coverage.*.out'
           name: 'unit.coverage.${{ matrix.os }}-${{ matrix.go }}'
+          retention-days: 1
 
       - name: Upload test report artifacts
         # upload report even if test fail. BTW, this is when they are valuable.
@@ -228,6 +316,7 @@ jobs:
         with:
           path: '**/unit.report.*.json'
           name: 'unit.report.${{ matrix.os }}-${{ matrix.go }}'
+          retention-days: 1
 
   codegen-test:
     # description: |
@@ -237,7 +326,7 @@ jobs:
     #   The test matrix applies to linux only. OS-specific quirks should
     #   be covered by unit tests.
     needs: [code-changed, lint]
-    if: ${{ needs.code-changed.outputs.proceed == 'true' }}
+    if: ${{ needs.code-changed.outputs.proceed_with_codegen == 'true' }}
     strategy:
       matrix:
         go: ["oldstable", "stable"]
@@ -269,15 +358,14 @@ jobs:
           mkdir /tmp/cov
 
       - name: Build binary with test coverage instrumentation
-        # TODO: should explicit / simplify this hack
-        run: >
-          ./hack/build-docker.sh --github-action
-          -cover
-          -covermode=atomic
-          -coverpkg=$(go list)/...
+        run: |
+          go install -a \
+             --ldflags "-s -w" \
+             -cover -covermode=atomic -coverpkg=$(go list)/... \
+             ./cmd/swagger
 
       - name: Run codegen tests
-        # TODO: this test harness should output a json test report
+        # TODO(fredbi): tests: nice to have - this test harness should output a json test report
         run: >
           /usr/bin/time
           go test -v -timeout 30m
@@ -295,53 +383,75 @@ jobs:
         with:
           path: '**/codegen.coverage.*.out'
           name: 'codegen.coverage.${{ matrix.os }}-${{ matrix.go }}'
+          retention-days: 1
 
   test-complete:
     # description: |
     #   Be explicit about all tests being passed. This allows for setting up only a few status checks on PRs.
     name: tests completed
-    needs: [code-changed, skip-test, build-test, codegen-test, unit-test]
+    needs: [code-changed, skip-test, build-test, codegen-test, unit-test, docker-test]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - name: debug
+      - name: Tests completed
+        if: ${{ needs.code-changed.outputs.proceed != 'true' }}
         run: |
-          echo "needs.code-changed.outputs.proceed=${{ needs.code-changed.outputs.proceed }}"
-          echo "needs.build-test.result=${{ needs.build-test.result }}"
-          echo "needs.codegen-test.result=${{ needs.codegen-test.result }}"
-          echo "needs.unit-test.result=${{ needs.unit-test.result }}"
-          echo "${{ toJSON( needs ) }}"
+          echo "::notice title=Success:All tests skipped (nothing to do)"
 
       - name: Tests completed
         if: >-
           ${{
-              needs.code-changed.outputs.proceed == 'true' &&
+              needs.code-changed.outputs.proceed_with_tests == 'true' &&
               needs.build-test.result == 'success' &&
-              needs.codegen-test.result == 'success' &&
               needs.unit-test.result == 'success'
            }}
         run: |
-          echo "::notice title=Success:All tests completed"
+          echo "::notice title=Success:All unit tests completed"
+
+      - name: Tests completed
+        if: >-
+          ${{
+              needs.code-changed.outputs.proceed_with_codegen == 'true' &&
+              needs.codegen-test.result == 'success'
+           }}
+        run: |
+          echo "::notice title=Success:All codegen tests completed"
+
+      - name: Tests completed
+        if: >-
+          ${{
+              needs.code-changed.outputs.proceed_with_docker == 'true' &&
+              needs.docker-test.result == 'success'
+           }}
+        run: |
+          echo "::notice title=Success:All docker tests completed"
 
       - name: Tests failed
         if: >-
           ${{
               needs.code-changed.outputs.proceed == 'true' &&
               (
-                needs.build-test.result != 'success' ||
-                needs.codegen-test.result != 'success' ||
-                needs.unit-test.result != 'success'
+                (
+                  needs.code-changed.outputs.proceed_with_tests == 'true' &&
+                  (
+                    needs.build-test.result != 'success' ||
+                    needs.unit-test.result != 'success'
+                  )
+                ) ||
+                (
+                  needs.code-changed.outputs.proceed_with_codegen == 'true' &&
+                  needs.codegen-test.result != 'success'
+                ) ||
+                (
+                  needs.code-changed.outputs.proceed_with_docker == 'true' &&
+                  needs.docker-test.result != 'success'
+                )
               )
            }}
         run: |
           echo "::error title=Failure:Tests failed"
 
           exit 1
-
-      - name: Tests completed
-        if: ${{ needs.code-changed.outputs.proceed != 'true' }}
-        run: |
-          echo "::notice title=Success:All tests skipped (nothing to do)"
 
       - name: Ensure status
         run: |
@@ -353,8 +463,8 @@ jobs:
     #   Gather, merge then uploads test coverage files from all test jobs (this includes integration tests,
     #   like codegen-test).
     name: collect test coverage
-    needs: [test-complete]
-    if: ${{ !cancelled() && needs.test-complete.result == 'success' }}
+    needs: [test-complete, code-changed]
+    if: ${{ !cancelled() && needs.test-complete.result == 'success' && needs.code-changed.outputs.proceed_with_tests == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -389,7 +499,7 @@ jobs:
     #   (see <https://github.com/go-swagger/go-swagger/actions>).
     name: collect test reports
     needs: [code-changed, unit-test]
-    if: ${{ needs.code-changed.outputs.proceed == 'true' && !cancelled() }}
+    if: ${{ needs.code-changed.outputs.proceed_with_tests == 'true' && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -413,7 +523,9 @@ jobs:
         # As a contemplated alternative, we could use gotestsum above to produce the JUnit XML directly.
         # At this moment, we keep a json format to dispatch test reports to codecov as well as to CTRF reports.
         #
-        # TODO: pin go-junit-report
+        # TODO(fredbi): sec compliance - pin go-junit-report
+        # TODO(fredbi): investigate - use mikepenz/action-junit-report@v5, that packages most of the following scripts
+        # in a single action. Alternative: for that action.
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
           go-junit-report -version

--- a/.github/workflows/update-doc.yaml
+++ b/.github/workflows/update-doc.yaml
@@ -1,5 +1,8 @@
 name: "Update documentation"
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -15,9 +18,6 @@ on:
     - docs/**
     - hack/doc-site/**
     - .github/workflows/update-doc.yaml
-
-permissions:
-  contents: read
 
 concurrency:
   group: "pages"

--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -1,0 +1,1 @@
+failure-threshold: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM --platform=$BUILDPLATFORM golang:alpine AS cross
+# syntax=docker/dockerfile:1
+ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
+
+FROM --platform=$BUILDPLATFORM golang@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS build
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 ARG TARGETOS TARGETARCH
 
 ARG commit_hash="dev"
 ARG tag_name="dev"
 
-ADD . /work
+COPY . /work
 WORKDIR /work
 
 RUN apk --no-cache add ca-certificates shared-mime-info mailcap git build-base binutils-gold
@@ -15,14 +19,14 @@ RUN mkdir -p bin &&\
   LDFLAGS="$LDFLAGS -X github.com/go-swagger/go-swagger/cmd/swagger/commands.Version=${tag_name}" &&\
   CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags osusergo,netgo -o bin/swagger -ldflags "$LDFLAGS" -a ./cmd/swagger
 
-FROM --platform=$TARGETPLATFORM alpine
+FROM --platform=$TARGETPLATFORM alpine@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 
 LABEL maintainer="Ivan Porto Carrero <ivan@flanders.co.nz> (@casualjim)"
 
 RUN apk --no-cache add ca-certificates shared-mime-info mailcap
 
-COPY --from=cross /work/bin/swagger /usr/bin/swagger
-COPY --from=cross /work/generator/templates/contrib /templates/
+COPY --from=build /work/bin/swagger /usr/bin/swagger
+COPY --from=build /work/generator/templates/contrib /templates/
 
 ENTRYPOINT ["/usr/bin/swagger"]
 CMD ["--help"]


### PR DESCRIPTION
This PR's goal is to improve a bit our CI workflow. Merge to master workflows have been tested on my personal fork.

* made test workflow less resource-intensive (pull request, push to master)
  * codegen runs are triggered only when codegen is affected
  * a workflow summary explains which steps are going to run and which are skipped
  * transitory artifacts are now explicitly retained only for 1 day
  * the workflow is organized so that only 1 status check is required for a PR (we might add more later on)

* added docker builds to tests
  * docker builds are tested (not pushed) whenever Dockerfile, dependencies or building actions are affected

* refactored docker builds
  * factorized docker builds common to test, push to master and release
  * added dockerfile linting step (w/ hadolint) (only errors are blockint atm)
  * added docker image scanning with trivy
  * added SBOMs to the image, including build stage SBOM
  * sha-pinned base images used in (main) Dockerfile

* improved security safeguards
  * fixed workflow-level write permissions: now declared for specific jobs as needed
  * added supplementary vulnerability scanner (trivy) to challenge & supplement CodeQL

* explicited the codegen build with coverage instrumentation
  * no long hidden inside ./hack