### PR TITLE
fix(generator): fix missing closing parenthesis in ReadOnly validation template

### DIFF
--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -640,7 +640,7 @@
     // at https://github.com/go-swagger/go-swagger/issues
     {{- if .ReadOnly }}
 
-  if err := validate.ReadOnly{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{.ValueExpression }}; err != nil {
+  if err := validate.ReadOnly{{ if and (eq .GoType "string") (not .IsNullable) }}String{{ end }}({{ path . }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
     return err
   }
     {{- end }}


### PR DESCRIPTION
## Summary

The `schemavalidator.gotmpl` template was generating invalid Go code for fields with `readOnly: true` and custom format types.

## Root Cause

In `generator/templates/schemavalidator.gotmpl` line 640, the `validate.ReadOnly...()` function call was missing the closing `)` before the `; err != nil` check:

```go
// Generated (broken):
if err := validate.ReadOnly(path, location, valueExpression; err != nil {

// Fixed:
if err := validate.ReadOnly(path, location, valueExpression); err != nil {
```

## Changes

- `generator/templates/schemavalidator.gotmpl`: Added missing `)` at line 640

## Impact

This bug causes a Go compilation error when generating server code for schemas that have both a custom format type and `readOnly: true`.

Closes #3278