### PR TITLE
fix(codescan): add nil check in isTextMarshaler to prevent panic

### DIFF
--- a/codescan/schema.go
+++ b/codescan/schema.go
@@ -1692,7 +1692,11 @@ func isTextMarshaler(tpe types.Type) bool {
 	if err != nil {
 		return false
 	}
-	ifc := encodingPkg.Scope().Lookup("TextMarshaler").Type().Underlying().(*types.Interface) // TODO: there is a better way to check this
+	obj := encodingPkg.Scope().Lookup("TextMarshaler")
+	if obj == nil {
+		return false
+	}
+	ifc := obj.Type().Underlying().(*types.Interface) // TODO: there is a better way to check this
 
 	return types.Implements(tpe, ifc)
 }


### PR DESCRIPTION
## Summary

`isTextMarshaler` in `codescan/schema.go` calls `.Type()` directly on the result of `encodingPkg.Scope().Lookup("TextMarshaler")` without checking for `nil`. In edge cases (malformed package, import failure), this causes a nil pointer dereference panic.

## Fix

Added a nil guard before calling `.Type()`:

```go
obj := encodingPkg.Scope().Lookup("TextMarshaler")
if obj == nil {
    return false
}
ifc := obj.Type().Underlying().(*types.Interface)
```

Returning `false` is the correct fallback — the type simply does not implement `TextMarshaler`.

Fixes #3225

Signed-off-by: lyydsheep <2230561977@qq.com>