### PR TITLE
ci: enhanced regen examples workflow

### DIFF
--- a/.github/workflows/close-examples-pr.yaml
+++ b/.github/workflows/close-examples-pr.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright 2015-2026 go-swagger maintainers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Clean up orphaned examples PRs when a go-swagger PR is closed without merge.
+#
+# Uses pull_request_target for access to secrets. No PR code is checked out.
+
+name: Close examples PR
+
+permissions:
+  contents: read
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  close-examples-pr:
+    name: close examples PR
+    if: ${{ !github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Configure bot credentials
+        uses: go-openapi/gh-actions/ci-jobs/bot-credentials@22f6d5e0e1d13b8e835ea0ffe69ed5589f7cc354 # v1.4.11
+        id: bot-credentials
+        with:
+          enable-github-app: "true"
+          github-app-id: ${{ secrets.CI_BOT_APP_ID }}
+          github-app-private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+          github-app-owner: go-swagger
+          github-app-repositories: examples
+      -
+        name: Close corresponding examples PR
+        env:
+          GH_TOKEN: ${{ steps.bot-credentials.outputs.app-token }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BRANCH="regen/pr-${PR_NUMBER}"
+          EXISTING=$(gh pr list --repo go-swagger/examples --head "${BRANCH}" --json number --jq '.[0].number // empty')
+          if [ -n "${EXISTING}" ]; then
+            gh pr close "${EXISTING}" --repo go-swagger/examples --delete-branch \
+              --comment "Closing: triggering go-swagger PR #${PR_NUMBER} was closed without merge."
+          fi

--- a/.github/workflows/regen-examples-pr.yaml
+++ b/.github/workflows/regen-examples-pr.yaml
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright 2015-2026 go-swagger maintainers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Phase 2 of the examples regeneration pipeline.
+#
+# Triggered by workflow_run after the "Regen examples" workflow completes.
+# Downloads the diff artifact produced by the untrusted phase 1,
+# applies it to the examples repo, and creates/updates a PR with
+# proper credentials (GitHub App token + GPG-signed commits).
+#
+#
+# Security model: this workflow never checks out or executes PR code.
+# It only applies a patch file (data, not code) produced by phase 1.
+
+name: Regen examples PR
+
+permissions:
+  contents: read
+
+on:
+  workflow_run:
+    workflows: ["Regen examples"]
+    types:
+      - completed
+
+jobs:
+  on-success:
+    name: Ensure triggering workflow was successful
+    if: >-
+      ${{
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      -
+        run: |
+          echo "The triggering workflow was successful"
+
+  on-failure:
+    name: Triggering workflow was unsuccessful
+    if: >-
+      ${{
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'failure'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      -
+        run: |
+          echo "The triggering workflow failed. Stopping here"
+          exit 1
+
+  create-examples-pr:
+    # description: |
+    #   Download the regen diff from the completed workflow run,
+    #   apply it to the examples repo, and create/update a PR.
+    name: create examples PR
+    needs: [on-success]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      -
+        name: Download regen artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        id: download
+        with:
+          name: regen-examples
+          path: /tmp/regen-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+        continue-on-error: true
+      -
+        name: Check for artifacts
+        id: check
+        run: |
+          if [ ! -f /tmp/regen-metadata/regen.patch ]; then
+            echo "No regen artifacts found — examples are up to date."
+            echo "has_artifacts=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_artifacts=true" >> "${GITHUB_OUTPUT}"
+            PR_NUMBER=$(cat /tmp/regen-metadata/pr_number.txt)
+            echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+          fi
+      -
+        name: Configure bot credentials
+        if: ${{ steps.check.outputs.has_artifacts == 'true' }}
+        uses: go-openapi/gh-actions/ci-jobs/bot-credentials@22f6d5e0e1d13b8e835ea0ffe69ed5589f7cc354 # v1.4.11
+        id: bot-credentials
+        with:
+          enable-github-app: "true"
+          github-app-id: ${{ secrets.CI_BOT_APP_ID }}
+          github-app-private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+          github-app-owner: go-swagger
+          github-app-repositories: examples
+          enable-gpg-signing: "true"
+          gpg-private-key: ${{ secrets.CI_BOT_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.CI_BOT_GPG_PASSPHRASE }}
+          gpg-fingerprint: ${{ secrets.CI_BOT_SIGNING_KEY }}
+          enable-commit-signing: "true"
+          enable-tag-signing: "false"
+      -
+        name: Checkout examples
+        if: ${{ steps.check.outputs.has_artifacts == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: go-swagger/examples
+          token: ${{ steps.bot-credentials.outputs.app-token }}
+      -
+        name: Apply patch
+        if: ${{ steps.check.outputs.has_artifacts == 'true' }}
+        run: |
+          git apply /tmp/regen-metadata/regen.patch
+      -
+        name: Create or update examples PR
+        if: ${{ steps.check.outputs.has_artifacts == 'true' }}
+        id: examples-pr
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          token: ${{ steps.bot-credentials.outputs.app-token }}
+          commit-message: |
+            chore: regenerate examples from go-swagger PR #${{ steps.check.outputs.pr_number }}
+
+            Origin: go-swagger/go-swagger#${{ steps.check.outputs.pr_number }}
+          branch: regen/pr-${{ steps.check.outputs.pr_number }}
+          delete-branch: true
+          title: "chore: regen examples (go-swagger PR #${{ steps.check.outputs.pr_number }})"
+          body: |
+            Regenerated examples from go-swagger/go-swagger#${{ steps.check.outputs.pr_number }}
+
+            Triggering PR: https://github.com/go-swagger/go-swagger/pull/${{ steps.check.outputs.pr_number }}
+          signoff: true
+          sign-commits: true
+      -
+        name: Comment on go-swagger PR
+        if: ${{ steps.examples-pr.outputs.pull-request-url != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ steps.check.outputs.pr_number }}"
+          DIFFSTAT=$(cat /tmp/regen-metadata/diffstat.txt)
+          COMMENT=$(cat <<CMTEOF
+          **Examples regeneration:** changes detected.
+
+          Examples PR: ${{ steps.examples-pr.outputs.pull-request-url }}
+
+          <details>
+          <summary>Diffstat</summary>
+
+          \`\`\`
+          ${DIFFSTAT}
+          \`\`\`
+
+          </details>
+          CMTEOF
+          )
+          gh pr comment "${PR_NUMBER}" --body "${COMMENT}"
+

--- a/.github/workflows/regen-examples.yaml
+++ b/.github/workflows/regen-examples.yaml
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright 2015-2026 go-swagger maintainers
 # SPDX-License-Identifier: Apache-2.0
 #
-# Regenerate examples in go-swagger/examples from the PR branch,
-# then create/update a PR in examples with the diff.
+# Phase 1 of the examples regeneration pipeline.
 #
-# Uses pull_request_target so secrets are available even for PRs from public forks.
-# IMPORTANT: only the workflow file from the base branch is used — the PR code is
-# checked out explicitly at the PR ref so it cannot tamper with this workflow.
+# Builds swagger from the PR, regenerates examples, and uploads
+# the resulting diff as an artifact. No secrets are used — untrusted
+# PR code runs in a sandboxed context.
+#
+# Phase 2 (regen-examples-pr.yaml) picks up the artifact via workflow_run
+# and creates the examples PR with proper credentials.
 
 name: Regen examples
 
@@ -14,26 +16,21 @@ permissions:
   contents: read
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - closed
+  pull_request:
 
 jobs:
   code-changed:
     name: check codegen changes
-    if: ${{ github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     outputs:
       proceed_with_codegen: ${{ steps.changed-source-files.outputs.should_run_codegen_any_changed }}
     steps:
       -
-        name: Checkout PR head
+        name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       -
         name: Get changed source files
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v4.7.0
@@ -52,23 +49,21 @@ jobs:
               - '!fixtures/goparsing/**'
               - '!**/*.md'
 
-  regen-examples:
+  regen:
     # description: |
-    #   Build swagger from the PR, regenerate examples in go-swagger/examples,
-    #   and create a PR in examples with the diff. Reviewer checks both PRs together.
-    name: regen examples
+    #   Build swagger from the PR, regenerate examples, and upload the diff
+    #   as an artifact. No secrets — safe for fork PRs.
+    name: regenerate
     needs: [code-changed]
     if: ${{ needs.code-changed.outputs.proceed_with_codegen == 'true' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       -
-        name: Checkout go-swagger at PR ref
+        name: Checkout go-swagger
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       -
         name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -82,27 +77,10 @@ jobs:
           go build -o "${GITHUB_WORKSPACE}/bin/swagger" ./cmd/swagger
           echo "${GITHUB_WORKSPACE}/bin" >> "${GITHUB_PATH}"
       -
-        name: Configure bot credentials
-        uses: go-openapi/gh-actions/ci-jobs/bot-credentials@22f6d5e0e1d13b8e835ea0ffe69ed5589f7cc354 # v1.4.11
-        id: bot-credentials
-        with:
-          enable-github-app: "true"
-          github-app-id: ${{ secrets.CI_BOT_APP_ID }}
-          github-app-private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
-          github-app-owner: go-swagger
-          github-app-repositories: examples
-          enable-gpg-signing: "true"
-          gpg-private-key: ${{ secrets.CI_BOT_GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.CI_BOT_GPG_PASSPHRASE }}
-          gpg-fingerprint: ${{ secrets.CI_BOT_SIGNING_KEY }}
-          enable-commit-signing: "true"
-          enable-tag-signing: "false"
-      -
         name: Checkout examples
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: go-swagger/examples
-          token: ${{ steps.bot-credentials.outputs.app-token }}
           path: _examples
       -
         name: Regenerate examples
@@ -115,14 +93,12 @@ jobs:
           cd _examples
           go build ./...
       -
-        name: Detect changes and create examples PR
-        id: regen
-        env:
-          GH_TOKEN: ${{ steps.bot-credentials.outputs.app-token }}
+        name: Produce diff artifacts
+        id: diff
         run: |
           cd _examples
 
-          # Stage everything first so we catch new/deleted files too
+          # Stage everything so we catch new/deleted files
           git add -A
 
           if git diff --cached --quiet; then
@@ -131,98 +107,21 @@ jobs:
           fi
           echo "has_changes=true" >> "${GITHUB_OUTPUT}"
 
-          # Collect diffstat for the comment
+          git diff --cached > /tmp/regen.patch
           git diff --cached --stat > /tmp/diffstat.txt
-
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          BRANCH="regen/pr-${PR_NUMBER}"
-
-          git checkout -b "${BRANCH}"
-          git commit -s \
-            -m "chore: regenerate examples from go-swagger PR #${PR_NUMBER}" \
-            -m "Origin: go-swagger/go-swagger#${PR_NUMBER}"
-
-          git push --force origin "${BRANCH}"
-
-          # Create or update PR
-          EXISTING=$(gh pr list --repo go-swagger/examples --head "${BRANCH}" --json number --jq '.[0].number // empty')
-
-          # Build PR body
-          BODY=$(cat <<PREOF
-          Regenerated examples from go-swagger/go-swagger#${PR_NUMBER}
-
-          Triggering PR: https://github.com/go-swagger/go-swagger/pull/${PR_NUMBER}
-
-          ---
-
-          ${{ github.event.pull_request.body }}
-          PREOF
-          )
-
-          if [ -n "${EXISTING}" ]; then
-            gh pr edit "${EXISTING}" --repo go-swagger/examples --body "${BODY}"
-          else
-            gh pr create --repo go-swagger/examples \
-              --head "${BRANCH}" --base master \
-              --title "chore: regen examples (go-swagger PR #${PR_NUMBER})" \
-              --body "${BODY}"
-          fi
       -
-        name: Comment on go-swagger PR
-        env:
-          GH_TOKEN: ${{ github.token }}
+        name: Save PR metadata
+        if: ${{ steps.diff.outputs.has_changes == 'true' }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          if [ "${{ steps.regen.outputs.has_changes }}" == "true" ]; then
-            EXAMPLES_PR=$(GH_TOKEN="${{ steps.bot-credentials.outputs.app-token }}" \
-              gh pr list --repo go-swagger/examples \
-              --head "regen/pr-${PR_NUMBER}" \
-              --json url --jq '.[0].url')
-            DIFFSTAT=$(cat /tmp/diffstat.txt)
-            COMMENT=$(cat <<CMTEOF
-          **Examples regeneration:** changes detected.
-
-          Examples PR: ${EXAMPLES_PR}
-
-          <details>
-          <summary>Diffstat</summary>
-
-          \`\`\`
-          ${DIFFSTAT}
-          \`\`\`
-
-          </details>
-          CMTEOF
-            )
-          else
-            COMMENT="**Examples regeneration:** no changes detected in generated examples."
-          fi
-          gh pr comment "${PR_NUMBER}" --body "${COMMENT}"
-
-  close-examples-pr:
-    name: close examples PR
-    if: ${{ github.event.action == 'closed' && !github.event.pull_request.merged }}
-    runs-on: ubuntu-latest
-    steps:
+          mkdir -p /tmp/regen-metadata
+          cp /tmp/regen.patch /tmp/regen-metadata/
+          cp /tmp/diffstat.txt /tmp/regen-metadata/
+          echo "${{ github.event.pull_request.number }}" > /tmp/regen-metadata/pr_number.txt
       -
-        name: Configure bot credentials
-        uses: go-openapi/gh-actions/ci-jobs/bot-credentials@22f6d5e0e1d13b8e835ea0ffe69ed5589f7cc354 # v1.4.11
-        id: bot-credentials
+        name: Upload regen artifacts
+        if: ${{ steps.diff.outputs.has_changes == 'true' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          enable-github-app: "true"
-          github-app-id: ${{ secrets.CI_BOT_APP_ID }}
-          github-app-private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
-          github-app-owner: go-swagger
-          github-app-repositories: examples
-      -
-        name: Close corresponding examples PR
-        env:
-          GH_TOKEN: ${{ steps.bot-credentials.outputs.app-token }}
-        run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          BRANCH="regen/pr-${PR_NUMBER}"
-          EXISTING=$(gh pr list --repo go-swagger/examples --head "${BRANCH}" --json number --jq '.[0].number // empty')
-          if [ -n "${EXISTING}" ]; then
-            gh pr close "${EXISTING}" --repo go-swagger/examples --delete-branch \
-              --comment "Closing: triggering go-swagger PR #${PR_NUMBER} was closed without merge."
-          fi
+          name: regen-examples
+          path: /tmp/regen-metadata/
+          retention-days: 1


### PR DESCRIPTION
* fixed security issue with insecure workflow
* split regen (local to triggering PR) from PR push to examples (by bot) and PR housecleaning (when triggering PR is closed)
* replaced gh pr scripting by peter-evans action