### PR TITLE
fix: handle operator characters in enum constants (fixes #1047)

### DIFF
--- a/generator/internal/funcmaps/golang/funcmap.go
+++ b/generator/internal/funcmaps/golang/funcmap.go
@@ -155,6 +155,20 @@ func replaceSpecialChar(in rune) string {
 		return "-Dash-"
 	case '#':
 		return "-Hashtag-"
+	case '=':
+		return "-Equal-"
+	case '!':
+		return "-Bang-"
+	case '~':
+		return "-Tilde-"
+	case '>':
+		return "-GreaterThan-"
+	case '<':
+		return "-LessThan-"
+	case '*':
+		return "-Star-"
+	case '/':
+		return "-Slash-"
 	}
 
 	return string(in)

--- a/generator/internal/funcmaps/golang/funcmap_test.go
+++ b/generator/internal/funcmaps/golang/funcmap_test.go
@@ -330,6 +330,12 @@ func TestFuncMap(t *testing.T) { //nolint:maintidx // false positive
 		assert.EqualT(t, "-Plus-1", cleanupEnumVariant("+1"))
 		assert.EqualT(t, "a-Dash-b-Hashtag-c", cleanupEnumVariant("a-b#c"))
 		assert.EqualT(t, "plain", cleanupEnumVariant("plain"))
+		assert.EqualT(t, "-Equal--Equal-", cleanupEnumVariant("=="))
+		assert.EqualT(t, "-Equal--Tilde-", cleanupEnumVariant("=~"))
+		assert.EqualT(t, "-GreaterThan--Equal-", cleanupEnumVariant(">="))
+		assert.EqualT(t, "-LessThan--Equal-", cleanupEnumVariant("<="))
+		assert.EqualT(t, "-Bang--Equal-", cleanupEnumVariant("!="))
+		assert.EqualT(t, "-Bang--Tilde-", cleanupEnumVariant("!~"))
 	})
 
 	t.Run("hasInsecure should detect the http scheme as insecure", func(t *testing.T) {
@@ -416,6 +422,13 @@ func TestReplaceSpecialChar(t *testing.T) {
 	assert.EqualT(t, "-Dash-", replaceSpecialChar('-'))
 	assert.EqualT(t, "-Hashtag-", replaceSpecialChar('#'))
 	assert.EqualT(t, "-Dot-", replaceSpecialChar('.'))
+	assert.EqualT(t, "-Equal-", replaceSpecialChar('='))
+	assert.EqualT(t, "-Bang-", replaceSpecialChar('!'))
+	assert.EqualT(t, "-Tilde-", replaceSpecialChar('~'))
+	assert.EqualT(t, "-GreaterThan-", replaceSpecialChar('>'))
+	assert.EqualT(t, "-LessThan-", replaceSpecialChar('<'))
+	assert.EqualT(t, "-Star-", replaceSpecialChar('*'))
+	assert.EqualT(t, "-Slash-", replaceSpecialChar('/'))
 	assert.EqualT(t, "x", replaceSpecialChar('x'))
 }
 


### PR DESCRIPTION
Extend replaceSpecialChar() in funcmap.go to handle operator characters commonly found in enum values: =, !, ~, >, <, *, /.

Previously, enum values containing these characters (e.g. "==", "=~", ">=", "<=", "!=", "!~") would all collapse to the GoType name because swag.ToGoName returned empty string after failing to process them.

With this fix, each character gets a human-readable replacement:
  '=' -> "-Equal-", '!' -> "-Bang-", '~' -> "-Tilde-"
  '>' -> "-GreaterThan-", '<' -> "-LessThan-"
  '*' -> "-Star-", '/' -> "-Slash-"

This produces unique, compilable Go constant names like:
  MyTypeEqualEqual for "=="
  MyTypeGreaterThanEqual for ">="
  MyTypeBangEqual for "!="

Fixes #1047