### PR TITLE
docs: add comprehensive documentation for API Browser (issue #2401)

### DIFF
--- a/docs/faq/faq_documenting.md
+++ b/docs/faq/faq_documenting.md
@@ -4,8 +4,88 @@ date: 2023-01-01T01:01:01-08:00
 draft: true
 ---
 <!-- Questions about the serve UI use-case -->
+
+### API Browser (SwaggerUI/ReDoc) on Generated Servers
+
+Every go-swagger generated server comes with an **API Browser** built-in, so you can easily explore and test your API without any additional configuration.
+
+#### Accessing the API Browser
+
+When you run a generated go-swagger server, the API documentation is automatically available at:
+
+| URL Path | Description |
+|----------|-------------|
+| `/docs` | ReDoc UI (default) |
+| `/swagger.json` | Raw OpenAPI 2.0 specification |
+
+For example, if your server is running on `http://localhost:8080`, you can access:
+
+* **ReDoc UI**: Visit `http://localhost:8080/docs`
+* **SwaggerUI**: Visit `http://localhost:8080/docs` (if configured) or `http://localhost:8080/swagger-ui/`
+* **Raw Spec**: `http://localhost:8080/swagger.json`
+
+#### Choosing Between ReDoc and SwaggerUI
+
+By default, generated servers use **ReDoc** for API documentation. ReDoc provides a clean, three-panel layout optimized for readability with support for dark mode.
+
+If you prefer SwaggerUI, you can configure it in your `configure_<appname>.go` file:
+
+```go
+func setupMiddlewares(handler http.Handler) http.Handler {
+    return middleware.SwaggerUI(middleware.SwaggerUIOpts{
+        BasePath: "/",
+        SpecURL:  "/swagger.json",
+        Path:     "swagger-ui",
+    }, handler)
+}
+```
+
+Then access SwaggerUI at `http://localhost:8080/swagger-ui/`.
+
+For more details on serving options, see the [`swagger serve` command](../usage/serve_ui.md).
+
+#### Customizing the API Browser Path
+
+If you need to serve the API documentation at a different path, you can modify the `Path` option in the middleware configuration. Note that changing the path requires updating both the middleware setup and any references in your documentation.
+
+#### How It Works
+
+The generated server embeds the OpenAPI 2.0 specification as an embedded asset. When you visit `/docs`:
+
+1. The server serves the embedded ReDoc or SwaggerUI assets
+2. The UI loads the swagger specification from `/swagger.json`
+3. The API documentation is rendered interactively
+
+This approach ensures that:
+- The API documentation is always in sync with the generated code
+- No additional servers or build steps are required
+- The documentation is available in any environment where the server runs
+
+#### Common Use Cases
+
+**Enable/disable API Browser in production:**
+```go
+func configureAPI(api *operations.MyAppAPI) http.Handler {
+    // ... other configuration ...
+    
+    // Conditionally serve docs based on environment
+    if os.Getenv("ENABLE_API_DOCS") != "false" {
+        return setupMiddlewares(api.Serve())
+    }
+    return api.Serve()
+}
+```
+
+**Require authentication for API docs:**
+```go
+func setupMiddlewares(handler http.Handler) http.Handler {
+    return authMiddleware(handler) // your auth middleware
+}
+```
+
+Originally from issue [#2401](https://github.com/go-swagger/go-swagger/issues/2401).
+
 ### Serving swagger-ui with the API Server
-Update: You can visit $API_BASE/docs and it should show the UI, as mentioned in [#comment](https://github.com/go-swagger/go-swagger/issues/2401#issuecomment-688962519) 
 
 _Use-Case_: I was trying to serve swagger-ui from the generated API Server and
 I didn't find a straightforward enough way in the docs,
@@ -117,7 +197,4 @@ That page also contains a link to a good explanation on how to create net/http m
 > An implementation example is provided by the go-swagger serve UI command. It constructs a server with a redoc middleware:
 > https://github.com/go-swagger/go-swagger/blob/f552963ac0dfdec0450f6749aeeeeb2d31cd5544/cmd/swagger/commands/serve.go#L35.
 
-Besides, every swagger generated server comes with the redoc UI baked in at `/{basepath}/docs`
-
 Originally from issue [#1375](https://github.com/go-swagger/go-swagger/issues/1375).
-

--- a/docs/features.md
+++ b/docs/features.md
@@ -41,7 +41,10 @@ weight: 30
     - basic auth
     - api key auth
     - oauth2 bearer auth
-  - [x] swagger docs UI (docUI and redoc flavors)
+  - [x] API Browser: interactive documentation with ReDoc and SwaggerUI
+      - Built-in on all generated servers at `/docs` endpoint
+      - Supports both ReDoc (default) and SwaggerUI flavors
+      - Serves OpenAPI 2.0 spec at `/swagger.json`
 
 - [x] Typed JSON Schema implementation
   - [x] JSON Pointer that knows about structs

--- a/docs/generate/server.md
+++ b/docs/generate/server.md
@@ -471,3 +471,82 @@ todos.AddOneHandlerFunc(func(params todos.AddOneParams, principal interface{}) m
   return AddOneCreated{created}
 })
 ```
+
+### API Documentation (ReDoc/SwaggerUI)
+
+Every generated server includes built-in API documentation powered by ReDoc by default. This provides an interactive API browser that allows you to explore and test your API endpoints directly from the browser.
+
+#### Accessing the API Documentation
+
+When your server is running, the API documentation is available at:
+
+| Endpoint | Description |
+|----------|-------------|
+| `/docs` | ReDoc UI (default) |
+| `/swagger.json` | Raw OpenAPI 2.0 specification |
+
+For example, if your server is running locally on port 8080:
+
+* Open `http://localhost:8080/docs` to view the API documentation in ReDoc
+* The raw specification is available at `http://localhost:8080/swagger.json`
+
+#### Switching to SwaggerUI
+
+If you prefer SwaggerUI over ReDoc, you can configure this in your `configure_<appname>.go` file by modifying the `setupMiddlewares` function:
+
+```go
+import (
+    "github.com/go-openapi/runtime/middleware"
+)
+
+func setupMiddlewares(handler http.Handler) http.Handler {
+    return middleware.SwaggerUI(middleware.SwaggerUIOpts{
+        BasePath: "/",
+        SpecURL:  "/swagger.json",
+        Path:     "swagger-ui",
+    }, handler)
+}
+```
+
+After restarting the server, access SwaggerUI at `http://localhost:8080/swagger-ui/`.
+
+#### Customizing Documentation Paths
+
+The default path `/docs` serves the ReDoc UI. You can customize this path by modifying the middleware configuration. For example, to serve at `/api-docs`:
+
+```go
+func setupMiddlewares(handler http.Handler) http.Handler {
+    return middleware.Redoc(middleware.RedocOpts{
+        BasePath: "/",
+        SpecURL:  "/swagger.json",
+        Path:     "api-docs",  // Change the path here
+    }, handler)
+}
+```
+
+Then access the API docs at `http://localhost:8080/api-docs`.
+
+#### Security Considerations
+
+By default, the API documentation is publicly accessible. To restrict access in production environments, add authentication middleware:
+
+```go
+func setupMiddlewares(handler http.Handler) http.Handler {
+    // Add your authentication middleware here
+    return authMiddleware(handler)
+}
+```
+
+For more advanced use cases, you can conditionally enable documentation based on environment variables or other criteria.
+
+#### Disabling the API Documentation
+
+If you need to disable the API documentation entirely, modify the `setupMiddlewares` function to return the handler without the documentation middleware:
+
+```go
+func setupMiddlewares(handler http.Handler) http.Handler {
+    return handler  // No documentation middleware
+}
+```
+
+For more information about the `swagger serve` command and its options, see the [serve UI documentation](../usage/serve_ui.md).


### PR DESCRIPTION
## Summary

Adds detailed documentation explaining how to access the built-in API Browser (ReDoc/SwaggerUI) on generated go-swagger servers.

## Changes

### docs/faq/faq_documenting.md
Added new section **'API Browser (SwaggerUI/ReDoc) on Generated Servers'** with comprehensive coverage of:
- Accessing the API documentation via /docs (ReDoc) and /swagger.json
- How to switch between ReDoc and SwaggerUI
- Customization options for documentation paths
- Common use cases (enable/disable, authentication)
- Reference to issue #2401

### docs/features.md
Expanded the minimal 'swagger docs UI' line to properly describe the API Browser feature with its endpoints.

### docs/generate/server.md
Added new section **'API Documentation (ReDoc/SwaggerUI)'** explaining:
- Built-in documentation on generated servers
- How to access via /docs and /swagger.json
- Switching to SwaggerUI configuration
- Customizing documentation paths
- Security considerations
- How to disable the documentation

## Motivation

Issue #2401 reported that users were not finding documentation on how to access the API Browser on generated servers. Many users were creating their own middleware to serve SwaggerUI, not knowing that go-swagger provides this functionality out of the box at .

## Testing

Documentation changes only - verified locally that markdown renders correctly.

Fixes #2401