### PR TITLE
ci: fix examples regeneration auto-PR

### DIFF
--- a/.github/workflows/regen-examples-pr.yaml
+++ b/.github/workflows/regen-examples-pr.yaml
@@ -4,10 +4,9 @@
 # Phase 2 of the examples regeneration pipeline.
 #
 # Triggered by workflow_run after the "Regen examples" workflow completes.
-# Downloads the diff artifact produced by the untrusted phase 1,
-# applies it to the examples repo, and creates/updates a PR with
-# proper credentials (GitHub App token + GPG-signed commits).
-#
+# Downloads the regen-examples artifact produced by phase 1, reads its
+# status, comments on the triggering PR, and (when the status is
+# "has-changes") applies the patch and creates/updates the examples PR.
 #
 # Security model: this workflow never checks out or executes PR code.
 # It only applies a patch file (data, not code) produced by phase 1.
@@ -52,11 +51,12 @@ jobs:
           echo "The triggering workflow failed. Stopping here"
           exit 1
 
-  create-examples-pr:
+  process-regen-result:
     # description: |
-    #   Download the regen diff from the completed workflow run,
-    #   apply it to the examples repo, and create/update a PR.
-    name: create examples PR
+    #   Download the regen artifact, comment status on the triggering PR,
+    #   and (when changes are present) apply the patch and create/update
+    #   the examples PR.
+    name: process regen result
     needs: [on-success]
     runs-on: ubuntu-latest
     permissions:
@@ -74,20 +74,25 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
         continue-on-error: true
       -
-        name: Check for artifacts
-        id: check
+        name: Read regen status
+        id: status
         run: |
-          if [ ! -f /tmp/regen-metadata/regen.patch ]; then
-            echo "No regen artifacts found — examples are up to date."
-            echo "has_artifacts=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "has_artifacts=true" >> "${GITHUB_OUTPUT}"
+          PR_NUMBER=""
+          STATUS="unknown"
+
+          if [[ -f /tmp/regen-metadata/pr_number.txt ]]; then
             PR_NUMBER=$(cat /tmp/regen-metadata/pr_number.txt)
-            echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
           fi
+          if [[ -f /tmp/regen-metadata/status.txt ]]; then
+            STATUS=$(cat /tmp/regen-metadata/status.txt)
+          fi
+
+          echo "::notice title=regen status::PR ${PR_NUMBER:-unknown}: ${STATUS}"
+          echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+          echo "status=${STATUS}" >> "${GITHUB_OUTPUT}"
       -
         name: Configure bot credentials
-        if: ${{ steps.check.outputs.has_artifacts == 'true' }}
+        if: ${{ steps.status.outputs.status == 'has-changes' }}
         uses: go-openapi/gh-actions/ci-jobs/bot-credentials@70c5bbea429a7d10a082ac9efb83036da0c5b7d0 # v1.4.14
         id: bot-credentials
         with:
@@ -104,48 +109,60 @@ jobs:
           enable-tag-signing: "false"
       -
         name: Checkout examples
-        if: ${{ steps.check.outputs.has_artifacts == 'true' }}
+        if: ${{ steps.status.outputs.status == 'has-changes' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: go-swagger/examples
           token: ${{ steps.bot-credentials.outputs.app-token }}
       -
         name: Apply patch
-        if: ${{ steps.check.outputs.has_artifacts == 'true' }}
+        if: ${{ steps.status.outputs.status == 'has-changes' }}
         run: |
           git apply /tmp/regen-metadata/regen.patch
       -
         name: Create or update examples PR
-        if: ${{ steps.check.outputs.has_artifacts == 'true' }}
+        if: ${{ steps.status.outputs.status == 'has-changes' }}
         id: examples-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.bot-credentials.outputs.app-token }}
           commit-message: |
-            chore: regenerate examples from go-swagger PR #${{ steps.check.outputs.pr_number }}
+            chore: regenerate examples from go-swagger PR #${{ steps.status.outputs.pr_number }}
 
-            Origin: go-swagger/go-swagger#${{ steps.check.outputs.pr_number }}
-          branch: regen/pr-${{ steps.check.outputs.pr_number }}
+            Origin: go-swagger/go-swagger#${{ steps.status.outputs.pr_number }}
+          branch: regen/pr-${{ steps.status.outputs.pr_number }}
           delete-branch: true
-          title: "chore: regen examples (go-swagger PR #${{ steps.check.outputs.pr_number }})"
+          title: "chore: regen examples (go-swagger PR #${{ steps.status.outputs.pr_number }})"
           body: |
-            Regenerated examples from go-swagger/go-swagger#${{ steps.check.outputs.pr_number }}
+            Regenerated examples from go-swagger/go-swagger#${{ steps.status.outputs.pr_number }}
 
-            Triggering PR: https://github.com/go-swagger/go-swagger/pull/${{ steps.check.outputs.pr_number }}
+            Triggering PR: https://github.com/go-swagger/go-swagger/pull/${{ steps.status.outputs.pr_number }}
           signoff: true
           sign-commits: true
       -
         name: Comment on go-swagger PR
-        if: ${{ steps.examples-pr.outputs.pull-request-url != '' }}
+        if: >-
+          ${{
+            steps.status.outputs.pr_number != '' &&
+            (steps.status.outputs.status == 'has-changes' ||
+             steps.status.outputs.status == 'no-changes')
+          }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.status.outputs.pr_number }}
+          STATUS: ${{ steps.status.outputs.status }}
+          EXAMPLES_PR_URL: ${{ steps.examples-pr.outputs.pull-request-url }}
         run: |
-          PR_NUMBER="${{ steps.check.outputs.pr_number }}"
-          DIFFSTAT=$(cat /tmp/regen-metadata/diffstat.txt)
-          COMMENT=$(cat <<CMTEOF
+          case "${STATUS}" in
+            no-changes)
+              COMMENT="**Examples regeneration:** ran, no changes detected in generated code."
+              ;;
+            has-changes)
+              DIFFSTAT=$(cat /tmp/regen-metadata/diffstat.txt)
+              COMMENT=$(cat <<CMTEOF
           **Examples regeneration:** changes detected.
 
-          Examples PR: ${{ steps.examples-pr.outputs.pull-request-url }}
+          Examples PR: ${EXAMPLES_PR_URL}
 
           <details>
           <summary>Diffstat</summary>
@@ -156,6 +173,9 @@ jobs:
 
           </details>
           CMTEOF
-          )
-          gh pr comment "${PR_NUMBER}" --body "${COMMENT}"
-
+              )
+              ;;
+          esac
+          gh pr comment "${PR_NUMBER}" \
+            --repo go-swagger/go-swagger \
+            --body "${COMMENT}"

--- a/.github/workflows/regen-examples.yaml
+++ b/.github/workflows/regen-examples.yaml
@@ -7,6 +7,16 @@
 # the resulting diff as an artifact. No secrets are used — untrusted
 # PR code runs in a sandboxed context.
 #
+# A single artifact "regen-examples" is always uploaded. It carries:
+#   - pr_number.txt  : the triggering PR number
+#   - status.txt     : one of "no-trigger", "no-changes", "has-changes"
+#   - regen.patch    : the diff (only when status is "has-changes")
+#   - diffstat.txt   : the diffstat (only when status is "has-changes")
+#
+# The "code-changed" job seeds the artifact with status="no-trigger" or
+# status="pending"; if the "regen" job runs, it overwrites the artifact
+# with the final status.
+#
 # Phase 2 (regen-examples-pr.yaml) picks up the artifact via workflow_run
 # and creates the examples PR with proper credentials.
 
@@ -33,21 +43,54 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       -
         name: Get changed source files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v4.7.0
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         id: changed-source-files
         with:
           files_yaml: |
             should_run_codegen:
-              - '**/go.(mod,sum)'
+              - '**/go.{mod,sum}'
               - 'cmd/**/*.go'
               - '!cmd/swagger/commands/generate/spec*.go'
               - '!cmd/swagger/commands/diff/*.go'
               - 'generator/**'
               - 'hack/codegen*.go'
               - 'hack/*.yaml'
-              - 'fixtures/**/*.(yaml,yml,json)'
+              - 'fixtures/**/*.{yaml,yml,json}'
               - '!fixtures/goparsing/**'
               - '!**/*.md'
+      -
+        name: Seed regen metadata artifact
+        env:
+          PROCEED: ${{ steps.changed-source-files.outputs.should_run_codegen_any_changed }}
+          MATCHED_FILES: ${{ steps.changed-source-files.outputs.should_run_codegen_all_changed_files }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p /tmp/regen-metadata
+          echo "${PR_NUMBER}" > /tmp/regen-metadata/pr_number.txt
+          if [[ "${PROCEED}" == 'true' ]]; then
+            echo "pending" > /tmp/regen-metadata/status.txt
+          else
+            echo "no-trigger" > /tmp/regen-metadata/status.txt
+          fi
+          {
+            echo "## Codegen change detection"
+            echo ""
+            echo "proceed_with_codegen=\`${PROCEED}\`"
+            echo ""
+            echo "Matched files:"
+            echo '```'
+            for f in ${MATCHED_FILES}; do
+              echo "${f}"
+            done
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+      -
+        name: Upload seed metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: regen-examples
+          path: /tmp/regen-metadata/
+          retention-days: 1
 
   regen:
     # description: |
@@ -102,27 +145,36 @@ jobs:
           # Stage everything so we catch new/deleted files
           git add -A
 
+          mkdir -p /tmp/regen-metadata
+          echo "${{ github.event.pull_request.number }}" > /tmp/regen-metadata/pr_number.txt
+
+          {
+            echo "## Regen diff"
+            echo ""
+          } >> "${GITHUB_STEP_SUMMARY}"
+
           if git diff --cached --quiet; then
+            echo "_no changes detected_" >> "${GITHUB_STEP_SUMMARY}"
+            echo "no-changes" > /tmp/regen-metadata/status.txt
             echo "has_changes=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
+
+          echo "has-changes" > /tmp/regen-metadata/status.txt
           echo "has_changes=true" >> "${GITHUB_OUTPUT}"
 
-          git diff --cached > /tmp/regen.patch
-          git diff --cached --stat > /tmp/diffstat.txt
-      -
-        name: Save PR metadata
-        if: ${{ steps.diff.outputs.has_changes == 'true' }}
-        run: |
-          mkdir -p /tmp/regen-metadata
-          cp /tmp/regen.patch /tmp/regen-metadata/
-          cp /tmp/diffstat.txt /tmp/regen-metadata/
-          echo "${{ github.event.pull_request.number }}" > /tmp/regen-metadata/pr_number.txt
+          git diff --cached --stat > /tmp/regen-metadata/diffstat.txt
+          git diff --cached > /tmp/regen-metadata/regen.patch
+          {
+            echo '```'
+            cat /tmp/regen-metadata/diffstat.txt
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
       -
         name: Upload regen artifacts
-        if: ${{ steps.diff.outputs.has_changes == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: regen-examples
           path: /tmp/regen-metadata/
           retention-days: 1
+          overwrite: true


### PR DESCRIPTION
The bot has stopped opening regen PRs against go-swagger/examples. Two root causes:

1. Broken glob patterns in the code-changed job (phase 1):
   - `**/go.(mod,sum)` and `fixtures/**/*.(yaml,yml,json)` use a `(a,b)` syntax that neither minimatch nor picomatch (the matchers used by tj-actions/changed-files) recognize as brace expansion. They match nothing, so PRs that only touch go.mod/go.sum or fixture specs never trigger regen. Switched to the standard `{mod,sum}` / `{yaml,yml,json}` brace syntax.

2. No status carried from phase 1 to phase 2 when no diff is produced. The previous design only uploaded an artifact when has_changes=true; phase 2 then printed "examples are up to date" indiscriminately for "regen skipped", "regen ran with no diff" and "regen ran with a diff that was lost". The triggering PR got no feedback either way.

   Phase 1 now always uploads a single `regen-examples` artifact with a `status.txt` of `no-trigger` / `no-changes` / `has-changes`. `code-changed` seeds it; `regen` overwrites it with the final state. Phase 2 reads the status and comments on the triggering PR for `no-changes` and `has-changes` (silent on `no-trigger` to avoid spamming docs-only PRs).

Also:
- Added `${GITHUB_STEP_SUMMARY}` diagnostics in both jobs so the run page tells the story even without artifacts.
- Fixed a latent bug in phase 2's `Comment on go-swagger PR` step: it was missing `--repo go-swagger/go-swagger`, so after `Checkout examples` the comment would have targeted the wrong repo.
- Corrected stale `# v4.7.0` comment on tj-actions/changed-files (the SHA is for v47.0.6).