### PR TITLE
ci: fix cross-workflow artifact download permission

### DIFF
--- a/.github/workflows/regen-examples-pr.yaml
+++ b/.github/workflows/regen-examples-pr.yaml
@@ -15,6 +15,7 @@ name: Regen examples PR
 
 permissions:
   contents: read
+  actions: read
 
 on:
   workflow_run:
@@ -72,6 +73,8 @@ jobs:
           name: regen-examples
           path: /tmp/regen-metadata
           run-id: ${{ github.event.workflow_run.id }}
+          repository: ${{ github.repository }}
+          github-token: ${{ github.token }}
         continue-on-error: true
       -
         name: Read regen status


### PR DESCRIPTION
When the phase 2 `regen-examples-pr` workflow (triggered by `workflow_run`) tries to download the artifact uploaded by phase 1 via `run-id`, `actions/download-artifact@v8` fails with "Artifact not found for name: regen-examples" — even though the artifact is visible in the run's UI.

The list-artifacts API call requires `actions: read` on the token that the action uses. Two changes are needed for this to work reliably:

1. Hoist `actions: read` to the workflow-level `permissions:` block. Setting it only at the job level is not enough — the `${{ github.token }}` default value of the action's `github-token` input is resolved at workflow scope and a job-level grant is not always propagated.

2. Pass `github-token: ${{ github.token }}` and `repository: ${{ github.repository }}` explicitly to the download step. The action's docs flag both as effectively required for cross-workflow-run downloads, despite the documented defaults.

With both in place, the API call to list the triggering run's artifacts returns the expected entry and the patch is downloaded correctly.