### PR TITLE
ci: checkout examples before configuring bot credentials

### DIFF
--- a/.github/workflows/regen-examples-pr.yaml
+++ b/.github/workflows/regen-examples-pr.yaml
@@ -94,6 +94,20 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
           echo "status=${STATUS}" >> "${GITHUB_OUTPUT}"
       -
+        name: Checkout examples
+        # NOTE: must run before "Configure bot credentials". The bot-credentials
+        # action delegates to crazy-max/ghaction-import-gpg, which runs
+        # `git config --local` for the signing key — that requires the working
+        # tree to already be a git repo. The default GITHUB_TOKEN is fine for
+        # the initial read (examples is public); the bot token is applied
+        # explicitly to `peter-evans/create-pull-request` below, which sets
+        # up its own push authentication.
+        if: ${{ steps.status.outputs.status == 'has-changes' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: go-swagger/examples
+          persist-credentials: false
+      -
         name: Configure bot credentials
         if: ${{ steps.status.outputs.status == 'has-changes' }}
         uses: go-openapi/gh-actions/ci-jobs/bot-credentials@70c5bbea429a7d10a082ac9efb83036da0c5b7d0 # v1.4.14
@@ -110,13 +124,6 @@ jobs:
           gpg-fingerprint: ${{ secrets.CI_BOT_SIGNING_KEY }}
           enable-commit-signing: "true"
           enable-tag-signing: "false"
-      -
-        name: Checkout examples
-        if: ${{ steps.status.outputs.status == 'has-changes' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: go-swagger/examples
-          token: ${{ steps.bot-credentials.outputs.app-token }}
       -
         name: Apply patch
         if: ${{ steps.status.outputs.status == 'has-changes' }}


### PR DESCRIPTION
The "Configure bot credentials" step delegates to
crazy-max/ghaction-import-gpg, which runs `git config --local` to set the signing key. That requires the working tree to already be a git repo, so the step fails with `fatal: not in a git directory` when no checkout has happened yet.

Swap the two steps so the examples repo is checked out first. The initial checkout uses the default GITHUB_TOKEN (sufficient for read access — examples is a public repo) and disables credential persistence, since the bot's app token is applied later, explicitly, to peter-evans/create-pull-request, which sets up its own push authentication.