### PR TITLE
ci: drop peter-evans sign-commits to avoid per-file API uploads

### DIFF
--- a/.github/workflows/regen-examples-pr.yaml
+++ b/.github/workflows/regen-examples-pr.yaml
@@ -148,7 +148,6 @@ jobs:
 
             Triggering PR: https://github.com/go-swagger/go-swagger/pull/${{ steps.status.outputs.pr_number }}
           signoff: true
-          sign-commits: true
       -
         name: Comment on go-swagger PR
         if: >-


### PR DESCRIPTION
`sign-commits: true` on peter-evans/create-pull-request makes the action create the commit through GitHub's REST API: every changed file is read via `git show`, uploaded as a blob, then assembled into a tree + commit. With ~hundreds of regenerated files in the examples diff, that's one round-trip per file and turns a sub-second step into a multi-minute one.

Drop the input (default is false). The action then commits locally via fast git plumbing — a single `git commit` + `git push`. The commit is still GPG-signed because the preceding bot-credentials step already configured `user.signingkey` and `commit.gpgsign true` in the working tree, so GitHub continues to display the commit as verified.