### PR TITLE
fix(codescan): upgraded codescan for swagger generate spec.

### DIFF
--- a/cmd/swagger/commands/generate/spec.go
+++ b/cmd/swagger/commands/generate/spec.go
@@ -38,6 +38,7 @@ type SpecFile struct {
 	SetXNullableForPointers bool           `description:"set x-nullable extension to true automatically for fields of pointer types without 'omitempty'" long:"nullable-pointers"           short:"n"`
 	RefAliases              bool           `description:"transform aliased types into $ref rather than expanding their definition"                       long:"ref-aliases"                 short:"r"`
 	TransparentAliases      bool           `description:"treat type aliases as completely transparent, never creating definitions for them"              long:"transparent-aliases"         short:""`
+	SkipExtensions          bool           `description:"skip generation of x-go-* go-swagger extensions"                                                long:"skip-extensions"             short:""`
 	DescWithRef             bool           `description:"allow descriptions to flow alongside $ref"                                                      long:"allow-desc-with-ref"         short:""`
 	Format                  string         `choice:"yaml"                                                                                                choice:"json"                      default:"json"  description:"the format for the spec document" long:"format"`
 }
@@ -58,21 +59,27 @@ func (s *SpecFile) Execute(args []string) error {
 		input = swspec
 	}
 
-	var opts codescan.Options
-	opts.Packages = args
-	opts.WorkDir = s.WorkDir
-	opts.InputSpec = input
-	opts.ScanModels = s.ScanModels
-	opts.BuildTags = s.BuildTags
-	opts.Include = s.Include
-	opts.Exclude = s.Exclude
-	opts.IncludeTags = s.IncludeTags
-	opts.ExcludeTags = s.ExcludeTags
-	opts.ExcludeDeps = s.ExcludeDeps
-	opts.SetXNullableForPointers = s.SetXNullableForPointers
-	opts.RefAliases = s.RefAliases
-	opts.TransparentAliases = s.TransparentAliases
-	opts.DescWithRef = s.DescWithRef
+	skipExt := s.SkipExtensions || os.Getenv("SWAGGER_GENERATE_EXTENSION") == "false"
+	debug := os.Getenv("DEBUG") != "" || os.Getenv("SWAGGER_DEBUG") != ""
+
+	opts := codescan.Options{
+		Packages:                args,
+		WorkDir:                 s.WorkDir,
+		InputSpec:               input,
+		ScanModels:              s.ScanModels,
+		BuildTags:               s.BuildTags,
+		Include:                 s.Include,
+		Exclude:                 s.Exclude,
+		IncludeTags:             s.IncludeTags,
+		ExcludeTags:             s.ExcludeTags,
+		ExcludeDeps:             s.ExcludeDeps,
+		SetXNullableForPointers: s.SetXNullableForPointers,
+		RefAliases:              s.RefAliases,
+		TransparentAliases:      s.TransparentAliases,
+		DescWithRef:             s.DescWithRef,
+		SkipExtensions:          skipExt,
+		Debug:                   debug,
+	}
 
 	swspec, err := codescan.Run(&opts)
 	if err != nil {

--- a/docs/generate-spec/_index.md
+++ b/docs/generate-spec/_index.md
@@ -14,11 +14,11 @@ Usage:
 generate a swagger spec document from a go application
 
 Application Options:
-  -q, --quiet                  silence logs
-      --log-output=LOG-FILE    redirect logs to file
+  -q, --quiet                       silence logs
+      --log-output=LOG-FILE         redirect logs to file
 
 Help Options:
-  -h, --help                   Show this help message
+  -h, --help                        Show this help message
 
 [spec command options]
       -w, --work-dir=               the base path to use (default: .)
@@ -35,6 +35,7 @@ Help Options:
       -n, --nullable-pointers       set x-nullable extension to true automatically for fields of pointer types without 'omitempty'
       -r, --ref-aliases             transform aliased types into $ref rather than expanding their definition
           --transparent-aliases     treat type aliases as completely transparent, never creating definitions for them
+          --skip-extensions         skip generation of x-go-* go-swagger extensions
           --allow-desc-with-ref     allow descriptions to flow alongside $ref
           --format=[yaml|json]      the format for the spec document (default: json)
 ```

--- a/docs/generate-spec/spec.md
+++ b/docs/generate-spec/spec.md
@@ -64,8 +64,11 @@ swagger generate spec -o ./swagger.yml
 If you don't want to generate Go language specific extensions in the spec file, you can disable them by doing
 
 ```sh
-SWAGGER_GENERATE_EXTENSION=false && swagger generate spec -o ./swagger.yml
+swagger generate spec --skip-extensions -o ./swagger.yml
 ```
+
+> NOTE: the previous setting using env var is deprecated but still supported, using:
+> `SWAGGER_GENERATE_EXTENSION=false`
 
 ## Parsing rules
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.1
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/go-openapi/analysis v0.25.0
-	github.com/go-openapi/codescan v0.33.3
+	github.com/go-openapi/codescan v0.34.0
 	github.com/go-openapi/errors v0.22.7
 	github.com/go-openapi/inflect v0.21.5
 	github.com/go-openapi/loads v0.23.3

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/go-openapi/analysis v0.25.0 h1:EnjAq1yO8wEO9HbPmY8vLPEIkdZuuFhCAKBPvC
 github.com/go-openapi/analysis v0.25.0/go.mod h1:5WFTRE43WLkPG9r9OtlMfqkkvUTYLVVCIxLlEpyF8kE=
 github.com/go-openapi/codescan v0.33.3 h1:1ybUbjR+uHi89WKpAc0jguloPdROcWldG2Ktk7Buqa4=
 github.com/go-openapi/codescan v0.33.3/go.mod h1:x55SpO1imFaDexCfFbVDyQtxV+mq6PY+UX8Hen8yIUk=
+github.com/go-openapi/codescan v0.34.0 h1:OgnK5YLYFLlSsO6On797Wx01+owSE69Q4Ww2KAuFwJY=
+github.com/go-openapi/codescan v0.34.0/go.mod h1:elA/HAvSRUSXGZuyb8CBIXjLu04N2ZsIBKcUb5tRPPg=
 github.com/go-openapi/errors v0.22.7 h1:JLFBGC0Apwdzw3484MmBqspjPbwa2SHvpDm0u5aGhUA=
 github.com/go-openapi/errors v0.22.7/go.mod h1://QW6SD9OsWtH6gHllUCddOXDL0tk0ZGNYHwsw4sW3w=
 github.com/go-openapi/inflect v0.21.5 h1:M2RCq6PPS3YbIaL7CXosGL3BbzAcmfBAT0nC3YfesZA=


### PR DESCRIPTION
This PR upgrades the spec generation package (codescan) to v0.34.0.

This release fixes a few quirks in spec generation and onboards.

* quirks fixed: see https://github.com/go-openapi/codescan/pull/18
* type array fix: https://github.com/go-openapi/codescan/pull/11

Additional command line argument `--skip-extensions`:
* supersedes the older way (yet still supported) of removing x-go-* go-swagger extensions from the generated spec.