### PR TITLE
fix(client): added operation with context to client interface.

### DIFF
--- a/generator/internal/funcmaps/golang/funcmap.go
+++ b/generator/internal/funcmaps/golang/funcmap.go
@@ -94,12 +94,17 @@ func FuncMap(mangler mangling.NameMangler) template.FuncMap {
 		"printGoLiteral": func(in any) string {
 			return interfaceReplacer.Replace(fmt.Sprintf("%#v", in))
 		},
+		"fold": func(in string) string {
+			return foldReplacer.Replace(in)
+		},
 	}
 
 	maps.Copy(f, extra)
 
 	return f
 }
+
+var foldReplacer = strings.NewReplacer("\n", " ", "\r", "")
 
 // pascalize converts a name to Go PascalCase, handling special prefix characters.
 func pascalize(mangler mangling.NameMangler) func(string) string {

--- a/generator/template_funcmap.go
+++ b/generator/template_funcmap.go
@@ -7,17 +7,6 @@ import (
 	"fmt"
 )
 
-/*
-// Package-level aliases for functions that moved to the golang funcmap package
-// but are still referenced from other files in the generator package.
-var (
-	pascalize   = golangfuncs.Pascalize
-	mediaMime   = golangfuncs.MediaMime
-	mediaGoName = golangfuncs.MediaGoName
-	asJSON      = golangfuncs.AsJSON
-)
-*/
-
 func resolvedDocCollectionFormat(cf string, child *GenItems) string {
 	if child == nil {
 		return cf

--- a/generator/templates/client/client.gotmpl
+++ b/generator/templates/client/client.gotmpl
@@ -118,7 +118,11 @@ func WithAccept{{ mediaGoName . }}(r *runtime.ClientOperation) {
 // ClientService is the interface for Client methods.
 type ClientService interface {
 	{{ range .Operations }}
+  {{ if or .Summary .Description }}// {{ pascalize .Name }}{{ if .Summary }} {{ humanize .Summary }}{{ else }} {{ fold .Description }}{{ end }}.{{ end }}
 	{{ pascalize .Name }}(params *{{ pascalize .Name }}Params{{ if .Authorized }}, authInfo runtime.ClientAuthInfoWriter{{end}}{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
+
+  {{ if or .Summary .Description }}// {{ pascalize .Name }}Context{{ if .Summary }} {{ humanize .Summary }}{{ else }} {{ fold .Description }}{{ end }}.{{ end }}
+	{{ pascalize .Name }}Context(ctx context.Context, params *{{ pascalize .Name }}Params{{ if .Authorized }}, authInfo runtime.ClientAuthInfoWriter{{end}}{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }}
 	{{ end }}
 
 	SetTransport(transport runtime.ContextualTransport)


### PR DESCRIPTION
Without a proper interface, the newly added context-aware methods are not usable.

* contributes #2997

Also: added doc strings to the interface definitions.

* fixes #2977