### PR TITLE
fix(client): moved internal fields in generated Params (timeout, Context) to their own struct.

### DIFF
--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -304,7 +304,7 @@ func TestGenClient_2471(t *testing.T) {
 	fixtureConfig := map[string][]string{
 		"client/operations/example_post_parameters.go": { // generated file
 			`func (o *ExamplePostParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {`,
-			`	if err := r.SetTimeout(o.timeout); err != nil {`,
+			`	if err := r.SetTimeout(o.inner.timeout); err != nil {`,
 			`	joinedFoo := o.bindParamFoo(reg)`,
 			`	if len(joinedFoo) > 0 {`,
 			`		if err := r.SetHeaderParam("Foo", joinedFoo[0]); err != nil {`,
@@ -371,8 +371,8 @@ func TestGenClient_2096(t *testing.T) {
 			`		fieldsDefault = []string{"first", "second", "third"}`,
 			`	val := ListResourcesParams{`,
 			`		Fields: fieldsDefault,`,
-			`	val.timeout = o.timeout`,
-			`	val.Context = o.Context`,
+			`	val.inner.timeout = o.inner.timeout`,
+			`	val.inner.ctx = o.inner.ctx`,
 			`	val.HTTPClient = o.HTTPClient`,
 			`	*o = val`,
 			`	joinedFields := o.bindParamFields(reg)`,
@@ -405,7 +405,7 @@ func TestGenClient_909_3(t *testing.T) {
 	fixtureConfig := map[string][]string{
 		"client/operations/get_optional_parameters.go": { // generated file
 			`func (o *GetOptionalParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {`,
-			`	if err := r.SetTimeout(o.timeout); err != nil {`,
+			`	if err := r.SetTimeout(o.inner.timeout); err != nil {`,
 			`	if o.IsAnOption2 != nil {`,
 			`		joinedIsAnOption2 := o.bindParamIsAnOption2(reg)`,
 			`		if err := r.SetQueryParam("isAnOption2", joinedIsAnOption2...); err != nil {`,

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -264,7 +264,7 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	var hasQueryParams, hasPathParams, hasHeaderParams, hasFormParams, hasFileParams, hasFormValueParams, hasBodyParams bool
 	paramsForOperation := b.Analyzed.ParamsFor(b.Method, b.Path)
 
-	idMapping, timeoutName := b.paramMappings(paramsForOperation)
+	idMapping, timeoutName, ctxName := b.paramMappings(paramsForOperation)
 
 	for _, p := range paramsForOperation {
 		cp, err := b.MakeParameter(receiver, resolver, p, idMapping)
@@ -447,7 +447,8 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 		Consumes:             operation.Consumes,   // for doc
 		ExtraSchemes:         extraSchemes,         // resolved schemes, for codegen
 		ExtraSchemeOverrides: originalExtraSchemes, // raw operation extra schemes, for doc
-		TimeoutName:          timeoutName,
+		TimeoutName:          timeoutName,          // deconflicted names for internal fields (and methods)
+		ContextName:          ctxName,
 		Extensions:           operation.Extensions,
 		StrictResponders:     b.GenOpts.StrictResponders,
 
@@ -877,7 +878,7 @@ func (b *codeGenOpBuilder) MakeBodyParameterItemsAndMaps(res *GenParameter, it *
 }
 
 // paramMappings yields a map of safe parameter names for an operation.
-func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[string]map[string]string, string) {
+func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[string]map[string]string, string, string) {
 	idMapping := map[string]map[string]string{
 		"query":    make(map[string]string, len(params)),
 		"path":     make(map[string]string, len(params)),
@@ -920,47 +921,65 @@ func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[
 	}
 
 	// pick a deconflicted private name for timeout for this operation
-	timeoutName := renameTimeout(seenIDs, timeoutVarNamePreferences[0], 0)
+	timeoutName := rename(timeoutVarNamePreferences)(seenIDs, timeoutVarNamePreferences[0], 0)
+	ctxName := rename(contextVarNamePreferences)(seenIDs, contextVarNamePreferences[0], 0)
 
-	return idMapping, timeoutName
+	return idMapping, timeoutName, ctxName
 }
 
-const timeoutName = "timeout"
+const (
+	timeoutName = "timeout"
+	contextName = "context"
+)
 
-var timeoutVarNamePreferences = []string{
-	timeoutName,
-	"requestTimeout",
-	"httpRequestTimeout",
-	"swaggerTimeout",
-	"operationTimeout",
-	"opTimeout",
-	"operTimeout",
-}
+var (
+	timeoutVarNamePreferences = []string{
+		timeoutName,
+		"requestTimeout",
+		"httpRequestTimeout",
+		"swaggerTimeout",
+		"operationTimeout",
+		"opTimeout",
+		"operTimeout",
+	}
 
-// renameTimeout renames the variable in use by client template to avoid conflicting
+	contextVarNamePreferences = []string{
+		contextName,
+		"requestContext",
+		"httpRequestContext",
+		"swaggerContext",
+		"operationContext",
+		"opContext",
+		"operContext",
+	}
+)
+
+// rename the variable in use by client template to avoid conflicting
 // with param names.
 //
 // NOTE: this merely protects the timeout field in the client parameter struct,
 // fields "Context" and "HTTPClient" remain exposed to name conflicts.
-func renameTimeout(seenIDs map[string]any, timeoutName string, index int) string {
-	if seenIDs == nil {
-		return timeoutName
-	}
+func rename(preferences []string) func(map[string]any, string, int) string {
+	return func(seenIDs map[string]any, previous string, index int) string {
+		if seenIDs == nil {
+			return previous
+		}
 
-	current := strings.ToLower(timeoutName)
-	if _, ok := seenIDs[current]; !ok {
-		return timeoutName
-	}
+		current := strings.ToLower(previous)
+		if _, ok := seenIDs[current]; !ok {
+			return previous
+		}
 
-	var next string
-	if index < len(timeoutVarNamePreferences)-1 {
-		index++
-		next = timeoutVarNamePreferences[index]
-	} else {
-		next = timeoutName + "1"
-	}
+		var next string
+		if index < len(preferences)-1 {
+			index++
+			next = preferences[index]
+		} else {
+			next = previous + "1"
+		}
 
-	return renameTimeout(seenIDs, next, index)
+		return rename(preferences)(seenIDs, next, index)
+	}
 }
 
 func producesOrDefault(produces []string, fallback []string, defaultProduces string) []string {

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -1426,6 +1426,7 @@ func TestRenameTimeout(t *testing.T) {
 	for idx, toPin := range makeClientTimeoutNameTest() {
 		i := idx
 		testCase := toPin
+		renameTimeout := rename(timeoutVarNamePreferences)
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			assert.EqualTf(t, testCase.expected, renameTimeout(testCase.seenIDs, testCase.name, 0), "unexpected deconflicting value [%d]", i)
@@ -1445,7 +1446,7 @@ func TestParamMappings(t *testing.T) {
 	opts := opts()
 	builder := codeGenOpBuilder{GenOpts: opts}
 	// Test deconfliction of duplicate param names across param locations
-	mappings, _ := builder.paramMappings(testInvalidParams())
+	mappings, _, _ := builder.paramMappings(testInvalidParams())
 	require.MapContainsT(t, mappings, "query")
 	require.MapContainsT(t, mappings, "path")
 	require.MapContainsT(t, mappings, "body")

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -645,6 +645,7 @@ type GenOperation struct {
 	ProducesMediaTypes   []string
 	ConsumesMediaTypes   []string
 	TimeoutName          string
+	ContextName          string
 
 	Extensions map[string]any
 

--- a/generator/templates/client/client.gotmpl
+++ b/generator/templates/client/client.gotmpl
@@ -11,6 +11,7 @@ import (
   "fmt"
   "io"
   "net/http"
+  "time"
 
   "github.com/go-openapi/errors"
   "github.com/go-openapi/runtime"
@@ -149,8 +150,8 @@ type ClientService interface {
 */
 func (a *Client) {{ pascalize .Name }}(params *{{ pascalize .Name }}Params{{ if .Authorized }}, authInfo runtime.ClientAuthInfoWriter{{end}}{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}, opts ...ClientOption) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
   var ctx context.Context
-  if params.Context != nil {
-    ctx = params.Context
+  if params.inner.ctx != nil {
+    ctx = params.inner.ctx
   } else {
     ctx = context.Background()
   }
@@ -260,4 +261,12 @@ func (a *Client) {{ pascalize .Name }}Context(ctx context.Context, params *{{ pa
 // SetTransport changes the transport on the client
 func (a *Client) SetTransport(transport runtime.ContextualTransport) {
   a.transport = transport
+}
+
+// innerParams captures internal fields so they don't conflict with user-supplied parameters.
+type innerParams struct {
+  timeout time.Duration
+
+  // Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params].
+  ctx context.Context
 }

--- a/generator/templates/client/parameter.gotmpl
+++ b/generator/templates/client/parameter.gotmpl
@@ -32,26 +32,28 @@ import (
 //
 // To enforce default values in parameter, use SetDefaults or WithDefaults.
 func New{{ pascalize .Name }}Params() *{{ pascalize .Name }}Params {
-  return &{{ pascalize .Name}}Params{
-    {{ camelize .TimeoutName }}: cr.DefaultTimeout,
-  }
+  return New{{ pascalize .Name }}ParamsWithTimeout(cr.DefaultTimeout)
 }
 
 // New{{ pascalize .Name }}ParamsWithTimeout creates a new {{ pascalize .Name }}Params object
 // with the ability to set a timeout on a request.
 func New{{ pascalize .Name }}ParamsWithTimeout(timeout time.Duration) *{{ pascalize .Name }}Params {
   return &{{ pascalize .Name}}Params{
-    {{ camelize .TimeoutName }}: timeout,
+    inner: innerParams{
+      timeout: timeout,
+    },
   }
 }
 
 // New{{ pascalize .Name }}ParamsWithContext creates a new {{ pascalize .Name }}Params object
 // with the ability to set a context for a request.
 //
-// Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params]
+// Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params].
 func New{{ pascalize .Name }}ParamsWithContext(ctx context.Context) *{{ pascalize .Name }}Params {
   return &{{ pascalize .Name}}Params{
-    Context: ctx,
+    inner: innerParams{
+      ctx: ctx,
+    },
   }
 }
 
@@ -101,11 +103,9 @@ type {{ pascalize .Name }}Params struct {
     {{ pascalize .ID }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}
   {{- end }}
 
-  {{ camelize .TimeoutName }} time.Duration
-
-  // Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params]
-  Context context.Context
   HTTPClient *http.Client
+
+  inner innerParams
 }
 
 // WithDefaults hydrates default values in the {{ humanize .Name }} params (not the query body).
@@ -148,8 +148,8 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) SetDefaults() {
   {{- end }}
   }
 
-  val.{{ camelize .TimeoutName }} = {{ .ReceiverName }}.{{ camelize .TimeoutName }}
-  val.Context = {{ .ReceiverName }}.Context
+  val.inner.timeout = {{ .ReceiverName }}.inner.timeout
+  val.inner.ctx= {{ .ReceiverName }}.inner.ctx
   val.HTTPClient = {{ .ReceiverName }}.HTTPClient
   *{{ .ReceiverName }} = val
 {{- else }}
@@ -157,61 +157,60 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) SetDefaults() {
 {{- end }}
 }
 
-// With{{ pascalize .TimeoutName }} adds the timeout to the {{ humanize .Name }} params
+// With{{ pascalize .TimeoutName }} adds the timeout to the {{ humanize .Name }} params.
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) With{{ pascalize .TimeoutName }}(timeout time.Duration) *{{ pascalize .Name }}Params {
   {{ .ReceiverName }}.Set{{ pascalize .TimeoutName }}(timeout)
   return {{ .ReceiverName }}
 }
 
-// Set{{ pascalize .TimeoutName }} adds the timeout to the {{ humanize .Name }} params
+// Set{{ pascalize .TimeoutName }} adds the timeout to the {{ humanize .Name }} params.
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) Set{{ pascalize .TimeoutName }}(timeout time.Duration) {
-  {{ .ReceiverName }}.{{ camelize .TimeoutName }} = timeout
+  {{ .ReceiverName }}.inner.timeout = timeout
 }
 
-// WithContext adds the context to the {{ humanize .Name }} params
+// With{{ pascalize .ContextName }} adds the context to the {{ humanize .Name }} params.
 //
-// Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params]
-func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) WithContext(ctx context.Context) *{{ pascalize .Name }}Params {
-  {{ .ReceiverName }}.SetContext(ctx)
+// Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params].
+func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) With{{ pascalize .ContextName }}(ctx context.Context) *{{ pascalize .Name }}Params {
+  {{ .ReceiverName }}.Set{{ pascalize .ContextName }}(ctx)
   return {{ .ReceiverName }}
 }
 
-// SetContext adds the context to the {{ humanize .Name }} params
+// Set{{ pascalize .ContextName }} adds the context to the {{ humanize .Name }} params.
 //
-// Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params]
-func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) SetContext(ctx context.Context) {
-  {{ .ReceiverName }}.Context = ctx
+// Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params].
+func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) Set{{ pascalize .ContextName }}(ctx context.Context) {
+  {{ .ReceiverName }}.inner.ctx = ctx
 }
 
-// WithHTTPClient adds the HTTPClient to the {{ humanize .Name }} params
+// WithHTTPClient adds the HTTPClient to the {{ humanize .Name }} params.
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) WithHTTPClient(client *http.Client) *{{ pascalize .Name }}Params {
   {{ .ReceiverName }}.SetHTTPClient(client)
   return {{ .ReceiverName }}
 }
 
-// SetHTTPClient adds the HTTPClient to the {{ humanize .Name }} params
+// SetHTTPClient adds the HTTPClient to the {{ humanize .Name }} params.
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) SetHTTPClient(client *http.Client) {
   {{ .ReceiverName }}.HTTPClient = client
 }
 
 {{- range .Params }}
 
-// With{{ pascalize .ID }} adds the {{ varname .Name  }} to the {{ humanize $.Name }} params
+// With{{ pascalize .ID }} adds the {{ varname .Name  }} to the {{ humanize $.Name }} params.
 func ({{ $.ReceiverName }} *{{ pascalize $.Name }}Params) With{{ pascalize .ID }}({{ varname .Name  }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}) *{{ pascalize $.Name }}Params {
   {{ $.ReceiverName }}.Set{{ pascalize .ID }}({{ varname .Name  }})
   return {{ .ReceiverName }}
 }
 
-// Set{{ pascalize .ID }} adds the {{ camelize .Name  }} to the {{ humanize $.Name }} params
+// Set{{ pascalize .ID }} adds the {{ camelize .Name  }} to the {{ humanize $.Name }} params.
 func ({{ $.ReceiverName }} *{{ pascalize $.Name }}Params) Set{{ pascalize .ID }}({{ varname .Name  }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}) {
   {{ $.ReceiverName }}.{{ pascalize .ID }} = {{ varname .Name  }}
 }
 {{- end }}
 
-// WriteToRequest writes these params to a swagger request
+// WriteToRequest writes these params to a [runtime.ClientRequest].
 func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
-
-  if err := r.SetTimeout({{ .ReceiverName }}.{{ camelize .TimeoutName }}); err != nil {
+  if err := r.SetTimeout({{ .ReceiverName }}.inner.timeout); err != nil {
     return err
   }
   var res []error
@@ -374,7 +373,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) WriteToRequest(r runtime
 
 {{- range .Params }}
   {{- if and (not .IsBodyParam) (not .IsFileParam) .IsArray }}
-// bindParam{{ pascalize $.Name }} binds the parameter {{ .Name }}
+// bindParam{{ pascalize $.Name }} binds the parameter {{ .Name }}.
 func ({{ .ReceiverName }} *{{ pascalize $.Name }}Params) bindParam{{ pascalize .Name }}(formats strfmt.Registry) []string {
   {{ varname .Child.ValueExpression }}R := {{ if and (not .IsArray) (not .IsStream) (not .IsMap) (.IsNullable) }}*{{end}}{{ .ValueExpression }}
 

--- a/generator/templates/contrib/stratoscale/client/client.gotmpl
+++ b/generator/templates/contrib/stratoscale/client/client.gotmpl
@@ -7,20 +7,23 @@
 package {{ .Name }}
 
 import (
+  "context"
   "fmt"
+  "io"
   "net/http"
+  "time"
 
   "github.com/go-openapi/errors"
   "github.com/go-openapi/runtime"
+  "github.com/go-openapi/strfmt"
   "github.com/go-openapi/validate"
-  strfmt "github.com/go-openapi/strfmt"
   {{ imports .DefaultImports }}
   {{ imports .Imports }}
 )
 
 //go:generate mockery --name API --keeptree --with-expecter --case underscore
 
-// API is the interface of the {{ humanize .Name }} client
+// API is the interface of the {{ humanize .Name }} client.
 type API interface {
 {{ range .Operations -}}
 /*
@@ -33,7 +36,7 @@ type API interface {
 }
 
 // New creates a new {{ humanize .Name }} API client.
-func New(transport runtime.ClientTransport, formats strfmt.Registry, authInfo runtime.ClientAuthInfoWriter) *Client {
+func New(transport runtime.ContextualTransport, formats strfmt.Registry, authInfo runtime.ClientAuthInfoWriter) *Client {
   return &Client{
     transport: transport,
     formats: formats,
@@ -47,21 +50,21 @@ Client {{ if .Summary }}{{ .Summary }}{{ if .Description }}
 {{ blockcomment .Description }}{{ end }}{{ else if .Description}}{{ blockcomment .Description }}{{ else }}for {{ humanize .Name }} API{{ end }}
 */
 type Client struct {
-  transport runtime.ClientTransport
+  transport runtime.ContextualTransport
   formats strfmt.Registry
   authInfo runtime.ClientAuthInfoWriter
 }
 
 {{ range .Operations -}}
 /*
-{{ pascalize .Name }} {{ if .Summary }}{{ pluralizeFirstWord (humanize .Summary) }}{{ if .Description }}
+{{ pascalize .Name }} {{ if .Summary }}{{ pluralizeFirstWord (humanize .Summary) }}.{{ if .Description }}
 
-{{ blockcomment .Description }}{{ end }}{{ else if .Description}}{{ blockcomment .Description }}{{ else }}{{ humanize .Name }} API{{ end }}
+{{ blockcomment .Description }}.{{ end }}{{ else if .Description}}{{ blockcomment .Description }}.{{ else }}{{ humanize .Name }} API.{{ end }}
 */
 func (a *Client) {{ pascalize .Name }}(ctx context.Context, params *{{ pascalize .Name }}Params{{ if .HasStreamingResponse }}, writer io.Writer{{ end }}) {{ if .SuccessResponse }}({{ range .SuccessResponses }}*{{ pascalize .Name }}, {{ end }}{{ end }}error{{ if .SuccessResponse }}){{ end }} {
   {{- $length := len .SuccessResponses }}
   {{- $success := .SuccessResponses }}
-  {{ if .Responses }}result{{else}}_{{end}}, err := a.transport.Submit(&runtime.ClientOperation{
+  {{ if .Responses }}result{{else}}_{{end}}, err := a.transport.SubmitContext(ctx, &runtime.ClientOperation{
     ID: {{ printf "%q" .Name }},
     Method: {{ printf "%q" .Method }},
     PathPattern: {{ printf "%q" .Path }},
@@ -73,7 +76,6 @@ func (a *Client) {{ pascalize .Name }}(ctx context.Context, params *{{ pascalize
     {{ if .Authorized -}}
     AuthInfo: a.authInfo,
     {{ end -}}
-    Context: ctx,
     Client:  params.HTTPClient,
   })
   if err != nil {
@@ -106,7 +108,7 @@ func (a *Client) {{ pascalize .Name }}(ctx context.Context, params *{{ pascalize
   // unexpected response.
     {{- if .DefaultResponse }}
   //
-  // a default response is provided: fill this and return an error
+  // a default response is provided: fill this and return an error.
   unexpectedSuccess := result.(*{{ pascalize .DefaultResponse.Name }})
 
   return {{ if $success }}{{ padSurround "nil" "nil" 0 $length }}, {{ end }}runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
@@ -114,7 +116,7 @@ func (a *Client) {{ pascalize .Name }}(ctx context.Context, params *{{ pascalize
 
   // no default response is defined.
   //
-  // safeguard: normally, in the absence of a default response, unknown responses return an error above: so this is a codegen issue
+  // safeguard: normally, in the absence of a default response, unknown responses return an error above: so this is a codegen issue.
   msg := fmt.Sprintf("unexpected success response for {{ .Name }}: API contract not enforced by server. Client expected to get an error, but got: %T", result)
   panic(msg)
     {{- end }}
@@ -123,3 +125,11 @@ func (a *Client) {{ pascalize .Name }}(ctx context.Context, params *{{ pascalize
   {{- end }}
 }
 {{ end }}
+
+// innerParams captures internal fields so they don't conflict with user-supplied parameters.
+type innerParams struct {
+  timeout time.Duration
+
+  // Deprecated: use the operation call with context to pass the context instead of [{{ pascalize .Name }}Params].
+  ctx context.Context
+}

--- a/generator/templates/contrib/stratoscale/client/facade.gotmpl
+++ b/generator/templates/contrib/stratoscale/client/facade.gotmpl
@@ -20,23 +20,21 @@ import (
 )
 
 const (
-	// DefaultHost is the default Host
-	// found in Meta (info) section of spec file
+	// DefaultHost is the default Host found in Meta (info) section of spec file.
 	DefaultHost string = {{ printGoLiteral .Host }}
-	// DefaultBasePath is the default BasePath
-	// found in Meta (info) section of spec file
+	// DefaultBasePath is the default BasePath found in Meta (info) section of spec file.
 	DefaultBasePath string = {{ printGoLiteral .BasePath }}
 )
 
-// DefaultSchemes are the default schemes found in Meta (info) section of spec file
+// DefaultSchemes are the default schemes found in Meta (info) section of spec file.
 var DefaultSchemes = {{ printGoLiteral .Schemes }}
 
 type Config struct {
-	// URL is the base URL of the upstream server
+	// URL is the base URL of the upstream server.
 	URL *url.URL
-	// Transport is an inner transport for the client
+	// Transport is an inner transport for the client.
 	Transport http.RoundTripper
-	// AuthInfo is for authentication
+	// AuthInfo is for authentication.
 	AuthInfo  runtime.ClientAuthInfoWriter
 }
 
@@ -68,7 +66,7 @@ func New(c Config) *{{ pascalize .Name }} {
 	return cli
 }
 
-// {{ pascalize .Name }} is a client for {{ humanize .Name }}
+// {{ pascalize .Name }} is a client for {{ humanize .Name }}.
 type {{ pascalize .Name }} struct {
 	{{ range .OperationGroups -}}
 	  {{ pascalize .Name }} {{ .PackageAlias }}.API


### PR DESCRIPTION
This move prevents user-supplied parameters from conflicting with internal parameters.

We leverage the deprecation of context-in-struct for client parameters to unexport it.

**Caution**: this is a (tolerable) breaking change as the context is no longer exported. Well-behaving client applications that used the provided setter methods (SetContext or WithContext) remain unaffected: only direct field access to the context won't compile any longer.

We've have left the HTTPClient field in the main structure, as it is less likely to produce name conflicts and more likely to be set directly in the struct.

* fixes #2997 (second part: name conflicts on parameters)

==================================

stratoscale client template has been adapted to use the new context-aware request SubmitContext method and the runtime.ContextualTransport interface. Its generated interface has not been affected, since this client was already using context as a parameter. Now it is no longer using the context-in-struct.

Follow-up: in a follow-up PR, we'll simplify the complicated and fragile name deconflicting in codegen for the timeout field.