### PR TITLE
fix(generator): fixed initialism issue (#3319)

### DIFF
--- a/fixtures/bugs/3319/3319.yaml
+++ b/fixtures/bugs/3319/3319.yaml
@@ -1,0 +1,38 @@
+swagger: "2.0"
+info:
+  title: Test x-go-name
+  version: 1.4.0
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: bla bla
+          schema:
+            $ref: "#/definitions/response"
+    post:
+      parameters:
+        - name: backend_tls_skip_verify
+          in: query
+          type: boolean
+          x-go-name: NoTls
+      responses:
+        200:
+          description: ok
+definitions:
+  response:
+    type: object
+    required:
+      - backendTlsSkipVerify
+    properties:
+      backendTlsSkipVerify:
+        type: boolean
+        x-go-name: NoTls
+      vmId:
+        type: string
+        x-go-name: VmId
+      recordId:
+        type: integer
+        x-go-name: ID
+      plain_tls_flag:
+        type: boolean

--- a/generator/model.go
+++ b/generator/model.go
@@ -546,7 +546,7 @@ func (sg *schemaGenContext) NewAdditionalItems(schema *spec.Schema) *schemaGenCo
 		pg.Path = pg.Path + "+ \".\" + strconv.Itoa(" + indexVar + mod + ")"
 	}
 	pg.IndexVar = indexVar
-	pg.ValueExpr = sg.ValueExpr + "." + sg.pascalize(sg.GoName()) + "Items[" + indexVar + "]"
+	pg.ValueExpr = sg.ValueExpr + "." + sg.GenSchema.GoName + "Items[" + indexVar + "]"
 	pg.Schema = spec.Schema{}
 	if schema != nil {
 		pg.Schema = *schema
@@ -582,7 +582,7 @@ func (sg *schemaGenContext) NewStructBranch(name string, schema spec.Schema) *sc
 		pg.Path = pg.Path + "+\".\"+" + fmt.Sprintf("%q", name)
 	}
 	pg.Name = name
-	pg.ValueExpr = pg.ValueExpr + "." + sg.pascalize(goName(&schema, name))
+	pg.ValueExpr = pg.ValueExpr + "." + schemaGoName(&schema, name, sg.mangler)
 	pg.Schema = schema
 	pg.IsProperty = true
 	if slices.Contains(sg.Schema.Required, name) {
@@ -957,7 +957,7 @@ func (sg *schemaGenContext) buildAllOf() error {
 		}
 		if comprop.GenSchema.IsMap && comprop.GenSchema.HasAdditionalProperties && comprop.GenSchema.AdditionalProperties != nil && !comprop.GenSchema.IsInterface {
 			// the anonymous branch is a map for AdditionalProperties: rewrite value expression
-			comprop.GenSchema.ValueExpression = comprop.GenSchema.ValueExpression + "." + comprop.Name
+			comprop.GenSchema.ValueExpression = comprop.GenSchema.ValueExpression + "." + comprop.GenSchema.GoName
 			comprop.GenSchema.AdditionalProperties.ValueExpression = comprop.GenSchema.ValueExpression + "[" + comprop.GenSchema.AdditionalProperties.KeyVar + "]"
 		}
 
@@ -1068,11 +1068,11 @@ func (sg *schemaGenContext) buildAdditionalProperties() error {
 			comprop.GenSchema.Required = true
 			comprop.GenSchema.HasValidations = true
 
-			comprop.GenSchema.ValueExpression = sg.GenSchema.ValueExpression + "." + sg.mangler.ToGoName(sg.GenSchema.Name) + "[" + comprop.KeyVar + "]"
+			comprop.GenSchema.ValueExpression = sg.GenSchema.ValueExpression + "." + sg.GenSchema.GoName + "[" + comprop.KeyVar + "]"
 
 			sg.GenSchema.AdditionalProperties = &comprop.GenSchema
 			sg.GenSchema.HasAdditionalProperties = true
-			sg.GenSchema.ValueExpression += "." + sg.mangler.ToGoName(sg.GenSchema.Name)
+			sg.GenSchema.ValueExpression += "." + sg.GenSchema.GoName
 
 			sg.MergeResult(comprop, false)
 
@@ -1080,7 +1080,7 @@ func (sg *schemaGenContext) buildAdditionalProperties() error {
 		}
 
 		// this is a regular named schema for AdditionalProperties
-		sg.GenSchema.ValueExpression += "." + sg.mangler.ToGoName(sg.GenSchema.Name)
+		sg.GenSchema.ValueExpression += "." + sg.GenSchema.GoName
 		comprop := sg.NewAdditionalProperty(*addp.Schema)
 		d := sg.TypeResolver.Doc
 		asch, err := analysis.Schema(analysis.SchemaOpts{
@@ -1337,6 +1337,7 @@ func (sg *schemaGenContext) buildItems() error {
 			sg.MergeResult(elProp, false)
 
 			elProp.GenSchema.Name = "p" + strconv.Itoa(i)
+			elProp.GenSchema.GoName = exportGoName("P"+strconv.Itoa(i), false, sg.mangler)
 			sg.GenSchema.Properties = append(sg.GenSchema.Properties, elProp.GenSchema)
 			sg.GenSchema.IsTuple = true
 		}
@@ -1735,7 +1736,6 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	sg.GenSchema.Path = sg.Path
 	sg.GenSchema.IndexVar = sg.IndexVar
 	sg.GenSchema.Location = body
-	sg.GenSchema.ValueExpression = sg.ValueExpr
 	sg.GenSchema.KeyVar = sg.KeyVar
 	sg.GenSchema.OriginalName = sg.Name
 	sg.GenSchema.Name = sg.GoName()
@@ -1753,6 +1753,8 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	sg.GenSchema.WantsRootedErrorPath = sg.WantsRootedErrorPath
 	sg.GenSchema.IsElem = sg.IsElem
 	sg.GenSchema.IsProperty = sg.IsProperty
+	sg.GenSchema.GoName = schemaGoName(&sg.Schema, sg.Name, sg.mangler)
+	sg.GenSchema.ValueExpression = sg.ValueExpr
 
 	var err error
 	returns, err := sg.shortCircuitNamedRef()

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -146,6 +146,7 @@ func TestGenerateModel_SchemaField(t *testing.T) {
 
 	var gmp GenSchema
 	gmp.Name = "some name"
+	gmp.GoName = exportGoName("some name", false, opts.LanguageOpts.Mangler)
 	gmp.OriginalName = "some name"
 	gmp.resolvedType = resolvedType{GoType: "string", IsPrimitive: true, IsEmptyOmitted: true}
 	gmp.Title = "The title of the property"
@@ -267,6 +268,7 @@ func TestGenerateModel_Primitives(t *testing.T) {
 			continue
 		}
 		val.Name = "theType"
+		val.GoName = exportGoName("theType", false, opts.LanguageOpts.Mangler)
 		exp := v.Expected
 		if val.IsInterface || val.IsStream {
 			tt.assertRender(&val, "type TheType "+exp+"\n  \n")
@@ -403,6 +405,80 @@ func TestGenerateModel_NotaWithMeta(t *testing.T) {
 	assertInCode(t, "type NotaWithMetaAnon struct {", res)
 	assertInCode(t, "Comment *string `json:\"comment\"`", res)
 	assertInCode(t, "Count int32 `json:\"count,omitempty\"`", res)
+}
+
+func TestGenerateModel_XGoNamePreserveExplicitCasing(t *testing.T) {
+	specDoc, err := loads.Spec("../fixtures/bugs/3319/3319.yaml")
+	require.NoError(t, err)
+
+	definitions := specDoc.Spec().Definitions
+	const k = "response"
+	schema := definitions[k]
+	opts := opts()
+	genModel, err := makeGenDefinition(k, "models", schema, specDoc, opts)
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, opts.templates.MustGet("model").Execute(buf, genModel))
+
+	ff, err := opts.LanguageOpts.FormatContent("response.go", buf.Bytes())
+	require.NoError(t, err)
+
+	res := string(ff)
+	assertInCode(t, `NoTls *bool`, res)
+	assertNotInCode(t, `NoTLS *bool`, res)
+	assertInCode(t, `json:"backendTlsSkipVerify`, res)
+	assertInCode(t, `VmId string`, res)
+	assertInCode(t, `json:"vmId`, res)
+	assertInCode(t, `ID int64`, res) // or int32, depending on format
+	assertNotInCode(t, `VMID string`, res)
+	assertInCode(t, `validateNoTls`, res)
+	assertNotInCode(t, `validateNoTLS`, res)
+	// implicit property without x-go-name still uses normal initialism mangling
+	assertInCode(t, `PlainTLSFlag bool`, res)
+	assertInCode(t, `json:"plain_tls_flag`, res)
+}
+
+func TestGenParameter_XGoNamePreserveExplicitCasing(t *testing.T) {
+	b, err := methodPathOpBuilder("post", "/test", "../fixtures/bugs/3319/3319.yaml")
+	require.NoError(t, err)
+
+	op, err := b.MakeOperation()
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(nil)
+	opts := opts()
+	require.NoError(t, opts.templates.MustGet("serverParameter").Execute(buf, op))
+
+	ff, err := opts.LanguageOpts.FormatContent("post_test_parameters.go", buf.Bytes())
+	require.NoError(t, err)
+
+	res := string(ff)
+	assertInCode(t, `NoTls *bool`, res)
+	assertNotInCode(t, `NoTLS *bool`, res)
+	assertInCode(t, `bindNoTls(`, res)
+	assertNotInCode(t, `bindNoTLS(`, res)
+}
+
+func TestGenClientParameter_XGoNamePreserveExplicitCasing(t *testing.T) {
+	b, err := methodPathOpBuilder("post", "/test", "../fixtures/bugs/3319/3319.yaml")
+	require.NoError(t, err)
+
+	op, err := b.MakeOperation()
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(nil)
+	opts := opts()
+	require.NoError(t, opts.templates.MustGet("clientParameter").Execute(buf, op))
+
+	ff, err := opts.LanguageOpts.FormatContent("post_test_parameters.go", buf.Bytes())
+	require.NoError(t, err)
+
+	res := string(ff)
+	assertInCode(t, `NoTls *bool`, res)
+	assertNotInCode(t, `NoTLS *bool`, res)
+	assertInCode(t, `WithNoTls(`, res)
+	assertNotInCode(t, `WithNoTLS(`, res)
 }
 
 func TestGenerateModel_RunParameters(t *testing.T) {

--- a/generator/name.go
+++ b/generator/name.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+package generator
+
+import (
+	"fmt"
+	"unicode"
+
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/swag/mangling"
+
+	golangfuncs "github.com/go-swagger/go-swagger/generator/internal/funcmaps/golang"
+)
+
+// exportGoName returns the Go identifier to emit in generated code.
+func exportGoName(rawName string, explicit bool, mangler mangling.NameMangler) string {
+	if rawName == "" {
+		return "Empty"
+	}
+	if explicit {
+		runes := []rune(rawName)
+		switch runes[0] {
+		case '+', '-', '#', '_', '*', '/', '=':
+			return golangfuncs.PrefixForName(rawName)
+		}
+		runes[0] = unicode.ToUpper(runes[0])
+		return string(runes)
+	}
+	// Double ToGoName matches legacy behavior.
+	return mangler.ToGoName(mangler.ToGoName(rawName))
+}
+
+func schemaGoName(sch *spec.Schema, fallback string, mangler mangling.NameMangler) string {
+	return extensionGoName(sch.Extensions, fallback, mangler)
+}
+
+// extensionGoName returns the exported Go identifier for an object that may carry x-go-name.
+// When x-go-name is present but invalid, the fallback is mangled normally (no error).
+func extensionGoName(ext spec.Extensions, fallback string, mangler mangling.NameMangler) string {
+	name, err := extensionGoNameOrError(ext, fallback, mangler)
+	if err != nil {
+		return exportGoName(fallback, false, mangler)
+	}
+	return name
+}
+
+func extensionGoNameOrError(ext spec.Extensions, fallback string, mangler mangling.NameMangler) (string, error) {
+	if raw, exists := ext[xGoName]; exists {
+		gn, ok := raw.(string)
+		if !ok {
+			return "", fmt.Errorf(`"x-go-name" field must be a string, not a %T`, raw)
+		}
+		return exportGoName(gn, true, mangler), nil
+	}
+	return exportGoName(fallback, false, mangler), nil
+}

--- a/generator/name_test.go
+++ b/generator/name_test.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/swag/mangling"
+	"github.com/go-openapi/testify/v2/assert"
+	"github.com/go-openapi/testify/v2/require"
+
+	golangfuncs "github.com/go-swagger/go-swagger/generator/internal/funcmaps/golang"
+)
+
+func testNameMangler() mangling.NameMangler {
+	return mangling.NewNameMangler(
+		mangling.WithGoNamePrefixFunc(golangfuncs.PrefixForName),
+	)
+}
+
+func TestExportGoName_Explicit(t *testing.T) {
+	t.Parallel()
+
+	mangler := testNameMangler()
+
+	cases := []struct {
+		name     string
+		raw      string
+		explicit bool
+		want     string
+	}{
+		{
+			name:     "preserves intentional casing from x-go-name",
+			raw:      "NoTls",
+			explicit: true,
+			want:     "NoTls",
+		},
+		{
+			name:     "exports lowercase explicit name without initialism rewrite",
+			raw:      "noTls",
+			explicit: true,
+			want:     "NoTls",
+		},
+		{
+			name:     "preserves VmId",
+			raw:      "VmId",
+			explicit: true,
+			want:     "VmId",
+		},
+		{
+			name:     "preserves all-caps explicit acronym",
+			raw:      "ID",
+			explicit: true,
+			want:     "ID",
+		},
+		{
+			name:     "empty raw name becomes Empty",
+			raw:      "",
+			explicit: true,
+			want:     "Empty",
+		},
+		{
+			name:     "special prefix uses PrefixForName",
+			raw:      "-myField",
+			explicit: true,
+			want:     golangfuncs.PrefixForName("-myField"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := exportGoName(tc.raw, tc.explicit, mangler)
+			assert.EqualT(t, tc.want, got)
+		})
+	}
+}
+
+func TestExportGoName_Implicit(t *testing.T) {
+	t.Parallel()
+
+	mangler := testNameMangler()
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{name: "swagger property key", raw: "backend_tls_skip_verify"},
+		{name: "camelCase property key", raw: "vmId"},
+		{name: "snake_case property key", raw: "record_id"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			want := mangler.ToGoName(mangler.ToGoName(tc.raw))
+			got := exportGoName(tc.raw, false, mangler)
+			assert.EqualT(t, want, got)
+		})
+	}
+}
+
+func TestSchemaGoName(t *testing.T) {
+	t.Parallel()
+
+	mangler := testNameMangler()
+
+	cases := []struct {
+		name     string
+		fallback string
+		schema   func() *spec.Schema
+		want     string
+	}{
+		{
+			name:     "x-go-name overrides fallback and skips initialisms",
+			fallback: "backendTlsSkipVerify",
+			schema: func() *spec.Schema {
+				sch := spec.Schema{}
+				sch.AddExtension(xGoName, "NoTls")
+				return &sch
+			},
+			want: "NoTls",
+		},
+		{
+			name:     "x-go-name exports lowercase value",
+			fallback: "vmId",
+			schema: func() *spec.Schema {
+				sch := spec.Schema{}
+				sch.AddExtension(xGoName, "VmId")
+				return &sch
+			},
+			want: "VmId",
+		},
+		{
+			name:     "x-go-name preserves acronym casing",
+			fallback: "recordId",
+			schema: func() *spec.Schema {
+				sch := spec.Schema{}
+				sch.AddExtension(xGoName, "ID")
+				return &sch
+			},
+			want: "ID",
+		},
+		{
+			name:     "without x-go-name uses normal mangling",
+			fallback: "backend_tls_skip_verify",
+			schema: func() *spec.Schema {
+				return &spec.Schema{}
+			},
+			want: mangler.ToGoName(mangler.ToGoName("backend_tls_skip_verify")),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sch := tc.schema()
+			require.NotNil(t, sch)
+
+			got := schemaGoName(sch, tc.fallback, mangler)
+			assert.EqualT(t, tc.want, got)
+		})
+	}
+}
+
+func TestExtensionGoNameOrError_InvalidType(t *testing.T) {
+	t.Parallel()
+
+	param := spec.Parameter{}
+	param.Extensions = spec.Extensions{xGoName: []any{"not", "a", "string"}}
+
+	_, err := extensionGoNameOrError(param.Extensions, "fallback", testNameMangler())
+	require.Error(t, err)
+	assert.StringContainsT(t, err.Error(), `must be a string`)
+}
+
+func TestExtensionGoName_InvalidTypeFallsBack(t *testing.T) {
+	t.Parallel()
+
+	mangler := testNameMangler()
+	ext := spec.Extensions{xGoName: []any{"not", "a", "string"}}
+	want := mangler.ToGoName(mangler.ToGoName("backend_tls_skip_verify"))
+
+	got := extensionGoName(ext, "backend_tls_skip_verify", mangler)
+	assert.EqualT(t, want, got)
+}
+
+func TestSchemaGoName_InvalidTypeFallsBack(t *testing.T) {
+	t.Parallel()
+
+	mangler := testNameMangler()
+	sch := spec.Schema{}
+	sch.AddExtension(xGoName, 42)
+	want := mangler.ToGoName(mangler.ToGoName("plain_tls_flag"))
+
+	got := schemaGoName(&sch, "plain_tls_flag", mangler)
+	assert.EqualT(t, want, got)
+}

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -264,7 +264,10 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	var hasQueryParams, hasPathParams, hasHeaderParams, hasFormParams, hasFileParams, hasFormValueParams, hasBodyParams bool
 	paramsForOperation := b.Analyzed.ParamsFor(b.Method, b.Path)
 
-	idMapping, timeoutName, ctxName := b.paramMappings(paramsForOperation)
+	idMapping, timeoutName, ctxName, err := b.paramMappings(paramsForOperation)
+	if err != nil {
+		return GenOperation{}, err
+	}
 
 	for _, p := range paramsForOperation {
 		cp, err := b.MakeParameter(receiver, resolver, p, idMapping)
@@ -511,10 +514,9 @@ func (b *codeGenOpBuilder) MakeResponse(receiver, name string, isSuccess bool, r
 }
 
 func (b *codeGenOpBuilder) MakeHeader(receiver, name string, hdr spec.Header) (GenHeader, error) {
-	mangle := b.GenOpts.LanguageOpts.Mangler.ToGoName
 	tpe := simpleResolvedType(hdr.Type, hdr.Format, hdr.Items, &hdr.CommonValidations)
 
-	id := mangle(name)
+	id := extensionGoName(hdr.Extensions, name, b.GenOpts.LanguageOpts.Mangler)
 	res := GenHeader{
 		sharedValidations: sharedValidations{
 			Required:          true,
@@ -524,6 +526,7 @@ func (b *codeGenOpBuilder) MakeHeader(receiver, name string, hdr spec.Header) (G
 		Package:          b.GenOpts.LanguageOpts.ManglePackageName(b.APIPackage, defaultOperationsTarget),
 		ReceiverName:     receiver,
 		ID:               id,
+		GoName:           id,
 		Name:             name,
 		Path:             fmt.Sprintf("%q", name),
 		ValueExpression:  fmt.Sprintf("%s.%s", receiver, id),
@@ -641,29 +644,27 @@ func (b *codeGenOpBuilder) MakeParameterItem(receiver, paramName, indexVar, path
 
 func (b *codeGenOpBuilder) MakeParameter(receiver string, resolver *typeResolver, param spec.Parameter, idMapping map[string]map[string]string) (GenParameter, error) {
 	debugLogf("[%s %s] making parameter %q", b.Method, b.Path, param.Name)
-	mangle := b.GenOpts.LanguageOpts.Mangler.ToGoName
-
-	// assume minimal flattening has been carried on, so there is not $ref in response (but some may remain in response schema)
 
 	var child *GenItems
-	id := mangle(param.Name)
-	if goName, ok := param.Extensions["x-go-name"]; ok {
-		id, ok = goName.(string)
-		if !ok {
-			return GenParameter{}, fmt.Errorf(`%s %s, parameter %q: "x-go-name" field must be a string, not a %T`,
-				b.Method, b.Path, param.Name, goName)
-		}
-	} else if len(idMapping) > 0 {
+	var id string
+	if len(idMapping) > 0 {
+		var ok bool
 		id, ok = idMapping[param.In][param.Name]
 		if !ok {
-			// skipped parameter
 			return GenParameter{}, fmt.Errorf(`%s %s, %q has an invalid parameter definition`,
 				b.Method, b.Path, param.Name)
+		}
+	} else {
+		var err error
+		id, err = extensionGoNameOrError(param.Extensions, param.Name, b.GenOpts.LanguageOpts.Mangler)
+		if err != nil {
+			return GenParameter{}, fmt.Errorf(`%s %s, parameter %q: %w`, b.Method, b.Path, param.Name, err)
 		}
 	}
 
 	res := GenParameter{
 		ID:               id,
+		GoName:           id,
 		Name:             param.Name,
 		ModelsPackage:    b.ModelsPackage,
 		Path:             fmt.Sprintf("%q", param.Name),
@@ -878,7 +879,7 @@ func (b *codeGenOpBuilder) MakeBodyParameterItemsAndMaps(res *GenParameter, it *
 }
 
 // paramMappings yields a map of safe parameter names for an operation.
-func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[string]map[string]string, string, string) {
+func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[string]map[string]string, string, string, error) {
 	idMapping := map[string]map[string]string{
 		"query":    make(map[string]string, len(params)),
 		"path":     make(map[string]string, len(params)),
@@ -890,7 +891,7 @@ func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[
 
 	// In order to avoid unstable generation, adopt same naming convention
 	// for all parameters with same name across locations.
-	mangle := b.GenOpts.LanguageOpts.Mangler.ToGoName
+	mangler := b.GenOpts.LanguageOpts.Mangler
 
 	seenIDs := make(map[string]any, len(params))
 	for id, p := range params {
@@ -911,11 +912,26 @@ func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[
 				panic(fmt.Errorf("internal error: invalid paramMapping: got %T", val))
 			}
 
-			idMapping[p.In][p.Name] = mangle(id)
+			prevParam := params[previous.id]
+
+			goID, err := extensionGoNameOrError(p.Extensions, id, mangler)
+			if err != nil {
+				return nil, "", "", fmt.Errorf("%s %s, parameter %q: %w", b.Method, b.Path, p.Name, err)
+			}
+			prevGoID, err := extensionGoNameOrError(prevParam.Extensions, previous.id, mangler)
+			if err != nil {
+				return nil, "", "", fmt.Errorf("%s %s, parameter %q: %w", b.Method, b.Path, prevParam.Name, err)
+			}
+
+			idMapping[p.In][p.Name] = goID
 			// rewrite the previously found one
-			idMapping[previous.in][p.Name] = mangle(previous.id)
+			idMapping[previous.in][p.Name] = prevGoID
 		} else {
-			idMapping[p.In][p.Name] = mangle(p.Name)
+			goID, err := extensionGoNameOrError(p.Extensions, p.Name, mangler)
+			if err != nil {
+				return nil, "", "", fmt.Errorf("%s %s, parameter %q: %w", b.Method, b.Path, p.Name, err)
+			}
+			idMapping[p.In][p.Name] = goID
 		}
 		seenIDs[strings.ToLower(idMapping[p.In][p.Name])] = struct{ id, in string }{id: id, in: p.In}
 	}
@@ -924,7 +940,7 @@ func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[
 	timeoutName := rename(timeoutVarNamePreferences)(seenIDs, timeoutVarNamePreferences[0], 0)
 	ctxName := rename(contextVarNamePreferences)(seenIDs, contextVarNamePreferences[0], 0)
 
-	return idMapping, timeoutName, ctxName
+	return idMapping, timeoutName, ctxName, nil
 }
 
 const (
@@ -1242,6 +1258,7 @@ func (b *codeGenOpBuilder) buildOperationSchema(schemaPath, containerName, schem
 				b.ExtraSchemas = make(map[string]GenSchema)
 			}
 			schema.Name = schemaName
+			schema.GoName = schemaName
 			schema.GoType = schemaName
 			schema.IsAnonymous = false
 			b.ExtraSchemas[schemaName] = schema

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -82,6 +82,33 @@ func TestMakeResponseHeader(t *testing.T) {
 	assert.EqualT(t, "X-Rate-Limit", gh.Name)
 }
 
+func TestMakeHeader_XGoNamePreserveExplicitCasing(t *testing.T) {
+	b, err := opBuilder("getTasks", "")
+	require.NoError(t, err)
+
+	hdr := spec.Header{}
+	hdr.Typed("boolean", "")
+	hdr.AddExtension(xGoName, "NoTls")
+
+	gh, er := b.MakeHeader("o", "X-Tls-Skip-Verify", hdr)
+	require.NoError(t, er)
+	assert.EqualT(t, "NoTls", gh.ID)
+	assert.EqualT(t, "o.NoTls", gh.ValueExpression)
+}
+
+func TestMakeHeader_XGoNameInvalidTypeFallsBack(t *testing.T) {
+	b, err := opBuilder("getTasks", "")
+	require.NoError(t, err)
+
+	hdr := spec.Header{}
+	hdr.Typed("boolean", "")
+	hdr.AddExtension(xGoName, []any{"bad"})
+
+	gh, er := b.MakeHeader("o", "X-Tls-Skip-Verify", hdr)
+	require.NoError(t, er)
+	assert.EqualT(t, "XTLSSkipVerify", gh.ID)
+}
+
 func TestMakeResponseHeaderDefaultValues(t *testing.T) {
 	b, err := opBuilder("getTasks", "")
 	require.NoError(t, err)
@@ -1446,7 +1473,8 @@ func TestParamMappings(t *testing.T) {
 	opts := opts()
 	builder := codeGenOpBuilder{GenOpts: opts}
 	// Test deconfliction of duplicate param names across param locations
-	mappings, _, _ := builder.paramMappings(testInvalidParams())
+	mappings, _, _, err := builder.paramMappings(testInvalidParams())
+	require.NoError(t, err)
 	require.MapContainsT(t, mappings, "query")
 	require.MapContainsT(t, mappings, "path")
 	require.MapContainsT(t, mappings, "body")

--- a/generator/schemavalidation_test.go
+++ b/generator/schemavalidation_test.go
@@ -36,7 +36,7 @@ func TestSchemaValidation_RequiredProps(t *testing.T) {
 
 		res := string(formatted)
 		assertInCode(t, k+") Validate(formats", res)
-		assertInCode(t, "validate"+opts.LanguageOpts.Mangler.ToGoName(p.Name), res)
+		assertInCode(t, "validate"+p.GoName, res)
 		assertInCode(t, "err := validate.Required", res)
 		assertInCode(t, "errors.CompositeValidationError(res...)", res)
 	}

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -61,8 +61,9 @@ type GenSchema struct {
 	resolvedType
 	sharedValidations
 
-	Example                    string
-	OriginalName               string
+	Example                    string // OriginalName is the wire/JSON property key from the spec.
+	OriginalName               string // Name is the resolved logical name (may come from x-go-name via goName()).
+	GoName                     string // GoName is the final exported Go identifier used in generated code.
 	Name                       string
 	Suffix                     string
 	Path                       string
@@ -299,6 +300,7 @@ type GenHeader struct {
 	IndexVar     string
 
 	ID              string
+	GoName          string // GoName is the exported Go identifier used in generated code.
 	Name            string
 	Path            string
 	ValueExpression string
@@ -356,6 +358,7 @@ type GenParameter struct {
 	sharedValidations
 
 	ID              string
+	GoName          string // GoName is the exported Go identifier used in generated code.
 	Name            string
 	ModelsPackage   string
 	Path            string

--- a/generator/templates/cli/retrieveflag.gotmpl
+++ b/generator/templates/cli/retrieveflag.gotmpl
@@ -8,7 +8,7 @@
             return err, false
         }
         {{- /* reciever by convention is m for CLI */}}
-        m.{{ pascalize .Name }} = {{- if .IsNullable }}&{{- end }}{{ flagValueVar .Name }}
+        m.{{ .GoName }} = {{- if .IsNullable }}&{{- end }}{{ flagValueVar .Name }}
     {{- else if or (eq .GoType "strfmt.DateTime") (eq .GoType "strfmt.ObjectId") (eq .GoType "strfmt.UUID" ) }} {{/*Get flag value as string, then parse it*/}}
         {{/*Many of the strfmt types can be added here*/}}
         {{ template "flagnamevar" . }}
@@ -20,7 +20,7 @@
 		if err := {{ flagValueVar .Name }}.UnmarshalText([]byte({{ flagValueVar .Name }}Str)); err != nil{
             return err, false
         }
-        m.{{ pascalize .Name }} = {{- if .IsNullable }}&{{- end }}{{ flagValueVar .Name }}
+        m.{{ .GoName }} = {{- if .IsNullable }}&{{- end }}{{ flagValueVar .Name }}
     {{- else }}
         // warning: primitive {{.Name}} {{.GoType }} is not supported by go-swagger cli yet
     {{- end }}
@@ -34,7 +34,7 @@
             return err, false
         }
         {{- /* receiver by convention is m for CLI */}}
-        m.{{ pascalize .Name }} = {{ flagValueVar .Name }}
+        m.{{ .GoName }} = {{ flagValueVar .Name }}
     {{- else if or (eq .GoType "[]strfmt.DateTime") (eq .GoType "[]strfmt.ObjectId") (eq .GoType "[]strfmt.UUID") }} {{/*Get flag value as string, then parse it*/}}
         {{ template "flagnamevar" . }}
         {{ flagValueVar .Name }}Str, err := cmd.Flags().GetStringSlice({{ flagNameVar .Name }})
@@ -48,7 +48,7 @@
                 return err, false
             }
         }
-        m.{{ pascalize .Name }} = {{- if .IsNullable }}&{{- end }}{{ flagValueVar .Name }}
+        m.{{ .GoName }} = {{- if .IsNullable }}&{{- end }}{{ flagValueVar .Name }}
     {{- else }}
         // warning: array {{.Name}} {{.GoType }} is not supported by go-swagger cli yet
     {{- end }}

--- a/generator/templates/cli/schema.gotmpl
+++ b/generator/templates/cli/schema.gotmpl
@@ -44,18 +44,18 @@
         {{- end }}
 	}
     {{- if and  .IsComplexObject (not .IsArray) (not .IsMap) (not .IsStream) }}
-    {{ flagValueVar .Name }} := m.{{pascalize .Name}}
+    {{ flagValueVar .Name }} := m.{{.GoName}}
     if typeutils.IsZero({{ flagValueVar .Name }}){
         {{ flagValueVar .Name }} = {{if .IsNullable }}&{{end}}{{if containsPkgStr .GoType}}{{ .GoType }}{{else}}{{ .Pkg }}.{{.GoType}}{{ end }}{}
     }
     {{/* always lift the payload to pointer and pass to model retrieve function. If .GoType has pkg str, use it, else use .Pkg+.GoType */}}
-    err, {{pascalize .Name }}Added := retrieveModel{{pascalize (dropPackage .GoType) }}Flags(depth + 1, {{if not .IsNullable }}&{{end}}{{ flagValueVar .Name }}, {{ flagNameVar .Name }}, cmd)
+    err, {{.GoName }}Added := retrieveModel{{pascalize (dropPackage .GoType) }}Flags(depth + 1, {{if not .IsNullable }}&{{end}}{{ flagValueVar .Name }}, {{ flagNameVar .Name }}, cmd)
     if err != nil{
         return err, false
     }
-    retAdded = retAdded || {{pascalize .Name }}Added
-    if {{pascalize .Name }}Added {
-        m.{{pascalize .Name}} = {{ flagValueVar .Name }}
+    retAdded = retAdded || {{.GoName }}Added
+    if {{.GoName }}Added {
+        m.{{.GoName}} = {{ flagValueVar .Name }}
     }
 	{{- end }}
 {{ end }}
@@ -67,7 +67,7 @@
 {{ $modelType := .GoType }}
 
 // register flags to command
-func registerModel{{pascalize .Name}}Flags(depth int, cmdPrefix string, cmd *cobra.Command) error {
+func registerModel{{.GoName}}Flags(depth int, cmdPrefix string, cmd *cobra.Command) error {
 	{{ range .AllOf }}
         {{- if not .IsAnonymous }}{{/* named type composition */}}
             {{ if or  .IsPrimitive .IsComplexObject }}
@@ -83,14 +83,14 @@ func registerModel{{pascalize .Name}}Flags(depth int, cmdPrefix string, cmd *cob
     // register anonymous fields for {{.Name}}
             {{ $anonName := .Name }}
             {{ range .Properties }}
-    if err := register{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascalize .Name }}(depth, cmdPrefix, cmd); err != nil{
+    if err := register{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ .GoName }}(depth, cmdPrefix, cmd); err != nil{
         return err
     }
             {{ end }}
         {{ end }}
     {{ end }}
     {{ range .Properties }}
-    if err := register{{ pascalize $modelName }}Prop{{ pascalize .Name }}(depth, cmdPrefix, cmd); err != nil{
+    if err := register{{ pascalize $modelName }}Prop{{ .GoName }}(depth, cmdPrefix, cmd); err != nil{
         return err
     }
     {{ end }}
@@ -102,7 +102,7 @@ func registerModel{{pascalize .Name}}Flags(depth int, cmdPrefix string, cmd *cob
 // inline definition name {{ .Name }}, type {{.GoType}}
         {{ $anonName := .Name }}
         {{ range .Properties }}
-func register{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascalize .Name }}(depth int, cmdPrefix string, cmd *cobra.Command) error {
+func register{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ .GoName }}(depth int, cmdPrefix string, cmd *cobra.Command) error {
     if depth > maxDepth {
         return nil
     }
@@ -115,7 +115,7 @@ func register{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascal
 
 {{/*register functions for each fields in this model */}}
 {{ range .Properties }}
-func register{{ pascalize $modelName }}Prop{{ pascalize .Name }}(depth int, cmdPrefix string, cmd *cobra.Command) error{
+func register{{ pascalize $modelName }}Prop{{ .GoName }}(depth int, cmdPrefix string, cmd *cobra.Command) error{
     if depth > maxDepth {
         return nil
     }
@@ -131,11 +131,11 @@ func retrieveModel{{pascalize $modelName }}Flags(depth int, m *{{if containsPkgS
         {{- if not .IsAnonymous }}{{/* named type composition */}}
             {{ if or  .IsPrimitive .IsComplexObject }}
     // retrieve model {{.GoType}}
-    err, {{pascalize .Name }}Added := retrieveModel{{ pascalize (dropPackage .GoType) }}Flags(depth, &m.{{pascalize (dropPackage .GoType) }}, cmdPrefix, cmd)
+    err, {{.GoName }}Added := retrieveModel{{ pascalize (dropPackage .GoType) }}Flags(depth, &m.{{pascalize (dropPackage .GoType) }}, cmdPrefix, cmd)
     if err != nil{
         return err, false
     }
-    retAdded = retAdded || {{pascalize .Name }}Added
+    retAdded = retAdded || {{.GoName }}Added
             {{ else }} {{/*inline anonymous case*/}}
 
             {{ end }}
@@ -143,20 +143,20 @@ func retrieveModel{{pascalize $modelName }}Flags(depth int, m *{{if containsPkgS
     // retrieve allOf {{.Name}} fields
             {{ $anonName := .Name }}
             {{ range .Properties }}
-    err, {{pascalize .Name}}Added := retrieve{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascalize .Name }}Flags(depth, m, cmdPrefix, cmd)
+    err, {{.GoName}}Added := retrieve{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ .GoName }}Flags(depth, m, cmdPrefix, cmd)
     if err != nil{
         return err, false
     }
-    retAdded = retAdded || {{ pascalize .Name }}Added
+    retAdded = retAdded || {{ .GoName }}Added
             {{ end }}
         {{- end }}
     {{ end }}
     {{ range .Properties }}
-        err, {{ pascalize .Name }}Added := retrieve{{pascalize $modelName }}Prop{{pascalize .Name }}Flags(depth, m, cmdPrefix, cmd)
+        err, {{ .GoName }}Added := retrieve{{pascalize $modelName }}Prop{{.GoName }}Flags(depth, m, cmdPrefix, cmd)
         if err != nil{
             return err, false
         }
-        retAdded = retAdded || {{ pascalize .Name }}Added
+        retAdded = retAdded || {{ .GoName }}Added
     {{ end }}
     return nil, retAdded
 }
@@ -166,7 +166,7 @@ func retrieveModel{{pascalize $modelName }}Flags(depth int, m *{{if containsPkgS
 // define retrieve functions for fields for inline definition name {{ .Name }}
         {{ $anonName := .Name }}
         {{ range .Properties }} {{/*anonymous fields will be registered directly on parent model*/}}
-func retrieve{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascalize .Name }}Flags(depth int, m *{{if containsPkgStr $modelType}}{{ $modelType }}{{else}}{{ $modelPkg }}.{{$modelType}}{{ end }},cmdPrefix string, cmd *cobra.Command) (error,bool) {
+func retrieve{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ .GoName }}Flags(depth int, m *{{if containsPkgStr $modelType}}{{ $modelType }}{{else}}{{ $modelPkg }}.{{$modelType}}{{ end }},cmdPrefix string, cmd *cobra.Command) (error,bool) {
     if depth > maxDepth {
         return nil, false
     }
@@ -179,7 +179,7 @@ func retrieve{{ pascalize $modelName }}PropAnon{{pascalize $anonName }}{{ pascal
 {{ end }}
 
 {{ range .Properties }}
-func retrieve{{pascalize $modelName }}Prop{{pascalize .Name }}Flags(depth int, m *{{if $modelPkg}}{{$modelPkg}}.{{ dropPackage $modelType }}{{else}}{{ $modelType }}{{end}}, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+func retrieve{{pascalize $modelName }}Prop{{.GoName }}Flags(depth int, m *{{if $modelPkg}}{{$modelPkg}}.{{ dropPackage $modelType }}{{else}}{{ $modelType }}{{end}}, cmdPrefix string, cmd *cobra.Command) (error, bool) {
     if depth > maxDepth {
         return nil, false
     }

--- a/generator/templates/client/parameter.gotmpl
+++ b/generator/templates/client/parameter.gotmpl
@@ -100,7 +100,7 @@ type {{ pascalize .Name }}Params struct {
         {{- end }}
       {{- end }}
     {{- end }}
-    {{ pascalize .ID }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}
+    {{ .ID }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}
   {{- end }}
 
   HTTPClient *http.Client
@@ -143,7 +143,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) SetDefaults() {
   val := {{ pascalize .Name }}Params{
   {{- range .Params }}
     {{- if and .HasDefault (not .IsFileParam) (not .IsStream) (not .IsBodyParam) }}
-    {{ pascalize .ID }}: {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (or .IsNullable  ) }}&{{ end }}{{ varname .ID }}Default,
+    {{ .ID }}: {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (or .IsNullable  ) }}&{{ end }}{{ varname .ID }}Default,
     {{- end }}
   {{- end }}
   }
@@ -196,15 +196,15 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) SetHTTPClient(client *ht
 
 {{- range .Params }}
 
-// With{{ pascalize .ID }} adds the {{ varname .Name  }} to the {{ humanize $.Name }} params.
-func ({{ $.ReceiverName }} *{{ pascalize $.Name }}Params) With{{ pascalize .ID }}({{ varname .Name  }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}) *{{ pascalize $.Name }}Params {
-  {{ $.ReceiverName }}.Set{{ pascalize .ID }}({{ varname .Name  }})
+// With{{ .ID }} adds the {{ varname .Name  }} to the {{ humanize $.Name }} params.
+func ({{ $.ReceiverName }} *{{ pascalize $.Name }}Params) With{{ .ID }}({{ varname .Name  }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}) *{{ pascalize $.Name }}Params {
+  {{ $.ReceiverName }}.Set{{ .ID }}({{ varname .Name  }})
   return {{ .ReceiverName }}
 }
 
-// Set{{ pascalize .ID }} adds the {{ camelize .Name  }} to the {{ humanize $.Name }} params.
-func ({{ $.ReceiverName }} *{{ pascalize $.Name }}Params) Set{{ pascalize .ID }}({{ varname .Name  }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}) {
-  {{ $.ReceiverName }}.{{ pascalize .ID }} = {{ varname .Name  }}
+// Set{{ .ID }} adds the {{ camelize .Name  }} to the {{ humanize $.Name }} params.
+func ({{ $.ReceiverName }} *{{ pascalize $.Name }}Params) Set{{ .ID }}({{ varname .Name  }} {{ if and (not .IsArray) (not .IsMap) (not .HasDiscriminator) (not .IsStream) (or .IsNullable  ) }}*{{ end }}{{ if not .IsFileParam }}{{ .GoType }}{{ else }}runtime.NamedReadCloser{{ end }}) {
+  {{ $.ReceiverName }}.{{ .ID }} = {{ varname .Name  }}
 }
 {{- end }}
 

--- a/generator/templates/client/response.gotmpl
+++ b/generator/templates/client/response.gotmpl
@@ -22,7 +22,7 @@ func New{{ pascalize .Name }}({{ if eq .Code -1 }}code int{{ end }}{{ if .Schema
     {{- end }}
     {{ range .Headers }}
       {{- if .HasDefault }}
-    {{ pascalize .Name}}: {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}&{{ end }}{{ varname .ID }}Default,
+    {{ .ID }}: {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}&{{ end }}{{ varname .ID }}Default,
       {{- end }}
     {{- end }}
     {{- if .Schema }}
@@ -56,7 +56,7 @@ type {{ pascalize .Name }} struct {
      {{- end }}
   */
     {{- end }}
-  {{ pascalize .Name }} {{ .GoType }}
+  {{ .ID }} {{ .GoType }}
   {{- end }}
   {{- if .Schema }}
 
@@ -150,16 +150,16 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) readResponse(response runtime.
   if err != nil {
     return errors.InvalidType({{ .Path }}, "header", "{{ .GoType }}", hdr{{ pascalize .Name }})
   }
-  {{ .ReceiverName }}.{{ pascalize .Name }} = val{{ camelize .Name }}
+  {{ .ReceiverName }}.{{ .ID }} = val{{ camelize .Name }}
     {{- else if .Child }}
 
   // binding header items for {{ .Name }}
-  val{{ pascalize .Name }}, err := {{ .ReceiverName }}.bindHeader{{ pascalize .Name }}(hdr{{ pascalize .Name }}, formats)
+  val{{ pascalize .Name }}, err := {{ .ReceiverName }}.bindHeader{{ .ID }}(hdr{{ pascalize .Name }}, formats)
   if err != nil {
     return err
   }
 
-  {{ .ReceiverName }}.{{ pascalize .Name }} = val{{ pascalize .Name }}
+  {{ .ReceiverName }}.{{ .ID }} = val{{ pascalize .Name }}
     {{- else if .IsCustomFormatter }}
   val{{ camelize .Name }}, err := formats.Parse({{ printf "%q" .SwaggerFormat }}, hdr{{ pascalize .Name }})
   if err != nil {
@@ -167,15 +167,15 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) readResponse(response runtime.
   }
       {{- if .IsNullable }}
   v := (val{{ camelize .Name }}.({{ .GoType }}))
-  {{ .ReceiverName }}.{{ pascalize .Name }} = &v
+  {{ .ReceiverName }}.{{ .ID }} = &v
       {{- else }}
-  {{ .ReceiverName }}.{{ pascalize .Name }} = *(val{{ camelize .Name }}.(*{{ .GoType }}))
+  {{ .ReceiverName }}.{{ .ID }} = *(val{{ camelize .Name }}.(*{{ .GoType }}))
       {{- end }}
     {{- else }}
       {{- if eq .GoType "string" }}
-  {{ .ReceiverName }}.{{ pascalize .Name }} = hdr{{ pascalize .Name }}
+  {{ .ReceiverName }}.{{ .ID }} = hdr{{ pascalize .Name }}
       {{- else }}
-  {{ .ReceiverName }}.{{ pascalize .Name }} = {{ .GoType }}(hdr{{ pascalize .Name }})
+  {{ .ReceiverName }}.{{ .ID }} = {{ .GoType }}(hdr{{ pascalize .Name }})
       {{- end }}
     {{- end }}
   }
@@ -209,7 +209,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) readResponse(response runtime.
     {{- if .Child }}
 
 // bindHeader{{ pascalize $.Name }} binds the response header {{ .Name }}
-func ({{ .ReceiverName }} *{{ pascalize $.Name }}) bindHeader{{ pascalize .Name }}(hdr string, formats strfmt.Registry) ({{ .GoType }}, error) {
+func ({{ .ReceiverName }} *{{ pascalize $.Name }}) bindHeader{{ .ID }}(hdr string, formats strfmt.Registry) ({{ .GoType }}, error) {
   {{ varname .Child.ValueExpression }}V := hdr
 
   {{ template "sliceclientheaderbinder" . }}

--- a/generator/templates/model.gotmpl
+++ b/generator/templates/model.gotmpl
@@ -1,7 +1,7 @@
 {{ template "header" . }}
 {{- if .IncludeModel }}
   {{- if .IsExported }}
-// {{ pascalize .Name }} {{ template "docstring" . }}
+// {{ .GoName }} {{ template "docstring" . }}
     {{- template "annotations" . }}
   {{- end }}
   {{- template "schema" . }}
@@ -10,7 +10,7 @@
 {{ range .ExtraSchemas }}
   {{- if .IncludeModel }}
     {{- if .IsExported }}
-// {{ pascalize .Name }} {{ template "docstring" . }}
+// {{ .GoName }} {{ template "docstring" . }}
       {{- template "annotations" . }}
     {{- end }}
     {{- template "schema" . }}

--- a/generator/templates/schema.gotmpl
+++ b/generator/templates/schema.gotmpl
@@ -1,7 +1,7 @@
 {{- if and .IsBaseType .IsExported (not .IsSuperAlias) }}
   {{- template "schemaPolymorphic" . }}
 {{- else if .IsSuperAlias }}
-  type {{ pascalize .Name }} {{ template "typeSchemaType" . }}{{/* For types declared as $ref on some other type, just declare the type as a golang _aliased_ type, e.g. type A = B. No method shall be redeclared.  */}}
+  type {{ .GoName }} {{ template "typeSchemaType" . }}{{/* For types declared as $ref on some other type, just declare the type as a golang _aliased_ type, e.g. type A = B. No method shall be redeclared.  */}}
   {{- if .IsBaseType }}
     {{ template "baseTypeSerializer" . }}{{/* When the alias redeclares a polymorphic type, define factory methods with this alias. */}}
   {{- end }}
@@ -9,11 +9,11 @@
   {{- template "schemaEmbedded" . }}
 {{- else }}
   {{- if or .IsComplexObject .IsTuple .IsAdditionalProperties }}{{/* TODO(fred): handle case of subtype inheriting from base type with AdditionalProperties, issue #2220 */}}
-      {{ if .Name }}type {{ if not .IsExported }}{{ .Name }}{{ else }}{{ pascalize .Name }}{{ end }}{{ end }} {{ template "schemaBody" . }}
+      {{ if .Name }}type {{ if not .IsExported }}{{ .Name }}{{ else }}{{ .GoName }}{{ end }}{{ end }} {{ template "schemaBody" . }}
     {{- range .Properties }}
       {{- if .IsBaseType }}
-        // {{ pascalize .Name}} gets the {{ humanize .Name }} of this base type{{/* all properties which are of a base type propagate its interface */}}
-        func ({{ $.ReceiverName}} *{{ pascalize $.Name}}) {{ pascalize .Name}}() {{ template "schemaType" . }}{
+        // {{ .GoName}} gets the {{ humanize .Name }} of this base type{{/* all properties which are of a base type propagate its interface */}}
+        func ({{ $.ReceiverName}} *{{ $.GoName}}) {{ .GoName}}() {{ template "schemaType" . }}{
           {{- if eq $.DiscriminatorField .Name }}
             return {{ printf "%q" $.DiscriminatorValue }}
           {{- else }}
@@ -21,8 +21,8 @@
           {{- end }}
         }
 
-        // Set{{ pascalize .Name}} sets the {{ humanize .Name }} of this base type
-        func ({{ $.ReceiverName}} *{{ pascalize $.Name}}) Set{{ pascalize .Name}}(val {{ template "schemaType" . }}) {
+        // Set{{ .GoName}} sets the {{ humanize .Name }} of this base type
+        func ({{ $.ReceiverName}} *{{ $.GoName}}) Set{{ .GoName}}(val {{ template "schemaType" . }}) {
           {{- if ne $.DiscriminatorField .Name }}
             {{ $.ReceiverName }}.{{camelize .Name}}Field = val
           {{- end }}
@@ -30,21 +30,21 @@
       {{- end }}
     {{- end }}
     {{- if .Default }}{{/* TODO(fred) - issue #2189 */}}
-      func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(b []byte) error {
-        type {{ pascalize .Name }}Alias {{ pascalize .Name }}
-        var t {{ pascalize .Name }}Alias
+      func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(b []byte) error {
+        type {{ .GoName }}Alias {{ .GoName }}
+        var t {{ .GoName }}Alias
         if err := json.Unmarshal([]byte({{printf "%q" (json .Default)}}), &t); err != nil {
           return err
         }
         if err := json.Unmarshal(b, &t); err != nil {
           return err
         }
-        *{{.ReceiverName}} = {{ pascalize .Name }}(t)
+        *{{.ReceiverName}} = {{ .GoName }}(t)
         return nil
       }
     {{- end }}
   {{- else }}
-    type {{ pascalize .Name }} {{ template "typeSchemaType" . }}
+    type {{ .GoName }} {{ template "typeSchemaType" . }}
   {{- end }}
   {{- if (and .IsPrimitive .IsAliased .IsCustomFormatter (not (stringContains .Zero "(\""))) }}
     {{ template "aliasedSerializer" . }}
@@ -54,8 +54,8 @@
       {{ range .Properties }}
         {{- if .IsBaseType }}
 
-        // {{ pascalize .Name}} gets the {{ humanize .Name }} of this subtype
-        func ({{$.ReceiverName}} *{{ pascalize $.Name}}) {{ pascalize .Name}}() {{ template "schemaType" . }}{
+        // {{ .GoName}} gets the {{ humanize .Name }} of this subtype
+        func ({{$.ReceiverName}} *{{ $.GoName}}) {{ .GoName}}() {{ template "schemaType" . }}{
           {{- if eq $.DiscriminatorField .Name }}
             return {{ printf "%q" $.DiscriminatorValue }}
           {{- else }}
@@ -63,8 +63,8 @@
           {{- end }}
         }
 
-        // Set{{ pascalize .Name}} sets the {{ humanize .Name }} of this subtype
-        func ({{$.ReceiverName}} *{{ pascalize $.Name}}) Set{{ pascalize .Name}}(val {{ template "schemaType" . }}) {
+        // Set{{ .GoName}} sets the {{ humanize .Name }} of this subtype
+        func ({{$.ReceiverName}} *{{ $.GoName}}) Set{{ .GoName}}(val {{ template "schemaType" . }}) {
           {{- if ne $.DiscriminatorField .Name }}
             {{ $.ReceiverName }}.{{camelize .Name}}Field = val
           {{- end }}
@@ -81,7 +81,7 @@
     {{- if (eq .SwaggerType "string") }}{{/* Enum factory for enums for which we generate const (atm, only strings)*/}}
       {{- if .Enum }}
 
-func New{{ pascalize .Name }}(value {{ .GoType }}) *{{ .GoType }} {
+func New{{ .GoName }}(value {{ .GoType }}) *{{ .GoType }} {
   return &value
 }
 
@@ -94,7 +94,7 @@ func ({{ .ReceiverName }} {{ .GoType }}) Pointer() *{{ .GoType }} {
     {{ template "schemavalidator" . }}
   {{- else if not (or .IsInterface .IsStream) }}
 // Validate validates this {{ humanize .Name }}{{/* this schema implements the runtime.Validatable interface but has no validations to check */}}
-func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if or (not .IsExported) .Discriminates }}{{ camelize .Name }}{{ else }}{{ pascalize .Name }}{{ end }}) Validate(formats strfmt.Registry) error {
+func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if or (not .IsExported) .Discriminates }}{{ camelize .Name }}{{ else }}{{ .GoName }}{{ end }}) Validate(formats strfmt.Registry) error {
   return nil
 }
   {{- else }}{{/* {{ .Name }} does not implement the runtime.Validatable interface: noop */}}
@@ -103,7 +103,7 @@ func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperti
     {{ template "schemacontextvalidator" . }}
   {{- else if not (or .IsInterface .IsStream) }}
 // ContextValidate validates this {{ humanize .Name }} based on context it is used {{/* this schema implements the runtime.ContextValidatable interface but has no validations to check */}}
-func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if or (not .IsExported) .Discriminates }}{{ camelize .Name }}{{ else }}{{ pascalize .Name }}{{ end }}) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if or (not .IsExported) .Discriminates }}{{ camelize .Name }}{{ else }}{{ .GoName }}{{ end }}) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
   return nil
 }
   {{- else }}{{/* {{ .Name }} does not implement the runtime.Validatable interface: noop */}}
@@ -117,12 +117,12 @@ func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperti
     {{- if .HasAdditionalProperties }}
       {{- with .AdditionalProperties }}
         // {{- template "docstring" . }}{{- template "propertyValidationDocString" . }}
-        {{ pascalize .Name }}() map[string]{{ template "schemaType" . }}
+        {{ .GoName }}() map[string]{{ template "schemaType" . }}
       {{- end }}
     {{- end }}
     {{- with .AdditionalItems }}
       // {{- template "docstring" . }}{{- template "propertyValidationDocString" . }}
-      {{ pascalize .Name }}() []{{ template "schemaType" . }}
+      {{ .GoName }}() []{{ template "schemaType" . }}
     {{- end }}
   {{- else }}
   // AdditionalProperties in base type shoud be handled just like regular properties{{/* TODO(fred): add full support for AdditionalProperties in base type */}}

--- a/generator/templates/schemabody.gotmpl
+++ b/generator/templates/schemabody.gotmpl
@@ -23,7 +23,7 @@
           // {{ template "docstring" .AdditionalProperties }}
           {{- template "propertyValidationDocString" .AdditionalProperties}}
           {{- if and .IsExported (not .IsSubType) }}
-            {{ pascalize .AdditionalProperties.Name }}
+            {{ .AdditionalProperties.GoName }}
           {{- else if or (not .AdditionalProperties.IsExported) (.AdditionalProperties.IsBaseType) }}
             {{ camelize .AdditionalProperties.Name }}Field
           {{- else }}
@@ -35,7 +35,7 @@
         // {{ template "docstring" .AdditionalItems }}
         {{- template "propertyValidationDocString" .AdditionalItems}}
         {{- if and .IsExported (not $.IsSubType) }}{{/* TODO(fred): make sure inherited AdditionalItems are camelized */}}
-          {{ pascalize .AdditionalItems.Name }}
+          {{ .AdditionalItems.GoName }}
         {{- else }}
           {{ .AdditionalItems.Name }}
         {{- end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
@@ -53,16 +53,16 @@
     // {{ template "docstring" .AdditionalProperties }}
     {{- template "propertyValidationDocString" .AdditionalProperties}}
       {{- if and .IsExported (not .IsSubType) }}
-        {{ pascalize .AdditionalProperties.Name }}
+        {{ .AdditionalProperties.GoName }}
       {{- else }}
-      {{ pascalize .AdditionalProperties.Name }}Field
+      {{ .AdditionalProperties.GoName }}Field
       {{- end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
     {{ end }}
   {{- end }}
   {{- if .AdditionalItems }}
     // {{ template "docstring" .AdditionalItems }}
     {{- template "propertyValidationDocString" .AdditionalItems}}
-    {{ if and .IsExported (not .IsSubType) }}{{ pascalize .AdditionalItems.Name }}{{ else }}{{ pascalize .AdditionalItems.Name }}Field{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
+    {{ if and .IsExported (not .IsSubType) }}{{ .AdditionalItems.GoName }}{{ else }}{{ .AdditionalItems.GoName }}Field{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
   {{ end }}
 }
 {{- end }}
@@ -88,7 +88,7 @@
       {{- if .HasAdditionalProperties }}
         {{- if .AdditionalProperties }}
           {{- if .IsExported }}
-            {{ pascalize .AdditionalProperties.Name }}
+            {{ .AdditionalProperties.GoName }}
           {{- else }}
             {{ .AdditionalProperties.Name }}
           {{- end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
@@ -96,7 +96,7 @@
       {{- end }}
       {{- if .AdditionalItems }}
         {{- if .IsExported }}
-          {{ pascalize .AdditionalItems.Name }}
+          {{ .AdditionalItems.GoName }}
         {{- else }}
           {{ .AdditionalItems.Name }}
         {{- end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
@@ -125,17 +125,17 @@
   {{- if .HasAdditionalProperties }}
     {{- if .AdditionalProperties }}
       {{- if and .IsExported }}
-        {{ pascalize .AdditionalProperties.Name }}
+        {{ .AdditionalProperties.GoName }}
       {{- else }}
-      {{ pascalize .AdditionalProperties.Name }}Field
+      {{ .AdditionalProperties.GoName }}Field
       {{- end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
     {{- end }}
   {{- end }}
   {{- if .AdditionalItems }}
     {{- if and .IsExported (not .IsSubType) }}
-      {{ pascalize .AdditionalItems.Name }}
+      {{ .AdditionalItems.GoName }}
     {{- else }}
-      {{ pascalize .AdditionalItems.Name }}Field
+      {{ .AdditionalItems.GoName }}Field
     {{- end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
   {{- end }}
 }
@@ -145,18 +145,18 @@
   {{ range .AllOf }}
   {{ if or (and .IsBaseType .IsExported) .IsAnonymous }}{{ range .Properties }}
   {{ if not .IsExported }}{{ if .IsTuple }}{{ template "privtuplefield" . }}{{ else }}{{template "privstructfield" . }}{{ end }}{{ else }}{{ if $.IsTuple }}{{ template "tuplefield" . }}{{ else }}{{template "structfield" . }}{{ end }}{{ end}}
-  {{ end }}{{ if .HasAdditionalProperties }}{{ if .IsExported }}{{ pascalize .AdditionalProperties.Name }}{{ else }}{{ .AdditionalProperties.Name }}{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`  {{end}}
-  {{ if .AdditionalItems }}{{ if and .IsExported }}{{ pascalize .AdditionalItems.Name }}{{ else }}{{ .AdditionalItems.Name }}{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
+  {{ end }}{{ if .HasAdditionalProperties }}{{ if .IsExported }}{{ .AdditionalProperties.GoName }}{{ else }}{{ .AdditionalProperties.Name }}{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`  {{end}}
+  {{ if .AdditionalItems }}{{ if and .IsExported }}{{ .AdditionalItems.GoName }}{{ else }}{{ .AdditionalItems.Name }}{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
   {{ end }}
   {{ else }}
   {{ if not (and .IsBaseType .IsExported) }}{{ .GoType }}{{ end }}{{ end }}
   {{ end }}
   {{range .Properties}}{{ if .IsBaseType }}
-  {{ if not $.IsExported }}{{ else }}{{ pascalize .Name}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`{{ end}}
+  {{ if not $.IsExported }}{{ else }}{{ .GoName}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`{{ end}}
   {{end}}{{ end }}
-  {{ if .HasAdditionalProperties }}{{ if and .IsExported }}{{ pascalize .AdditionalProperties.Name }}{{ else }}{{ pascalize .AdditionalProperties.Name }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
+  {{ if .HasAdditionalProperties }}{{ if and .IsExported }}{{ .AdditionalProperties.GoName }}{{ else }}{{ .AdditionalProperties.GoName }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
   {{ end }}
-  {{ if .AdditionalItems }}{{ if and .IsExported (not .IsSubType) }}{{ pascalize .AdditionalItems.Name }}{{ else }}{{ pascalize .AdditionalItems.Name }}Field{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
+  {{ if .AdditionalItems }}{{ if and .IsExported (not .IsSubType) }}{{ .AdditionalItems.GoName }}{{ else }}{{ .AdditionalItems.GoName }}Field{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
   {{ end }}
 }
 {{- end }}
@@ -172,16 +172,16 @@
             {{template "structfield" . }}
           {{ end }}
         {{ else }}
-          {{ pascalize .Name }} json.RawMessage `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName }} json.RawMessage `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
         {{ end}}
       {{ end }}
       {{ if .HasAdditionalProperties }}
         {{ if .AdditionalProperties }}
-          {{ if .IsExported }}{{ pascalize .AdditionalProperties.Name }}{{ else }}{{ .AdditionalProperties.Name }}{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
+          {{ if .IsExported }}{{ .AdditionalProperties.GoName }}{{ else }}{{ .AdditionalProperties.Name }}{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
         {{end}}
       {{ end }}
       {{ if .AdditionalItems }}
-        {{ if .IsExported }}{{ pascalize .AdditionalItems.Name }}{{ else }}{{ .AdditionalItems.Name }}{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
+        {{ if .IsExported }}{{ .AdditionalItems.GoName }}{{ else }}{{ .AdditionalItems.Name }}{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
       {{ end }}
     {{ else }}
       {{ if not (and .IsBaseType .IsExported) }}
@@ -194,14 +194,14 @@
       {{ if not $.IsExported }}
         {{template "privstructfield" . }}
       {{ else }}
-        {{ pascalize .Name}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+        {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
       {{ end}}
     {{ else }}
-      {{ pascalize .Name }} json.RawMessage `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+      {{ .GoName }} json.RawMessage `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
     {{end}}
   {{ end }}
   {{ if .HasAdditionalProperties }}
-    {{ pascalize .AdditionalProperties.Name }}{{ if .IsExported }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
+    {{ .AdditionalProperties.GoName }}{{ if .IsExported }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
   {{ end }}
 }
 {{- end }}
@@ -220,11 +220,11 @@
       {{ end }}
       {{ if .HasAdditionalProperties }}
         {{ if .AdditionalProperties }}
-          {{ if .IsExported }}{{ pascalize .AdditionalProperties.Name }}{{ else }}{{ .AdditionalProperties.Name }}{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
+          {{ if .IsExported }}{{ .AdditionalProperties.GoName }}{{ else }}{{ .AdditionalProperties.Name }}{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
         {{end}}
       {{ end }}
       {{ if .AdditionalItems }}
-        {{ if .IsExported }}{{ pascalize .AdditionalItems.Name }}{{ else }}{{ .AdditionalItems.Name }}{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
+        {{ if .IsExported }}{{ .AdditionalItems.GoName }}{{ else }}{{ .AdditionalItems.Name }}{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
       {{ end }}
       {{ else }}
         {{ if not (and .IsBaseType .IsExported) }}
@@ -237,18 +237,18 @@
       {{ if not .IsExported }}
         {{template "privstructfield" . }}
       {{ else }}
-        {{ pascalize .Name}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+        {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
       {{ end}}
     {{end}}
   {{ end }}
   {{ if .HasAdditionalProperties }}
-    {{ pascalize .AdditionalProperties.Name }}{{ if .IsExported }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
+    {{ .AdditionalProperties.GoName }}{{ if .IsExported }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
   {{ end }}}{
   {{ range .AllOf }}
     {{ if .IsAnonymous }}
       {{ range .Properties }}
         {{ if not .IsBaseType }}
-          {{ pascalize .Name }}: {{ .ReceiverName}}.{{ pascalize .Name }},
+          {{ .GoName }}: {{ .ReceiverName}}.{{ .GoName }},
         {{ end }}
       {{ end }}
     {{ else }}
@@ -259,7 +259,7 @@
   {{ end }}
   {{ range .Properties }}
     {{ if and (not .IsBaseType) .IsExported }}
-      {{ pascalize .Name }}: {{ .ReceiverName }}.{{ pascalize .Name }},
+      {{ .GoName }}: {{ .ReceiverName }}.{{ .GoName }},
     {{ end }}
   {{ end }}
   },
@@ -269,30 +269,30 @@
   {{ range .AllOf }}
     {{ range .Properties }}
       {{ if .IsBaseType }}
-        {{ pascalize .Name }} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+        {{ .GoName }} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
       {{ end }}
     {{ end }}
   {{ end }}
   {{ range .Properties }}
     {{ if or (not .IsExported) .IsBaseType }}
-      {{ pascalize .Name }} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+      {{ .GoName }} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
     {{ end }}
   {{end}}} {
   {{ range .AllOf }}
     {{ range .Properties }}
      {{ if .IsBaseType }}
-       {{ pascalize .Name }}:
+       {{ .GoName }}:
        {{ if ne .DiscriminatorField .Name }}
-         {{ .ReceiverName }}.{{ if .IsSubType}}{{ camelize .Name }}Field{{ else }}{{ pascalize .Name }}(){{ end }},
+         {{ .ReceiverName }}.{{ if .IsSubType}}{{ camelize .Name }}Field{{ else }}{{ .GoName }}(){{ end }},
        {{ else }}
-         {{ .ReceiverName }}.{{pascalize .Name}}(),
+         {{ .ReceiverName }}.{{.GoName}}(),
        {{ end }}
      {{ end }}
     {{ end }}
   {{ end }}
   {{ range .Properties }}
     {{ if or (not .IsExported) .IsBaseType }}
-      {{ pascalize .Name }}: {{ .ReceiverName }}.{{ if .IsBaseType}}{{ camelize .Name }}Field{{ else }}{{ pascalize .Name }}{{ end }},
+      {{ .GoName }}: {{ .ReceiverName }}.{{ if .IsBaseType}}{{ camelize .Name }}Field{{ else }}{{ .GoName }}{{ end }},
     {{ end }}
   {{ end }} },
 {{- end }}

--- a/generator/templates/schemaembedded.gotmpl
+++ b/generator/templates/schemaembedded.gotmpl
@@ -1,9 +1,9 @@
 {{ define "schemaEmbedded" }}
-type {{ pascalize .Name }} struct {
+type {{ .GoName }} struct {
   {{ if .ElemType.IsNullable }}*{{ end }}{{ .ElemType.GoType }}
 }
 
-func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject }}*{{ end }}{{ if .Discriminates }}{{ camelize .Name }}{{ else if .IsExported }}{{ pascalize .Name }}{{ else }}{{ .Name }}{{ end }}) Validate(formats strfmt.Registry) error {
+func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject }}*{{ end }}{{ if .Discriminates }}{{ camelize .Name }}{{ else if .IsExported }}{{ .GoName }}{{ else }}{{ .Name }}{{ end }}) Validate(formats strfmt.Registry) error {
   var f any = {{ .ReceiverName }}.{{ dropPackage .ElemType.GoType }}
   if v, ok := f.(runtime.Validatable) ; ok {
     return v.Validate(formats)
@@ -11,7 +11,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject }}*{{ end }}{{ if .D
   return nil
 }
 
-func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject }}*{{ end }}{{ if .Discriminates }}{{ camelize .Name }}{{ else if .IsExported }}{{ pascalize .Name }}{{ else }}{{ .Name }}{{ end }}) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject }}*{{ end }}{{ if .Discriminates }}{{ camelize .Name }}{{ else if .IsExported }}{{ .GoName }}{{ else }}{{ .Name }}{{ end }}) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
   var f any = {{ .ReceiverName }}.{{ dropPackage .ElemType.GoType }}
   if v, ok := f.(runtime.ContextValidatable) ; ok {
     return v.ContextValidate(ctx, formats)

--- a/generator/templates/schemapolymorphic.gotmpl
+++ b/generator/templates/schemapolymorphic.gotmpl
@@ -1,5 +1,5 @@
 {{ define "schemaPolymorphic" }}
-  type {{ pascalize .Name }} interface {
+  type {{ .GoName }} interface {
   {{- if not (or .IsInterface .IsStream) }}{{/*
         A base type is always Validatable.
         Under normal conditions, we can't have a base type rendered a .IsStream or .IsInterface: this check is just for sanity check).
@@ -33,8 +33,8 @@
   type {{ camelize .Name }} {{ template "schemaBody" . }}{{/* unexported implementation of the interface (TODO(fred): atm, this is not used, issue #232) */}}
   {{- range .Properties }}
 
-    // {{ pascalize .Name}} gets the {{ humanize .Name }} of this polymorphic type
-    func ({{ $.ReceiverName}} *{{ camelize $.Name}}) {{ pascalize .Name}}() {{ template "schemaType" . }}{
+    // {{ .GoName}} gets the {{ humanize .Name }} of this polymorphic type
+    func ({{ $.ReceiverName}} *{{ camelize $.Name}}) {{ .GoName}}() {{ template "schemaType" . }}{
       {{- if eq $.DiscriminatorField .Name }}
         return {{ printf "%q" $.DiscriminatorValue }}
       {{- else }}
@@ -42,8 +42,8 @@
       {{- end }}
     }
 
-    // Set{{ pascalize .Name}} sets the {{ humanize .Name }} of this polymorphic type
-    func ({{ $.ReceiverName}} *{{ camelize $.Name}}) Set{{ pascalize .Name}}(val {{ template "schemaType" . }}) {
+    // Set{{ .GoName}} sets the {{ humanize .Name }} of this polymorphic type
+    func ({{ $.ReceiverName}} *{{ camelize $.Name}}) Set{{ .GoName}}(val {{ template "schemaType" . }}) {
       {{- if ne $.DiscriminatorField .Name }}
         {{ $.ReceiverName }}.{{camelize .Name}}Field = val
       {{- end }}

--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -49,7 +49,7 @@
   {{ end }}
   {{ if .Enum }}
   // value enum
-  if err := {{.ReceiverName }}.validate{{ pascalize .Name }}{{ .Suffix }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}); err != nil {
+  if err := {{.ReceiverName }}.validate{{ .GoName }}{{ .Suffix }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{ if .IsNullable }}*{{ end }}{{.ValueExpression }}); err != nil {
     return err
   }
   {{- end }}
@@ -103,15 +103,15 @@
     }
   {{ end }}
   {{ if or .MinItems .MaxItems }}
-    {{ .IndexVar }}{{ pascalize .Name }}Size := int64(len({{.ValueExpression }}))
+    {{ .IndexVar }}{{ .GoName }}Size := int64(len({{.ValueExpression }}))
   {{ end }}
   {{ if .MinItems }}
-    if err := validate.MinItems({{ path . }}, {{ printf "%q" .Location }}, {{ .IndexVar }}{{ pascalize .Name }}Size, {{.MinItems }}); err != nil {
+    if err := validate.MinItems({{ path . }}, {{ printf "%q" .Location }}, {{ .IndexVar }}{{ .GoName }}Size, {{.MinItems }}); err != nil {
       return err
     }
   {{ end }}
   {{ if .MaxItems }}
-    if err := validate.MaxItems({{ path . }}, {{ printf "%q" .Location }}, {{ .IndexVar }}{{ pascalize .Name }}Size, {{.MaxItems }}); err != nil {
+    if err := validate.MaxItems({{ path . }}, {{ printf "%q" .Location }}, {{ .IndexVar }}{{ .GoName }}Size, {{.MaxItems }}); err != nil {
       return err
     }
   {{ end }}
@@ -122,7 +122,7 @@
   {{ end }}
   {{ if .Enum }}
     // for slice
-    if err := {{.ReceiverName }}.validate{{ pascalize .Name }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
+    if err := {{.ReceiverName }}.validate{{ .GoName }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{.ValueExpression }}); err != nil {
       return err
     }
   {{ end }}
@@ -169,7 +169,7 @@
 {{ define "mapcontextvalidator" }}
   {{- if and .Required }}
     {{- if or .IsNullable .IsInterface }}
-    if {{ .ReceiverName }}.{{ pascalize .Name }} == nil {
+    if {{ .ReceiverName }}.{{ .GoName }} == nil {
       return errors.Required({{ path . }}, {{ printf "%q" .Location }}, nil)
     }
     {{- else }}
@@ -229,7 +229,7 @@
           {{ template "mapcontextvalidator" . }}
         {{- else if and .IsMap .IsInterface }}
           {{ if .Enum }}
-      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
+      if err := {{ .ReceiverName }}.validate{{ .GoName }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
         return err
       }
           {{- end }}
@@ -293,7 +293,7 @@
 {{ define "mapvalidator" }}{{/* validates additionalProperties */}}
   {{- if and .Required }}
     {{- if or .IsNullable .IsInterface }}
-    if {{ .ReceiverName }}.{{ pascalize .Name }} == nil {
+    if {{ .ReceiverName }}.{{ .GoName }} == nil {
       return errors.Required({{ path . }}, {{ printf "%q" .Location }}, nil)
     }
     {{- else }}
@@ -375,13 +375,13 @@
           {{ template "minmaxProperties" .}}
           {{ template "mapvalidator" . }}
           {{ if .Enum }}
-      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
+      if err := {{ .ReceiverName }}.validate{{ .GoName }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
         return err
       }
           {{- end }}
         {{- else if and .IsMap .IsInterface }}
           {{ if .Enum }}
-      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
+      if err := {{ .ReceiverName }}.validate{{ .GoName }}ValueEnum({{ path . }}, {{ printf "%q" .Location }}, {{ $validatedValues }}[{{ $keyVar }}]); err != nil {
         return err
       }
           {{- end }}
@@ -427,7 +427,7 @@
     {{ end }}
     {{ if .Enum }}
     // from map
-    if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{ .ValueExpression }}); err != nil {
+    if err := {{ .ReceiverName }}.validate{{ .GoName }}Enum({{ path . }}, {{ printf "%q" .Location }}, {{ .ValueExpression }}); err != nil {
       return err
     }
     {{ end }}
@@ -457,7 +457,7 @@
     {{- end }}
   {{- else if .Enum }}
     // from map without additionalProperties
-    if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}Enum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ValueExpression }}); err != nil {
+    if err := {{ .ReceiverName }}.validate{{ .GoName }}Enum({{ if .Path }}{{ .Path }}{{ else }}""{{ end }}, {{ printf "%q" .Location }}, {{ .ValueExpression }}); err != nil {
       return err
     }
   {{- end }}
@@ -751,7 +751,7 @@
 
 {{define "schemacontextvalidator" }}
 // ContextValidate validate this {{ humanize .Name }} based on the context it is used
-func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if .Discriminates }}{{ camelize .Name }}{{ else if .IsExported }}{{ pascalize .Name }}{{ else }}{{ .Name }}{{ end }}) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if .Discriminates }}{{ camelize .Name }}{{ else if .IsExported }}{{ .GoName }}{{ else }}{{ .Name }}{{ end }}) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
   var res []error
   {{ range .AllOf }}
     {{- if not .Properties }}
@@ -761,7 +761,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
       {{ template "fieldcontextvalidator" . }}
       {{ range .Properties }}
         {{ if and (ne $.DiscriminatorField .Name) (or .HasContextValidations) }}
-          if err := {{.ReceiverName }}.contextValidate{{ pascalize .Name }}(ctx, formats); err != nil {
+          if err := {{.ReceiverName }}.contextValidate{{ .GoName }}(ctx, formats); err != nil {
             res = append(res, err)
           }
         {{- end }}
@@ -773,7 +773,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
       // TODO: context validating additional items should go here, if you see this raise an issue
       // at https://github.com/go-swagger/go-swagger/issues
       {{/*
-      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}Items(formats); err != nil {
+      if err := {{ .ReceiverName }}.validate{{ .GoName }}Items(formats); err != nil {
         res = append(res, err)
       }
       */}}
@@ -787,7 +787,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
   {{ template "fieldcontextvalidator" . }}
   {{ range .Properties }}
     {{ if .HasContextValidations }} {{/* complex obj always has cv*/}}
-      if err := {{.ReceiverName }}.contextValidate{{ pascalize .Name }}(ctx, formats); err != nil {
+      if err := {{.ReceiverName }}.contextValidate{{ .GoName }}(ctx, formats); err != nil {
         res = append(res, err)
       }
     {{ end }}
@@ -804,7 +804,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
 
   {{ range .Properties }}
     {{ if .HasContextValidations }}
-func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) contextValidate{{ pascalize .Name }}(ctx context.Context, formats strfmt.Registry) error {
+func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) contextValidate{{ .GoName }}(ctx context.Context, formats strfmt.Registry) error {
        {{template "propertycontextvalidator" . }}
   return nil
 }
@@ -813,7 +813,7 @@ func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else i
   {{ range .AllOf }}
     {{ range .Properties }}
       {{ if .HasContextValidations }}
-func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) contextValidate{{ pascalize .Name }}(ctx context.Context, formats strfmt.Registry) error {
+func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) contextValidate{{ .GoName }}(ctx context.Context, formats strfmt.Registry) error {
        {{template "propertycontextvalidator" . }}
   return nil
 }
@@ -847,7 +847,7 @@ func init() {
   }
 }
 
-func ({{ .ReceiverName }} {{ if not .IsPrimitive }}*{{ end }}{{ if .IsExported }}{{ pascalize .Name }}{{ else }}{{ .Name }}{{ end }}) validate{{ pascalize .Name }}Enum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
+func ({{ .ReceiverName }} {{ if not .IsPrimitive }}*{{ end }}{{ if .IsExported }}{{ .GoName }}{{ else }}{{ .Name }}{{ end }}) validate{{ .GoName }}Enum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
   if err := validate.EnumCase(path, location, value, {{ camelize .Name }}Enum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
@@ -867,7 +867,7 @@ func init() {
   }
 }
 
-func ({{ .ReceiverName }} *{{ if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{  $.Name }}{{ end }}) validate{{ pascalize .Name }}ItemsEnum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .Items }}) error {
+func ({{ .ReceiverName }} *{{ if $.IsExported }}{{ $.GoName }}{{ else }}{{  $.Name }}{{ end }}) validate{{ .GoName }}ItemsEnum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .Items }}) error {
   if err := validate.EnumCase(path, location, value, {{ camelize .Name }}ItemsEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
@@ -889,7 +889,7 @@ func init() {
   }
 }
 
-func ({{ .ReceiverName }} *{{ if .IsExported }}{{ pascalize .Name }}{{ else }}{{ .Name }}{{ end }}) validate{{ pascalize .Name }}ValueEnum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
+func ({{ .ReceiverName }} *{{ if .IsExported }}{{ .GoName }}{{ else }}{{ .Name }}{{ end }}) validate{{ .GoName }}ValueEnum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
   if err := validate.EnumCase(path, location, value, {{ camelize .Name }}ValueEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
@@ -898,7 +898,7 @@ func ({{ .ReceiverName }} *{{ if .IsExported }}{{ pascalize .Name }}{{ else }}{{
     {{- end }}
   {{ end }}
 // Validate validates this {{ humanize .Name }}
-func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if .Discriminates }}{{ camelize .Name }}{{ else if .IsExported }}{{ pascalize .Name }}{{ else }}{{ .Name }}{{ end }}) Validate(formats strfmt.Registry) error {
+func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ if .Discriminates }}{{ camelize .Name }}{{ else if .IsExported }}{{ .GoName }}{{ else }}{{ .Name }}{{ end }}) Validate(formats strfmt.Registry) error {
   var res []error
   {{ template "minmaxProperties" .}}
   {{ range .AllOf }}
@@ -910,7 +910,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
 
       {{ range .Properties }}
         {{ if and (ne $.DiscriminatorField .Name) (or .Required .HasValidations) }}
-          if err := {{.ReceiverName }}.validate{{ pascalize .Name }}(formats); err != nil {
+          if err := {{.ReceiverName }}.validate{{ .GoName }}(formats); err != nil {
             res = append(res, err)
           }
         {{- end }}
@@ -919,7 +919,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
         {{ template "mapvalidator" . }}
       {{- end }}
       {{ if and .IsTuple .AdditionalItems }}
-      if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}Items(formats); err != nil {
+      if err := {{ .ReceiverName }}.validate{{ .GoName }}Items(formats); err != nil {
         res = append(res, err)
       }
       {{ end }}
@@ -932,7 +932,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
   {{ template "fieldvalidator" . }}
   {{ range .Properties }}
     {{ if and (ne $.DiscriminatorField .Name) (or .Required .HasValidations) }}
-      if err := {{.ReceiverName }}.validate{{ pascalize .Name }}(formats); err != nil {
+      if err := {{.ReceiverName }}.validate{{ .GoName }}(formats); err != nil {
         res = append(res, err)
       }
     {{ end }}
@@ -941,13 +941,13 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
     {{ template "mapvalidator" . }}
   {{- end }}
   {{ if and .IsTuple .AdditionalItems }}{{/* validates additionalItems in a tuple */}}
-    if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}Items(formats); err != nil {
+    if err := {{ .ReceiverName }}.validate{{ .GoName }}Items(formats); err != nil {
       res = append(res, err)
     }
   {{ end }}
   {{ if and .Enum (not .IsPrimitive) (not .IsMap) }}
     // value enum
-    if err := {{ .ReceiverName }}.validate{{ pascalize .Name }}Enum("", "body", {{ .ReceiverName }}); err != nil {
+    if err := {{ .ReceiverName }}.validate{{ .GoName }}Enum("", "body", {{ .ReceiverName }}); err != nil {
       res = append(res, err)
     }
   {{ end }}
@@ -961,7 +961,7 @@ func ({{.ReceiverName }} {{ if or .IsTuple .IsComplexObject .IsAdditionalPropert
   {{ range .Properties }}
     {{ if or .Required .HasValidations }}
       {{ if .Enum }}
-var {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum []any
+var {{ camelize $.Name }}Type{{ .GoName }}PropEnum []any
 
 func init() {
   var res []{{ template "dereffedSchemaType" . }}
@@ -969,7 +969,7 @@ func init() {
     panic(err)
   }
   for _, v := range res {
-    {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum = append({{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum, v)
+    {{ camelize $.Name }}Type{{ .GoName }}PropEnum = append({{ camelize $.Name }}Type{{ .GoName }}PropEnum, v)
   }
 }
 
@@ -978,7 +978,7 @@ func init() {
           {{ $propname := .Name }}
 const (
           {{ range .Enum }}
-          {{- $variant := print (pascalize $.Name) (pascalize $propname) (pascalize (cleanupEnumVariant .)) }}
+          {{- $variant := print ($.GoName) (pascalize $propname) (pascalize (cleanupEnumVariant .)) }}
   // {{ $variant }} captures enum value {{ printf "%q" . }}
 	{{ $variant }} {{ $gotype }} = {{ printf "%q" . }}
           {{ end }}
@@ -986,27 +986,27 @@ const (
         {{ end }}
 
 // prop value enum
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}Enum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
-  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}Enum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
+  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}Type{{ .GoName }}PropEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
 }
       {{ end }}
       {{ if .ItemsEnum }}
-var {{ camelize $.Name }}{{ pascalize .Name }}ItemsEnum []any
+var {{ camelize $.Name }}{{ .GoName }}ItemsEnum []any
 func init() {
   var res []{{ template "dereffedSchemaType" .Items }}
   if err := json.Unmarshal([]byte(`{{ json .ItemsEnum }}`), &res); err != nil {
     panic(err)
   }
   for _, v := range res {
-    {{ camelize $.Name }}{{ pascalize .Name }}ItemsEnum = append({{ camelize $.Name }}{{ pascalize .Name }}ItemsEnum, v)
+    {{ camelize $.Name }}{{ .GoName }}ItemsEnum = append({{ camelize $.Name }}{{ .GoName }}ItemsEnum, v)
   }
 }
 
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}ItemsEnum(path, location string, value {{ if or .Items.IsTuple .Items.IsComplexObject .Items.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .Items }}) error {
-  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}{{ pascalize .Name }}ItemsEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}ItemsEnum(path, location string, value {{ if or .Items.IsTuple .Items.IsComplexObject .Items.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .Items }}) error {
+  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}{{ .GoName }}ItemsEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
@@ -1014,7 +1014,7 @@ func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else 
       {{ end }}
       {{ if .AdditionalItems }}
         {{ if .AdditionalItems.Enum }}
-var {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum []any
+var {{ camelize $.Name }}Type{{ .GoName }}PropEnum []any
 
 func init() {
   var res []{{ template "dereffedSchemaType" .AdditionalItems }}
@@ -1022,12 +1022,12 @@ func init() {
     panic(err)
   }
   for _, v := range res {
-    {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum = append({{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum, v)
+    {{ camelize $.Name }}Type{{ .GoName }}PropEnum = append({{ camelize $.Name }}Type{{ .GoName }}PropEnum, v)
   }
 }
 
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}Enum(path, location string, value {{ if or .AdditionalItems.IsTuple .AdditionalItems.IsComplexObject .AdditionalItems.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .AdditionalItems }}) error {
-  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}Enum(path, location string, value {{ if or .AdditionalItems.IsTuple .AdditionalItems.IsComplexObject .AdditionalItems.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .AdditionalItems }}) error {
+  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}Type{{ .GoName }}PropEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
@@ -1037,7 +1037,7 @@ func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else 
       {{ with .AdditionalProperties }}
         {{ if .Enum }}
 // additional properties value enum
-var {{ camelize $.Name }}{{ pascalize .Name }}ValueEnum []any
+var {{ camelize $.Name }}{{ .GoName }}ValueEnum []any
 
 func init() {
   var res []{{ template "dereffedSchemaType" . }}
@@ -1045,12 +1045,12 @@ func init() {
     panic(err)
   }
   for _, v := range res {
-    {{ camelize $.Name }}{{ pascalize .Name }}ValueEnum = append({{ camelize $.Name }}{{ pascalize .Name }}ValueEnum, v)
+    {{ camelize $.Name }}{{ .GoName }}ValueEnum = append({{ camelize $.Name }}{{ .GoName }}ValueEnum, v)
   }
 }
 
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}ValueEnum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
-  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}{{ pascalize .Name }}ValueEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}ValueEnum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
+  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}{{ .GoName }}ValueEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
@@ -1059,7 +1059,7 @@ func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else 
       {{ end }}
 
       {{ if and (ne $.DiscriminatorField .Name) (or .Required .HasValidations) }}
-func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}(formats strfmt.Registry) error {
+func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}(formats strfmt.Registry) error {
         {{- if not .Required }}
           {{- if .IsInterface }}
   if .ValueExpression == nil { // not required
@@ -1095,7 +1095,7 @@ func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else i
     {{ range .Properties }}
       {{ if and (ne $.DiscriminatorField .Name) (or .Required .HasValidations) }}
         {{ if .Enum }}
-var {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum []any
+var {{ camelize $.Name }}Type{{ .GoName }}PropEnum []any
 
 func init() {
   var res []{{ template "dereffedSchemaType" . }}
@@ -1103,20 +1103,20 @@ func init() {
     panic(err)
   }
   for _, v := range res {
-    {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum = append({{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum, v)
+    {{ camelize $.Name }}Type{{ .GoName }}PropEnum = append({{ camelize $.Name }}Type{{ .GoName }}PropEnum, v)
   }
 }
 
 // property enum
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}Enum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
-  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}Enum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
+  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}Type{{ .GoName }}PropEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
 }
         {{ end }}
         {{ if .ItemsEnum }}
-var {{ camelize $.Name }}{{ pascalize .Name }}ItemsEnum []any
+var {{ camelize $.Name }}{{ .GoName }}ItemsEnum []any
 
 func init() {
   var res []{{ template "dereffedSchemaType" .Items }}
@@ -1124,12 +1124,12 @@ func init() {
     panic(err)
   }
   for _, v := range res {
-    {{ camelize $.Name }}{{ pascalize .Name }}ItemsEnum = append({{ camelize $.Name }}{{ pascalize .Name }}ItemsEnum, v)
+    {{ camelize $.Name }}{{ .GoName }}ItemsEnum = append({{ camelize $.Name }}{{ .GoName }}ItemsEnum, v)
   }
 }
 
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}ItemsEnum(path, location string, value {{ if or .Items.IsTuple .Items.IsComplexObject .Items.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .Items }}) error {
-  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}{{ pascalize .Name }}ItemsEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}ItemsEnum(path, location string, value {{ if or .Items.IsTuple .Items.IsComplexObject .Items.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .Items }}) error {
+  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}{{ .GoName }}ItemsEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
@@ -1137,7 +1137,7 @@ func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else 
         {{ end }}
         {{ if .AdditionalItems }}
           {{ if .AdditionalItems.Enum }}
-var {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum []any
+var {{ camelize $.Name }}Type{{ .GoName }}PropEnum []any
 
 func init() {
   var res []{{ template "dereffedSchemaType" .AdditionalItems }}
@@ -1145,12 +1145,12 @@ func init() {
     panic(err)
   }
   for _, v := range res {
-    {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum = append({{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum, v)
+    {{ camelize $.Name }}Type{{ .GoName }}PropEnum = append({{ camelize $.Name }}Type{{ .GoName }}PropEnum, v)
   }
 }
 
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}Enum(path, location string, value {{ if or .AdditionalItems.IsTuple .AdditionalItems.IsComplexObject .AdditionalItems.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .AdditionalItems }}) error {
-  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}Type{{ pascalize .Name }}PropEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}Enum(path, location string, value {{ if or .AdditionalItems.IsTuple .AdditionalItems.IsComplexObject .AdditionalItems.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .AdditionalItems }}) error {
+  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}Type{{ .GoName }}PropEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
@@ -1159,20 +1159,20 @@ func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else 
         {{ end }}
         {{ with .AdditionalProperties }}
           {{ if .Enum }}
-var {{ camelize $.Name }}{{ pascalize .Name }}ValueEnum []any
+var {{ camelize $.Name }}{{ .GoName }}ValueEnum []any
 func init() {
   var res []{{ template "dereffedSchemaType" . }}
   if err := json.Unmarshal([]byte(`{{ json .Enum }}`), &res); err != nil {
     panic(err)
   }
   for _, v := range res {
-    {{ camelize $.Name }}{{ pascalize .Name }}ValueEnum = append({{ camelize $.Name }}{{ pascalize .Name }}ValueEnum, v)
+    {{ camelize $.Name }}{{ .GoName }}ValueEnum = append({{ camelize $.Name }}{{ .GoName }}ValueEnum, v)
   }
 }
 
 // additional properties value enum
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}ValueEnum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
-  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}{{ pascalize .Name }}ValueEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}ValueEnum(path, location string, value {{ if or .IsTuple .IsComplexObject .IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" . }}) error {
+  if err := validate.EnumCase(path, location, value, {{ camelize $.Name }}{{ .GoName }}ValueEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
@@ -1181,7 +1181,7 @@ func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else 
         {{ end }}
 
 
-func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}(formats strfmt.Registry) error {
+func ({{.ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}(formats strfmt.Registry) error {
         {{ if not .Required }}
           {{- if .IsInterface }}
   if {{ .ValueExpression }} == nil { // not required
@@ -1213,16 +1213,16 @@ func init() {
   }
 }
 
-func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ pascalize $.Name }}{{ else }}{{ $.Name }}{{ end }}) validate{{ pascalize .Name }}ItemsEnum(path, location string, value {{ if or .AdditionalItems.IsTuple .AdditionalItems.IsComplexObject .AdditionalItems.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .AdditionalItems }}) error {
+func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else if $.IsExported }}{{ $.GoName }}{{ else }}{{ $.Name }}{{ end }}) validate{{ .GoName }}ItemsEnum(path, location string, value {{ if or .AdditionalItems.IsTuple .AdditionalItems.IsComplexObject .AdditionalItems.IsAdditionalProperties }}*{{ end }}{{ template "dereffedSchemaType" .AdditionalItems }}) error {
   if err := validate.EnumCase(path, location, value, {{ camelize .Name }}ItemsEnum, {{ if .IsEnumCI }}false{{ else }}true{{ end }}); err != nil {
     return err
   }
   return nil
 }
     {{ end }}
-func ({{.ReceiverName }} *{{ pascalize .Name }}) validate{{ pascalize .Name }}Items(formats strfmt.Registry) error {
+func ({{.ReceiverName }} *{{ .GoName }}) validate{{ .GoName }}Items(formats strfmt.Registry) error {
     {{ if and (or .AdditionalItems.Required .AdditionalItems.HasValidations) (not .AdditionalItems.SkipExternalValidation) }}
-  for {{ .IndexVar }} := range {{ .ValueExpression }}.{{ pascalize .Name }}Items {
+  for {{ .IndexVar }} := range {{ .ValueExpression }}.{{ .GoName }}Items {
       {{template "propertyvalidator" .AdditionalItems }}
   }
     {{ end }}

--- a/generator/templates/serializers/additionalpropertiesserializer.gotmpl
+++ b/generator/templates/serializers/additionalpropertiesserializer.gotmpl
@@ -1,14 +1,14 @@
 {{ define "additionalPropertiesSerializer" }}
 // UnmarshalJSON unmarshals this object with additional properties from JSON
-func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(data []byte) error {
+func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(data []byte) error {
   // stage 1, bind the properties
   var stage1 {{ template "withoutAdditionalBody" . }}
   if err := json.Unmarshal(data, &stage1); err != nil {
     return err
   }
-  var rcv {{ pascalize .Name }}
+  var rcv {{ .GoName }}
   {{ range .Properties }}
-  rcv.{{ pascalize .Name }} = stage1.{{ pascalize .Name }}
+  rcv.{{ .GoName }} = stage1.{{ .GoName }}
   {{- end }}
   *{{ .ReceiverName }} = rcv
 
@@ -19,7 +19,7 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(data []byte) error
   }
 
   {{ range .Properties }}
-  delete(stage2, {{ printf "%q" .Name }})
+  delete(stage2, {{ printf "%q" .OriginalName }})
   {{- end }}
 
   {{- if .AdditionalProperties }}
@@ -43,10 +43,10 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(data []byte) error
 }
 
 // MarshalJSON marshals this object with additional properties into a JSON object
-func ({{.ReceiverName}} {{ pascalize .Name }}) MarshalJSON() ([]byte, error) {
+func ({{.ReceiverName}} {{ .GoName }}) MarshalJSON() ([]byte, error) {
   var stage1 {{ template "withoutAdditionalBody" . }}
   {{ range .Properties }}
-  stage1.{{ pascalize .Name }} = {{ .ValueExpression }}
+  stage1.{{ .GoName }} = {{ .ValueExpression }}
   {{- end }}
 
   // make JSON object for known properties
@@ -76,7 +76,7 @@ func ({{.ReceiverName}} {{ pascalize .Name }}) MarshalJSON() ([]byte, error) {
 
 {{ define "noAdditionalPropertiesSerializer" }}
 // UnmarshalJSON unmarshals this object while disallowing additional properties from JSON
-func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(data []byte) error {
+func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(data []byte) error {
   var props {{ template "withoutAdditionalBody" . }}
 
   dec := json.NewDecoder(bytes.NewReader(data))
@@ -87,7 +87,7 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(data []byte) error
 
   {{- $rcv :=  .ReceiverName }}
   {{ range .Properties }}
-    {{ .ReceiverName }}.{{ pascalize .Name }} = props.{{ pascalize .Name }}
+    {{ .ReceiverName }}.{{ .GoName }} = props.{{ .GoName }}
   {{- end }}
   return nil
 }

--- a/generator/templates/serializers/aliasedserializer.gotmpl
+++ b/generator/templates/serializers/aliasedserializer.gotmpl
@@ -1,11 +1,11 @@
 {{ define "aliasedSerializer" }}
-// UnmarshalJSON sets a {{ pascalize .Name }} value from JSON input
-func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(b []byte) error {
+// UnmarshalJSON sets a {{ .GoName }} value from JSON input
+func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(b []byte) error {
   return ((*{{ .AliasedType }})({{ .ReceiverName}})).UnmarshalJSON(b)
 }
 
-// MarshalJSON retrieves a {{ pascalize .Name }} value as JSON output
-func ({{.ReceiverName}} {{ pascalize .Name }}) MarshalJSON() ([]byte, error) {
+// MarshalJSON retrieves a {{ .GoName }} value as JSON output
+func ({{.ReceiverName}} {{ .GoName }}) MarshalJSON() ([]byte, error) {
   return ({{ .AliasedType }}({{ .ReceiverName}})).MarshalJSON()
 }
 {{- end }}

--- a/generator/templates/serializers/allofserializer.gotmpl
+++ b/generator/templates/serializers/allofserializer.gotmpl
@@ -1,39 +1,39 @@
 {{ define "allOfSerializer" }}
   {{- $receiverName := .ReceiverName }}
 // UnmarshalJSON unmarshals this object from a JSON structure
-func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error {
+func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(raw []byte) error {
   {{- range .AllOf }}
-    // {{ pascalize .Name }}
+    // {{ .GoName }}
     {{- if and .IsAnonymous .Properties }}{{/* unmarshalling properties in all of anonymous objects */}}
-      {{- $part :=  pascalize .Name }}
+      {{- $part :=  .GoName }}
       var data{{ $part }} struct {
       {{- range .Properties }}
         {{- if not .IsBaseType }}
           {{- if not $.IsExported }}
             {{ template "privstructfield" . }}
           {{- else }}
-            {{ pascalize .Name}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+            {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
           {{- end }}
         {{ else }}
           {{ if not $.IsExported }}
             {{ template "privstructfield" . }}
           {{ else }}
-            {{ pascalize .Name}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+            {{ .GoName}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
           {{ end }}
         {{ end }}
       {{- end }}
       {{- if .HasAdditionalProperties }}
-        {{ pascalize .AdditionalProperties.Name }}{{ if not .IsExported }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
+        {{ .AdditionalProperties.GoName }}{{ if not .IsExported }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
       {{- end }}
       {{- if .AdditionalItems }}
-        {{ pascalize .AdditionalItems.Name }}{{ if or (not .IsExported) .IsSubType }}Field{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
+        {{ .AdditionalItems.GoName }}{{ if or (not .IsExported) .IsSubType }}Field{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
       {{- end }}
   }
   if err := jsonutils.ReadJSON(raw, &data{{ $part }}); err != nil {
     return err
   }
       {{ range .Properties }}
-  {{ $receiverName }}.{{ pascalize .Name }} = data{{ $part }}.{{ pascalize .Name }}
+  {{ $receiverName }}.{{ .GoName }} = data{{ $part }}.{{ .GoName }}
       {{ end }}
     {{- else if .IsAnonymous }}
   var {{ varname .Name }} {{ .GoType }}
@@ -52,20 +52,20 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
   {{ end }}
   {{- if .Properties }}
     // now for regular properties
-    {{- $part :=  pascalize .Name }}
+    {{- $part :=  .GoName }}
     var props{{ $part }} struct {
     {{- range .Properties }}
       {{- if not .IsBaseType }}
         {{- if not $.IsExported }}
           {{ template "privstructfield" . }}
         {{- else }}
-          {{ pascalize .Name}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
         {{- end }}
       {{- else }}
         {{- if not $.IsExported }}
           {{ template "privstructfield" . }}
         {{- else }}
-          {{ pascalize .Name}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
         {{- end }}
       {{- end }}
     {{ end }}
@@ -74,7 +74,7 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
        return err
     }
     {{- range .Properties }}
-      {{ $receiverName }}.{{ pascalize .Name }} = props{{ $part }}.{{ pascalize .Name }}
+      {{ $receiverName }}.{{ .GoName }} = props{{ $part }}.{{ .GoName }}
     {{ end }}
   {{- end }}
   {{ if .HasAdditionalProperties }}
@@ -87,37 +87,37 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
 }
 
 // MarshalJSON marshals this object to a JSON structure
-func ({{.ReceiverName}} {{ pascalize .Name }}) MarshalJSON() ([]byte, error) {
+func ({{.ReceiverName}} {{ .GoName }}) MarshalJSON() ([]byte, error) {
   _parts := make([][]byte, 0, {{ len .AllOf }})
   {{ range .AllOf }}
     {{- if and .IsAnonymous .Properties }}
-      {{- $part :=  pascalize .Name }}
+      {{- $part :=  .GoName }}
   var data{{ $part }} struct {
       {{- range .Properties }}
         {{- if not .IsBaseType }}
           {{- if not $.IsExported }}
             {{ template "privstructfield" . }}
           {{- else }}
-            {{ pascalize .Name}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+            {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
           {{- end }}
         {{- else }}
           {{- if not $.IsExported }}
             {{ template "privstructfield" . }}
           {{- else }}
-            {{ pascalize .Name}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+            {{ .GoName}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
             {{- end }}
         {{- end }}
       {{ end }}
       {{- if .HasAdditionalProperties }}
-        {{ pascalize .AdditionalProperties.Name }}{{ if not .IsExported }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
+        {{ .AdditionalProperties.GoName }}{{ if not .IsExported }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
       {{- end }}
       {{- if .AdditionalItems }}
-        {{ pascalize .AdditionalItems.Name }}{{ if or (not .IsExported) .IsSubType }}Field{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
+        {{ .AdditionalItems.GoName }}{{ if or (not .IsExported) .IsSubType }}Field{{ end }} []{{ template "schemaType" .AdditionalItems }} `json:"-"`
       {{- end }}
   }
 
       {{ range .Properties }}
-  data{{ $part }}.{{ pascalize .Name }} = {{ $receiverName }}.{{ pascalize .Name }}
+  data{{ $part }}.{{ .GoName }} = {{ $receiverName }}.{{ .GoName }}
       {{ end }}
 
   jsonData{{ $part }}, err{{ $part }} := jsonutils.WriteJSON(data{{ $part }})
@@ -144,26 +144,26 @@ func ({{.ReceiverName}} {{ pascalize .Name }}) MarshalJSON() ([]byte, error) {
   {{- if .Properties }}
 
     // now for regular properties
-    {{- $part :=  pascalize .Name }}
+    {{- $part :=  .GoName }}
     var props{{ $part }} struct {
     {{- range .Properties }}
       {{- if not .IsBaseType }}
         {{- if not $.IsExported }}
           {{ template "privstructfield" . }}
         {{- else }}
-          {{ pascalize .Name}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
         {{- end }}
       {{- else }}
         {{- if not $.IsExported }}
           {{ template "privstructfield" . }}
         {{- else }}
-          {{ pascalize .Name}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
         {{- end }}
       {{- end }}
     {{ end }}
     }
     {{- range .Properties }}
-    props{{ $part }}.{{ pascalize .Name }} = {{ $receiverName }}.{{ pascalize .Name }}
+    props{{ $part }}.{{ .GoName }} = {{ $receiverName }}.{{ .GoName }}
     {{ end }}
     jsonDataProps{{ $part }}, err{{ $part }} := jsonutils.WriteJSON(props{{ $part }})
     if err{{ $part }} != nil {

--- a/generator/templates/serializers/basetypeserializer.gotmpl
+++ b/generator/templates/serializers/basetypeserializer.gotmpl
@@ -1,14 +1,14 @@
 {{ define "polymorphicSerializer" }}
-// Unmarshal{{ pascalize .Name }}Slice unmarshals polymorphic slices of {{ pascalize .Name }}
-func Unmarshal{{ pascalize .Name }}Slice(reader io.Reader, consumer runtime.Consumer) ([]{{ pascalize .Name }}, error) {
+// Unmarshal{{ .GoName }}Slice unmarshals polymorphic slices of {{ .GoName }}
+func Unmarshal{{ .GoName }}Slice(reader io.Reader, consumer runtime.Consumer) ([]{{ .GoName }}, error) {
   var elements []json.RawMessage
   if err := consumer.Consume(reader, &elements); err != nil {
     return nil, err
   }
 
-  var result []{{ pascalize .Name }}
+  var result []{{ .GoName }}
   for _, element := range elements {
-    obj, err := unmarshal{{ pascalize .Name }}(element, consumer)
+    obj, err := unmarshal{{ .GoName }}(element, consumer)
     if err != nil {
       return nil, err
     }
@@ -17,17 +17,17 @@ func Unmarshal{{ pascalize .Name }}Slice(reader io.Reader, consumer runtime.Cons
   return  result, nil
 }
 
-// Unmarshal{{ pascalize .Name }} unmarshals polymorphic {{ pascalize .Name }}
-func Unmarshal{{ pascalize .Name }}(reader io.Reader, consumer runtime.Consumer) ({{ pascalize .Name }}, error) {
+// Unmarshal{{ .GoName }} unmarshals polymorphic {{ .GoName }}
+func Unmarshal{{ .GoName }}(reader io.Reader, consumer runtime.Consumer) ({{ .GoName }}, error) {
   // we need to read this twice, so first into a buffer
   data, err := io.ReadAll(reader)
   if err != nil {
     return nil, err
   }
-  return  unmarshal{{ pascalize .Name }}(data, consumer)
+  return  unmarshal{{ .GoName }}(data, consumer)
 }
 
-func unmarshal{{ pascalize .Name }}(data []byte, consumer runtime.Consumer) ({{ pascalize .Name }}, error) {
+func unmarshal{{ .GoName }}(data []byte, consumer runtime.Consumer) ({{ .GoName }}, error) {
   buf := bytes.NewBuffer(data)
   {{ if .Discriminates }} buf2 := bytes.NewBuffer(data) {{ end }}
 
@@ -45,7 +45,7 @@ func unmarshal{{ pascalize .Name }}(data []byte, consumer runtime.Consumer) ({{ 
   switch getType.{{ pascalize .DiscriminatorField }} {
     {{- range $k, $v := .Discriminates }}
     case {{ printf "%q" $k }}:
-      var result {{ if eq (upper (pascalize $.Name)) (upper $v) }}{{ camelize $.Name }}{{ else }}{{ $v }}{{ end }}
+      var result {{ if eq (upper $.GoName) (upper $v) }}{{ camelize $.Name }}{{ else }}{{ $v }}{{ end }}
       if err := consumer.Consume(buf2, &result); err != nil {
         return nil, err
       }
@@ -57,13 +57,13 @@ func unmarshal{{ pascalize .Name }}(data []byte, consumer runtime.Consumer) ({{ 
 {{- end }}
 
 {{ define "baseTypeSerializer" }}
-// Unmarshal{{ pascalize .Name }} unmarshals polymorphic {{ pascalize .Name }}
-func Unmarshal{{ pascalize .Name }}(reader io.Reader, consumer runtime.Consumer) ({{ pascalize .Name }}, error) {
+// Unmarshal{{ .GoName }} unmarshals polymorphic {{ .GoName }}
+func Unmarshal{{ .GoName }}(reader io.Reader, consumer runtime.Consumer) ({{ .GoName }}, error) {
   return Unmarshal{{ pascalize .GoType }}(reader, consumer)
 }
 
-// Unmarshal{{ pascalize .Name }}Slice unmarshals polymorphic slices of {{ pascalize .Name }}
-func Unmarshal{{ pascalize .Name }}Slice(reader io.Reader, consumer runtime.Consumer) ([]{{ pascalize .Name }}, error) {
+// Unmarshal{{ .GoName }}Slice unmarshals polymorphic slices of {{ .GoName }}
+func Unmarshal{{ .GoName }}Slice(reader io.Reader, consumer runtime.Consumer) ([]{{ .GoName }}, error) {
   return Unmarshal{{ pascalize .GoType }}Slice(reader, consumer)
 }
 {{- end }}

--- a/generator/templates/serializers/marshalbinaryserializer.gotmpl
+++ b/generator/templates/serializers/marshalbinaryserializer.gotmpl
@@ -1,6 +1,6 @@
 {{ define "marshalBinarySerializer" }}
 // MarshalBinary interface implementation
-func ({{.ReceiverName}} *{{ pascalize .Name }}) MarshalBinary() ([]byte, error) {
+func ({{.ReceiverName}} *{{ .GoName }}) MarshalBinary() ([]byte, error) {
   if {{ .ReceiverName }} == nil {
     return nil, nil
   }
@@ -8,8 +8,8 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) MarshalBinary() ([]byte, error) 
 }
 
 // UnmarshalBinary interface implementation
-func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalBinary(b []byte) error {
-  var res {{ pascalize .Name }}
+func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalBinary(b []byte) error {
+  var res {{ .GoName }}
   if err := jsonutils.ReadJSON(b, &res); err != nil {
     return err
   }

--- a/generator/templates/serializers/subtypeserializer.gotmpl
+++ b/generator/templates/serializers/subtypeserializer.gotmpl
@@ -1,6 +1,6 @@
 {{ define "hasDiscriminatedSerializer" }}
 // UnmarshalJSON unmarshals this object with a polymorphic type from a JSON structure
-func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error {
+func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(raw []byte) error {
   var data {{ template "withoutBaseTypeBody" . }}
   buf := bytes.NewBuffer(raw)
   dec := json.NewDecoder(buf)
@@ -25,16 +25,16 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
       {{ range .Properties }}
         {{- if or .IsBaseType (not .IsExported) }}
           {{- if not .Required }}
-  var allOf{{ pascalize .Name }} {{ if .IsArray }}[]{{ pascalize .Items.GoType }}{{ else }}{{ pascalize .GoType }}{{ end }}
-  if string(data.{{ pascalize .Name }}) != "null" {
-    {{ camelize .Name }}, err := Unmarshal{{ if .IsArray }}{{ pascalize .Items.GoType }}Slice{{ else }}{{ pascalize .GoType }}{{ end }}(bytes.NewBuffer(data.{{ pascalize .Name }}), runtime.JSONConsumer())
+  var allOf{{ .GoName }} {{ if .IsArray }}[]{{ pascalize .Items.GoType }}{{ else }}{{ pascalize .GoType }}{{ end }}
+  if string(data.{{ .GoName }}) != "null" {
+    {{ camelize .Name }}, err := Unmarshal{{ if .IsArray }}{{ pascalize .Items.GoType }}Slice{{ else }}{{ pascalize .GoType }}{{ end }}(bytes.NewBuffer(data.{{ .GoName }}), runtime.JSONConsumer())
     if err != nil && !stderrors.Is(err, io.EOF) {
       return err
     }
-    allOf{{ pascalize .Name }} = {{ camelize .Name }}
+    allOf{{ .GoName }} = {{ camelize .Name }}
   }
           {{- else }}
-  allOf{{ pascalize .Name }}, err := Unmarshal{{ if .IsArray }}{{ pascalize .Items.GoType }}Slice{{ else }}{{ pascalize .GoType }}{{ end }}(bytes.NewBuffer(data.{{ pascalize .Name }}), runtime.JSONConsumer())
+  allOf{{ .GoName }}, err := Unmarshal{{ if .IsArray }}{{ pascalize .Items.GoType }}Slice{{ else }}{{ pascalize .GoType }}{{ end }}(bytes.NewBuffer(data.{{ .GoName }}), runtime.JSONConsumer())
   if err != nil && !stderrors.Is(err, io.EOF) {
     return err
   }
@@ -46,16 +46,16 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
   {{ range .Properties }}
     {{- if or .IsBaseType (not .IsExported) }}
       {{- if not .Required }}
-  var prop{{ pascalize .Name }} {{ if .IsArray }}[]{{ pascalize .Items.GoType }}{{ else }}{{ pascalize .GoType }}{{ end }}
-  if string(data.{{ pascalize .Name }}) != "null" {
-    {{ camelize .Name }}, err := Unmarshal{{ if .IsArray }}{{ pascalize .Items.GoType }}Slice{{ else }}{{ pascalize .GoType }}{{ end }}(bytes.NewBuffer(data.{{ pascalize .Name }}), runtime.JSONConsumer())
+  var prop{{ .GoName }} {{ if .IsArray }}[]{{ pascalize .Items.GoType }}{{ else }}{{ pascalize .GoType }}{{ end }}
+  if string(data.{{ .GoName }}) != "null" {
+    {{ camelize .Name }}, err := Unmarshal{{ if .IsArray }}{{ pascalize .Items.GoType }}Slice{{ else }}{{ pascalize .GoType }}{{ end }}(bytes.NewBuffer(data.{{ .GoName }}), runtime.JSONConsumer())
     if err != nil && !stderrors.Is(err, io.EOF) {
       return err
     }
-    prop{{ pascalize .Name }} = {{ camelize .Name }}
+    prop{{ .GoName }} = {{ camelize .Name }}
   }
       {{- else }}
-  prop{{ pascalize .Name }}, err := Unmarshal{{ if .IsArray }}{{ pascalize .Items.GoType }}Slice{{ else }}{{ pascalize .GoType }}{{ end }}(bytes.NewBuffer(data.{{ pascalize .Name }}), runtime.JSONConsumer())
+  prop{{ .GoName }}, err := Unmarshal{{ if .IsArray }}{{ pascalize .Items.GoType }}Slice{{ else }}{{ pascalize .GoType }}{{ end }}(bytes.NewBuffer(data.{{ .GoName }}), runtime.JSONConsumer())
   if err != nil && !stderrors.Is(err, io.EOF) {
     return err
   }
@@ -63,30 +63,30 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
     {{- end }}
   {{- end }}
 
-  var result {{ pascalize .Name }}
+  var result {{ .GoName }}
   {{ range $_, $parent := .AllOf }}
     {{- if $parent.IsAnonymous }}
       {{- if $parent.IsBaseType }}
         {{ range $idx, $val := $parent.Properties }}
           {{- if ne $parent.DiscriminatorField $val.Name }}
             {{- if $val.IsExported }}
-  result.{{ camelize $val.Name }}Field = base.{{ pascalize $val.Name }}
+  result.{{ camelize $val.Name }}Field = base.{{ $val.GoName }}
             {{- else }}
-  result.{{ camelize $val.Name }}Field = allOf{{ pascalize $val.Name }}
+  result.{{ camelize $val.Name }}Field = allOf{{ $val.GoName }}
             {{- end }}
           {{- else }}
-  if base.{{ pascalize $val.Name }} != result.{{ pascalize $val.Name }}() {
+  if base.{{ $val.GoName }} != result.{{ $val.GoName }}() {
     /* Not the type we're looking for. */
-    return errors.New(422, "invalid {{$val.Name}} value: %q", base.{{ pascalize $val.Name }})
+    return errors.New(422, "invalid {{$val.Name}} value: %q", base.{{ $val.GoName }})
   }
           {{- end }}
         {{- end }}
       {{- else }}
         {{ range $idx, $val := $parent.Properties }}
           {{- if $val.IsBaseType }}
-  result.{{ camelize $val.Name }}Field = allOf{{ pascalize $val.Name }}
+  result.{{ camelize $val.Name }}Field = allOf{{ $val.GoName }}
           {{- else }}
-  result.{{ pascalize $val.Name }} = data.{{ pascalize $val.Name }}
+  result.{{ $val.GoName }} = data.{{ $val.GoName }}
           {{- end }}
         {{- end }}
       {{- end }}
@@ -95,14 +95,14 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
         {{ range $idx, $val := $parent.Properties }}
           {{- if ne $parent.DiscriminatorField $val.Name }}
             {{- if $val.IsExported }}
-  result.{{ camelize $val.Name }}Field = base.{{ pascalize $val.Name }}
+  result.{{ camelize $val.Name }}Field = base.{{ $val.GoName }}
             {{ else }}
-  result.{{ camelize $val.Name }}Field = allOf{{ pascalize $val.Name }}
+  result.{{ camelize $val.Name }}Field = allOf{{ $val.GoName }}
             {{- end }}
           {{- else }}
-  if base.{{ pascalize $val.Name }} != result.{{ pascalize $val.Name }}() {
+  if base.{{ $val.GoName }} != result.{{ $val.GoName }}() {
     /* Not the type we're looking for. */
-    return errors.New(422, "invalid {{$val.Name}} value: %q", base.{{ pascalize $val.Name }})
+    return errors.New(422, "invalid {{$val.Name}} value: %q", base.{{ $val.GoName }})
   }
           {{- end }}
         {{- end }}
@@ -113,7 +113,7 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
   {{- end }}
   {{ range .Properties }}
   // {{ .Name }}
-  result.{{ if .IsBaseType }}{{ camelize .Name }}Field{{ else }}{{ pascalize .Name }}{{ end }} = {{ if .IsBaseType }}prop{{ pascalize .Name }}{{ else }}data.{{ pascalize .Name}}{{ end }}
+  result.{{ if .IsBaseType }}{{ camelize .Name }}Field{{ else }}{{ .GoName }}{{ end }} = {{ if .IsBaseType }}prop{{ .GoName }}{{ else }}data.{{ .GoName}}{{ end }}
   {{ end }}
   *{{ .ReceiverName }} = result
 
@@ -124,7 +124,7 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
     return err
   }
     {{ range .Properties }}
-  delete(rawProps, {{ printf "%q" .Name }})
+  delete(rawProps, {{ printf "%q" .OriginalName }})
     {{- end }}
     {{ if .AdditionalProperties }}
   if len(rawProps) > 0 {
@@ -146,7 +146,7 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
 }
 
 // MarshalJSON marshals this object with a polymorphic type to a JSON structure
-func ({{.ReceiverName}} {{ pascalize .Name }}) MarshalJSON() ([]byte, error) { {{ $receiverName := .ReceiverName }}
+func ({{.ReceiverName}} {{ .GoName }}) MarshalJSON() ([]byte, error) { {{ $receiverName := .ReceiverName }}
 	var b1, b2, b3 []byte
 	var err error
 	b1, err = json.Marshal({{ template "withoutBaseTypeBodyOrNonExported" . }})

--- a/generator/templates/serializers/tupleserializer.gotmpl
+++ b/generator/templates/serializers/tupleserializer.gotmpl
@@ -1,6 +1,6 @@
 {{ define "tupleSerializer" }}
 // UnmarshalJSON unmarshals this tuple type from a JSON array
-func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error {
+func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(raw []byte) error {
   // stage 1, get the array but just the array
   var stage1 []json.RawMessage
   buf := bytes.NewBuffer(raw)
@@ -16,14 +16,14 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
   var lastIndex int
   {{ end }}
   {{ range $idx, $val := .Properties }}if len(stage1) > {{ $idx }} {
-    var data{{ pascalize .Name }} {{ template "dereffedSchemaType" . }}
+    var data{{ .GoName }} {{ template "dereffedSchemaType" . }}
     buf = bytes.NewBuffer(stage1[{{ $idx }}])
     dec := json.NewDecoder(buf)
     dec.UseNumber()
-    if err := dec.Decode(&data{{ pascalize .Name }}); err != nil {
+    if err := dec.Decode(&data{{ .GoName }}); err != nil {
       return err
     }
-    {{ .ReceiverName }}.{{ if .IsExported }}{{ pascalize .Name }}{{ else }}{{ camelize .Name }}{{ end }} = {{ if .IsNullable }}&{{ end }}data{{ pascalize .Name }}
+    {{ .ReceiverName }}.{{ if .IsExported }}{{ .GoName }}{{ else }}{{ camelize .Name }}{{ end }} = {{ if .IsNullable }}&{{ end }}data{{ .GoName }}
     {{ if $.AdditionalItems }}
     lastIndex = {{ $idx }}
     {{ end }}
@@ -41,7 +41,7 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
         return err
       }
       {{- with .AdditionalItems }}
-        {{ $.ValueExpression }}.{{- if .IsExported }}{{ pascalize .Name }}{{ else }}{{ camelize .Name }}{{ end }} = append({{ $.ValueExpression }}.{{- if .IsExported }}{{ pascalize .Name }}{{ else }}{{ camelize .Name }}{{ end }}, toadd)
+        {{ $.ValueExpression }}.{{- if .IsExported }}{{ .GoName }}{{ else }}{{ camelize .Name }}{{ end }} = append({{ $.ValueExpression }}.{{- if .IsExported }}{{ .GoName }}{{ else }}{{ camelize .Name }}{{ end }}, toadd)
       {{- end }}
     }
   }
@@ -50,14 +50,14 @@ func ({{.ReceiverName}} *{{ pascalize .Name }}) UnmarshalJSON(raw []byte) error 
 }
 
 // MarshalJSON marshals this tuple type into a JSON array
-func ({{.ReceiverName}} {{ pascalize .Name }}) MarshalJSON() ([]byte, error) {
+func ({{.ReceiverName}} {{ .GoName }}) MarshalJSON() ([]byte, error) {
   data := []any{
   {{ range .Properties -}}
-    {{.ReceiverName}}.{{ pascalize .Name }},
+    {{.ReceiverName}}.{{ .GoName }},
   {{- end }}
   }
   {{ with .AdditionalItems }}
-  for _, v := range {{ $.ValueExpression }}.{{ if .IsExported }}{{ pascalize .Name }}{{ else }}{{ camelize .Name }}{{ end }} {
+  for _, v := range {{ $.ValueExpression }}.{{ if .IsExported }}{{ .GoName }}{{ else }}{{ camelize .Name }}{{ end }} {
     data = append(data, v)
   }
   {{- end }}

--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -13,7 +13,7 @@
   }
 
   if len(res) == 0 {
-    {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+    {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
   }
   {{- else if and .HasSimpleBodyParams .HasModelBodyItems }}
 
@@ -23,7 +23,7 @@
     {{- end }}
 
     {{- if .Schema.HasSliceValidations }}
-      {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+      {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
       {{ template "sliceparamvalidator" . }}
     {{- end }}
 
@@ -48,12 +48,12 @@
       {{- if not .Schema.HasSliceValidations }}
 
   if len(res) == 0 {
-    {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+    {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
   }
       {{- end }}
     {{- else }}
   // no validation for items in this slice
-  {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+  {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
     {{- end }}
 
   {{- else if and .HasSimpleBodyParams .HasModelBodyMap }}
@@ -91,33 +91,33 @@
   }
 
   if len(res) == 0 {
-    {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+    {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
   }
     {{- else }}
   // no validation for this map
-  {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+  {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
     {{- end }}
   {{- else if .HasSimpleBodyParams }}
     {{- if and (not .IsArray) (not .IsMap) .Schema.HasValidations }}
   // validate inline body
-  {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
-  if err := {{ .ReceiverName }}.validate{{ pascalize .ID }}Body(route.Formats); err != nil {
+  {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+  if err := {{ .ReceiverName }}.validate{{ .ID }}Body(route.Formats); err != nil {
     res = append(res, err)
   }
     {{- else if and (or .IsArray .IsMap) .Schema.HasValidations }}
   // validate inline body {{ if .IsArray }}array{{ else }}map{{ end }}
-  {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
-  if err := {{ .ReceiverName }}.validate{{ pascalize .ID }}Body(route.Formats); err != nil {
+  {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+  if err := {{ .ReceiverName }}.validate{{ .ID }}Body(route.Formats); err != nil {
     res = append(res, err)
   }
     {{- else  }}
   // no validation required on inline body
-  {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+  {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
     {{- end}}
   {{- else }}
     {{- if .IsInterface }}
   // no validation on generic interface
-  {{ .ReceiverName }}.{{ pascalize .Name }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
+  {{ .ReceiverName }}.{{ .ID }} = {{ if and (not .Schema.IsBaseType) .IsNullable }}&{{ end }}body
     {{- end }}
   {{- end }}
 {{- end }}
@@ -378,7 +378,7 @@ func New{{ pascalize .Name }}Params() {{ pascalize .Name }}Params {
 {{- end }}
 {{ end }}
   return {{ pascalize .Name }}Params{ {{ range .Params }}{{ if .HasDefault }}
-    {{ pascalize .ID}}: {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}&{{ end }}{{ varname .ID }}Default,
+    {{ .ID}}: {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}&{{ end }}{{ varname .ID }}Default,
   {{ end }}{{ end }} }
 }
 
@@ -406,7 +406,7 @@ type {{ pascalize .Name }}Params struct {
   Collection Format: {{ .CollectionFormat }}{{ end }}{{ if .HasDefault }}
   Default: {{ printGoLiteral .Default }}{{ end }}
   */
-  {{ if not .Schema }}{{ pascalize .ID }} {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}*{{ end }}{{.GoType}}{{ else }}{{ pascalize .Name }} {{ if and (not .Schema.IsBaseType) .IsNullable (not .Schema.IsStream) }}*{{ end }}{{.GoType}}{{ end }}
+  {{ if not .Schema }}{{ .ID }} {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}*{{ end }}{{.GoType}}{{ else }}{{ .ID }} {{ if and (not .Schema.IsBaseType) .IsNullable (not .Schema.IsStream) }}*{{ end }}{{.GoType}}{{ end }}
   {{- end}}
 }
 
@@ -427,7 +427,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
     runtime.BindFormMaxBody({{ pascalize .Name }}MaxBodySize),
   {{- range .Params }}
     {{- if .IsFileParam }}
-    runtime.BindFormFile({{ .Path }}, {{ or .Required (not .IsNullable) }}, {{ .ReceiverName }}.bind{{ pascalize .ID }}),
+    runtime.BindFormFile({{ .Path }}, {{ or .Required (not .IsNullable) }}, {{ .ReceiverName }}.bind{{ .ID }}),
     {{- end }}
   {{- end }}
   )
@@ -449,23 +449,23 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
     {{- if .IsQueryParam }}
 
   q{{ pascalize .Name }}, qhk{{ pascalize .Name }}, _ := qs.GetOK({{ .Path }})
-  if err := {{ .ReceiverName }}.bind{{ pascalize .ID }}(q{{ pascalize .Name }}, qhk{{ pascalize .Name }}, route.Formats); err != nil {
+  if err := {{ .ReceiverName }}.bind{{ .ID }}(q{{ pascalize .Name }}, qhk{{ pascalize .Name }}, route.Formats); err != nil {
     res = append(res, err)
   }
     {{- else if .IsPathParam }}
 
   r{{ pascalize .Name }}, rhk{{ pascalize .Name }}, _ := route.Params.GetOK({{ .Path }})
-  if err := {{ .ReceiverName }}.bind{{ pascalize .ID }}(r{{ pascalize .Name }}, rhk{{ pascalize .Name }}, route.Formats); err != nil {
+  if err := {{ .ReceiverName }}.bind{{ .ID }}(r{{ pascalize .Name }}, rhk{{ pascalize .Name }}, route.Formats); err != nil {
     res = append(res, err)
   }
     {{- else if .IsHeaderParam }}
 
-  if err := {{ .ReceiverName }}.bind{{ pascalize .ID }}(r.Header[http.CanonicalHeaderKey({{ .Path }})], true, route.Formats); err != nil {
+  if err := {{ .ReceiverName }}.bind{{ .ID }}(r.Header[http.CanonicalHeaderKey({{ .Path }})], true, route.Formats); err != nil {
     res = append(res, err)
   }
     {{- else if and .IsFormParam (not .IsFileParam) }}
   fd{{ pascalize .Name }}, fdhk{{ pascalize .Name }}, _ := fds.GetOK({{ .Path }})
-  if err := {{ .ReceiverName }}.bind{{ pascalize .ID }}(fd{{ pascalize .Name }}, fdhk{{ pascalize .Name }}, route.Formats); err != nil {
+  if err := {{ .ReceiverName }}.bind{{ .ID }}(fd{{ pascalize .Name }}, fdhk{{ pascalize .Name }}, route.Formats); err != nil {
     res = append(res, err)
   }
     {{- end }}
@@ -473,24 +473,24 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
     {{- if .IsQueryParam }}
 
   q{{ pascalize .Name }}, qhk{{ pascalize .Name }}, _ := qs.GetOK({{ .Path }})
-  if err := {{ .ReceiverName }}.bind{{ pascalize .ID }}(q{{ pascalize .Name }}, qhk{{ pascalize .Name }}, route.Formats); err != nil {
+  if err := {{ .ReceiverName }}.bind{{ .ID }}(q{{ pascalize .Name }}, qhk{{ pascalize .Name }}, route.Formats); err != nil {
     res = append(res, err)
   }
     {{- else if .IsPathParam }}
 
   r{{ pascalize .Name }}, rhk{{ pascalize .Name }}, _ := route.Params.GetOK({{ .Path }})
-  if err := {{ .ReceiverName }}.bind{{ pascalize .ID }}(r{{ pascalize .Name }}, rhk{{ pascalize .Name }}, route.Formats); err != nil {
+  if err := {{ .ReceiverName }}.bind{{ .ID }}(r{{ pascalize .Name }}, rhk{{ pascalize .Name }}, route.Formats); err != nil {
     res = append(res, err)
   }
     {{- else if .IsHeaderParam }}
 
-  if err := {{ .ReceiverName }}.bind{{ pascalize .ID }}(r.Header[http.CanonicalHeaderKey({{ .Path }})], true, route.Formats); err != nil {
+  if err := {{ .ReceiverName }}.bind{{ .ID }}(r.Header[http.CanonicalHeaderKey({{ .Path }})], true, route.Formats); err != nil {
     res = append(res, err)
   }
     {{- else if and .IsFormParam }}
 
   fd{{ pascalize .Name }}, fdhk{{ pascalize .Name }}, _ := fds.GetOK({{ .Path }})
-  if err := {{ .ReceiverName }}.bind{{ pascalize .ID }}(fd{{ pascalize .Name }}, fdhk{{ pascalize .Name }}, route.Formats); err != nil {
+  if err := {{ .ReceiverName }}.bind{{ .ID }}(fd{{ pascalize .Name }}, fdhk{{ pascalize .Name }}, route.Formats); err != nil {
     res = append(res, err)
   }
     {{- end }}
@@ -500,7 +500,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
 
   if runtime.HasBody(r) {
     {{- if .Schema.IsStream }}
-    {{ .ReceiverName }}.{{ pascalize .Name }} = r.Body
+    {{ .ReceiverName }}.{{ .ID }} = r.Body
     {{- else }}
     defer func() {
       _ = r.Body.Close()
@@ -547,10 +547,10 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
 {{- $className := (pascalize .Name) }}
 {{ range .Params }}
   {{- if .IsFileParam }}
-// bind{{ pascalize .ID }} validates file parameter File1 and assigns it as a *runtime.File on success.
+// bind{{ .ID }} validates file parameter File1 and assigns it as a *runtime.File on success.
 //
 // The only supported validations on files are MinLength and MaxLength
-func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ pascalize .ID }}(file multipart.File, header *multipart.FileHeader) error {
+func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ .ID }}(file multipart.File, header *multipart.FileHeader) error {
     {{- if or .MinLength .MaxLength }}
     size, err := file.Seek(0, io.SeekEnd)
     if err != nil {
@@ -574,14 +574,14 @@ func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ pascalize .ID }}(file 
     }
     {{- end }}
 
-    {{ .ReceiverName }}.{{ pascalize .Name }} = &runtime.File{Data: file, Header: header}
+    {{ .ReceiverName }}.{{ .ID }} = &runtime.File{Data: file, Header: header}
     return nil
 }
   {{- else if not .IsBodyParam }}
     {{- if or .IsPrimitive .IsCustomFormatter }}
 
-// bind{{ pascalize .ID }} binds and validates parameter {{ .ID }} from {{ .Location }}.
-func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ pascalize .ID }}(rawData []string, hasKey bool, formats strfmt.Registry) error {
+// bind{{ .ID }} binds and validates parameter {{ .ID }} from {{ .Location }}.
+func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ .ID }}(rawData []string, hasKey bool, formats strfmt.Registry) error {
       {{- if and (not .IsPathParam) .Required }}
     if !hasKey {
         return errors.Required({{ .Path }}, {{ printf "%q" .Location }}, rawData)
@@ -636,7 +636,7 @@ func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ pascalize .ID }}(rawDa
 
       {{- if .HasValidations }}
 
-  if err := {{ .ReceiverName }}.validate{{ pascalize .ID }}(formats); err != nil {
+  if err := {{ .ReceiverName }}.validate{{ .ID }}(formats); err != nil {
     return err
   }
       {{- end }}
@@ -645,10 +645,10 @@ func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ pascalize .ID }}(rawDa
 }
     {{- else if .IsArray }}
 
-// bind{{ pascalize .ID }} binds and validates array parameter {{ .ID }} from {{ .Location }}.
+// bind{{ .ID }} binds and validates array parameter {{ .ID }} from {{ .Location }}.
 //
 // Arrays are parsed according to CollectionFormat: "{{ .CollectionFormat }}" (defaults to "csv" when empty).
-func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ pascalize .ID }}(rawData []string, hasKey bool, formats strfmt.Registry) error {
+func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ .ID }}(rawData []string, hasKey bool, formats strfmt.Registry) error {
       {{- if .Required }}
   if !hasKey {
     return errors.Required({{ .Path }}, {{ printf "%q" .Location }}, rawData)
@@ -680,7 +680,7 @@ func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ pascalize .ID }}(rawDa
       {{ template "sliceparambinder" . }}
   {{ .ValueExpression }} = {{ varname .Child.ValueExpression }}R
       {{- if .HasSliceValidations }}
-  if err := {{ .ReceiverName }}.validate{{ pascalize .ID }}(formats); err != nil {
+  if err := {{ .ReceiverName }}.validate{{ .ID }}(formats); err != nil {
     return err
   }
       {{- end }}
@@ -691,8 +691,8 @@ func ({{ .ReceiverName }} *{{ $className }}Params) bind{{ pascalize .ID }}(rawDa
 
     {{- if or (and (not .IsArray) .HasValidations) (and .IsArray .HasSliceValidations) }}
 
-// validate{{ pascalize .ID }} carries out validations for parameter {{ .ID }}
-func ({{ .ReceiverName }} *{{ $className }}Params) validate{{ pascalize .ID }}(formats strfmt.Registry) error {
+// validate{{ .ID }} carries out validations for parameter {{ .ID }}
+func ({{ .ReceiverName }} *{{ $className }}Params) validate{{ .ID }}(formats strfmt.Registry) error {
   {{ template "propertyparamvalidator" . }}
   return nil
 }
@@ -702,8 +702,8 @@ func ({{ .ReceiverName }} *{{ $className }}Params) validate{{ pascalize .ID }}(f
     {{- if and .HasSimpleBodyParams (not .HasModelBodyItems) (not .HasModelBodyMap) }}
       {{- if .Schema.HasValidations }}
 
-// validate{{ pascalize .ID }}Body validates an inline body parameter
-func ({{ .ReceiverName }} *{{ $className }}Params) validate{{ pascalize .ID }}Body(formats strfmt.Registry) error {
+// validate{{ .ID }}Body validates an inline body parameter
+func ({{ .ReceiverName }} *{{ $className }}Params) validate{{ .ID }}Body(formats strfmt.Registry) error {
         {{- if .IsArray }}
           {{- if .HasSliceValidations }}
               {{- template "sliceparamvalidator" . }}

--- a/generator/templates/server/responses.gotmpl
+++ b/generator/templates/server/responses.gotmpl
@@ -4,10 +4,10 @@
 {{ define "simpleserverheaderbuilder" }}
 {{ if .IsNullable -}}
 var {{ varname .ID }} string
-if {{ .ReceiverName }}.{{ pascalize .ID }} != nil {
-  {{ varname .ID }} = {{ if .Formatter }}{{ .Formatter }}(*{{ .ReceiverName }}.{{ pascalize .ID }}){{ else }}{{ if not .IsCustomFormatter }}*{{ end }}{{ .ReceiverName }}.{{ pascalize .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
+if {{ .ReceiverName }}.{{ .ID }} != nil {
+  {{ varname .ID }} = {{ if .Formatter }}{{ .Formatter }}(*{{ .ReceiverName }}.{{ .ID }}){{ else }}{{ if not .IsCustomFormatter }}*{{ end }}{{ .ReceiverName }}.{{ .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
 }
-{{ else }}{{ varname .ID }} := {{ if .Formatter }}{{ .Formatter }}({{ .ReceiverName }}.{{ pascalize .ID }}){{ else }}{{ .ReceiverName }}.{{ pascalize .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
+{{ else }}{{ varname .ID }} := {{ if .Formatter }}{{ .Formatter }}({{ .ReceiverName }}.{{ .ID }}){{ else }}{{ .ReceiverName }}.{{ .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
 {{ end -}}
 if {{ varname .ID }} != "" {
   rw.Header().Set({{ printf "%q" .Name }}, {{ varname .ID }})
@@ -73,7 +73,7 @@ type {{ pascalize .Name }} struct {
   Unique: true{{ end }}{{ if .HasDefault }}
   Default: {{ printGoLiteral .Default }}{{ end }}
   */
-  {{ pascalize .Name }} {{ .GoType }} `json:"{{.Name}}{{ if not .Required }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+  {{ .ID }} {{ .GoType }} `json:"{{.Name}}{{ if not .Required }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
   {{ end }}
   {{ if .Schema }}{{ with .Schema }}
   /*{{if .Description }}{{ blockcomment .Description }}{{ end }}{{ if .Maximum }}
@@ -136,7 +136,7 @@ if code <= 0 {
   return &{{ pascalize .Name }}{
     {{ if eq .Code -1 }}_statusCode: code,{{ end }}
     {{ range .Headers }}{{ if .HasDefault }}
-    {{ pascalize .Name}}: {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}&{{ end }}{{ varname .ID }}Default,
+    {{ .ID }}: {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}&{{ end }}{{ varname .ID }}Default,
     {{ end }}
   {{ end -}}
   }
@@ -154,15 +154,15 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) SetStatusCode(code int) {
   {{ .ReceiverName }}._statusCode = code
 }
 {{ end }}{{ range .Headers }}
-// With{{ pascalize .Name }} adds the {{ camelize .Name  }} to the {{ humanize $.Name }} response
-func ({{ $.ReceiverName }} *{{ pascalize $.Name }}) With{{ pascalize .Name }}({{ varname .Name  }} {{ .GoType}}) *{{ pascalize $.Name }} {
-  {{ $.ReceiverName }}.{{ pascalize .Name }} = {{ varname .Name  }}
+// With{{ .ID }} adds the {{ camelize .Name  }} to the {{ humanize $.Name }} response
+func ({{ $.ReceiverName }} *{{ pascalize $.Name }}) With{{ .ID }}({{ varname .Name  }} {{ .GoType}}) *{{ pascalize $.Name }} {
+  {{ $.ReceiverName }}.{{ .ID }} = {{ varname .Name  }}
   return {{ .ReceiverName }}
 }
 
-// Set{{ pascalize .Name }} sets the {{ camelize .Name  }} to the {{ humanize $.Name }} response
-func ({{ $.ReceiverName }} *{{ pascalize $.Name }}) Set{{ pascalize .Name }}({{ varname .Name  }} {{ .GoType}}) {
-  {{ $.ReceiverName }}.{{ pascalize .Name }} = {{ varname .Name  }}
+// Set{{ .ID }} sets the {{ camelize .Name  }} to the {{ humanize $.Name }} response
+func ({{ $.ReceiverName }} *{{ pascalize $.Name }}) Set{{ .ID }}({{ varname .Name  }} {{ .GoType}}) {
+  {{ $.ReceiverName }}.{{ .ID }} = {{ varname .Name  }}
 }
 {{ end }}{{ if .Schema }}
 // WithPayload adds the payload to the {{ humanize .Name }} response

--- a/generator/templates/server/urlbuilder.gotmpl
+++ b/generator/templates/server/urlbuilder.gotmpl
@@ -4,10 +4,10 @@
 {{ define "simplequeryparambuilder" }}
 {{ if .IsNullable -}}
 var {{ varname .ID }}Q string
-if {{ .ReceiverName }}.{{ pascalize .ID }} != nil {
-  {{ varname .ID }}Q = {{ if .Formatter }}{{ .Formatter }}(*{{ .ReceiverName }}.{{ pascalize .ID }}){{ else }}{{ if not .IsCustomFormatter }}*{{ end }}{{ .ReceiverName }}.{{ pascalize .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
+if {{ .ReceiverName }}.{{ .ID }} != nil {
+  {{ varname .ID }}Q = {{ if .Formatter }}{{ .Formatter }}(*{{ .ReceiverName }}.{{ .ID }}){{ else }}{{ if not .IsCustomFormatter }}*{{ end }}{{ .ReceiverName }}.{{ .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
 }
-{{ else }}{{ varname .ID }}Q := {{ if .Formatter }}{{ .Formatter }}({{ .ReceiverName }}.{{ pascalize .ID }}){{ else }}{{ .ReceiverName }}.{{ pascalize .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
+{{ else }}{{ varname .ID }}Q := {{ if .Formatter }}{{ .Formatter }}({{ .ReceiverName }}.{{ .ID }}){{ else }}{{ .ReceiverName }}.{{ .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
 {{ end -}}
 if {{ varname .ID }}Q != "" {
   qs.Set({{ printf "%q" .Name }}, {{ varname .ID }}Q)
@@ -105,10 +105,10 @@ import (
 // {{ pascalize .Name }}URL generates an URL for the {{ humanize .Name }} operation
 type {{ pascalize .Name }}URL struct {
   {{ range .PathParams }}
-  {{ pascalize .ID }} {{.GoType}}
+  {{ .ID }} {{.GoType}}
   {{- end }}
   {{ range .QueryParams }}
-  {{ pascalize .ID }} {{ if and (not .IsArray) .IsNullable }}*{{ end }}{{.GoType}}
+  {{ .ID }} {{ if and (not .IsArray) .IsNullable }}*{{ end }}{{.GoType}}
   {{- end }}
 
   _basePath string
@@ -143,7 +143,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}URL) Build() (*url.URL, error) {
   {{ range .PathParams }}{{ if .IsArray }}
     {{ template "slicepathparambuilder" . -}}
   {{ else }}
-  {{ varname .ID }} := {{ if .Formatter }}{{ .Formatter }}({{ .ReceiverName }}.{{ pascalize .ID }}){{ else }}{{ .ReceiverName }}.{{ pascalize .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
+  {{ varname .ID }} := {{ if .Formatter }}{{ .Formatter }}({{ .ReceiverName }}.{{ .ID }}){{ else }}{{ .ReceiverName }}.{{ .ID }}{{ if .IsCustomFormatter }}.String(){{end}}{{end}}
   if {{ varname .ID }} != "" {
     _path = strings.ReplaceAll(_path, "{{ printf "{%s}" .Name }}", {{ varname .ID }})
   } else {

--- a/generator/templates/structfield.gotmpl
+++ b/generator/templates/structfield.gotmpl
@@ -3,7 +3,7 @@
     // {{ template "docstring" . }}
     {{- template "propertyValidationDocString" .}}
   {{- end}}
-{{ pascalize .Name}} {{ template "schemaType" . }} {{ .PrintTags }}
+{{ .GoName }} {{ template "schemaType" . }} {{ .PrintTags }}
 {{ end }}
 
 {{- define "tuplefield" }}
@@ -11,7 +11,7 @@
     // {{ template "docstring" . }}
     {{- template "propertyValidationDocString" .}}
 {{ end }}
-{{- pascalize .Name}} {{ template "schemaType" . }} `json:"-"
+{{- .GoName }} {{ template "schemaType" . }} `json:"-"
 {{- if .CustomTag }} {{ .CustomTag }}{{ end }}` // custom serializer
 {{ end }}
 
@@ -20,16 +20,16 @@
     // {{ template "docstring" . }}
     {{- template "propertyValidationDocString" .}}
   {{- end }}
-{{ pascalize .Name}}() {{ template "schemaType" . }}
-Set{{ pascalize .Name}}({{ template "schemaType" . }})
+{{ .GoName }}() {{ template "schemaType" . }}
+Set{{ .GoName }}({{ template "schemaType" . }})
 {{ end }}
 {{ define "tuplefieldIface" }}
   {{- if not $.IsBaseType -}}
     // {{ template "docstring" . }}
     {{- template "propertyValidationDocString" . }}
 {{ end }}
-{{- pascalize .Name}}() {{ template "schemaType" . }}
-Set{{ pascalize .Name}}({{ template "schemaType" . }})
+{{- .GoName }}() {{ template "schemaType" . }}
+Set{{ .GoName }}({{ template "schemaType" . }})
 {{ end }}
 
 {{- define "privstructfield" }}


### PR DESCRIPTION
PR fixes #3319 - `x-go-name` was erroneously overridden by common initialism rules (e.g., `x-go-name: NoTls` becoming `NoTLS`).

- Updated `knownDefGoType` in `generator/types.go` to intercept `x-go-name` for internal schemas and process the name string using `Camelize` instead of `ToGoName`.
- Ignored (`isExternalType`).
- Adjusted hardcoded string expectations in `generator/typeresolver_test.go` to match the accurate camel-cased formatting outputs.

Verified locally. All tests passing:
`ok  	github.com/go-swagger/go-swagger/generator`