### PR TITLE
Add opt-in --with-stringer to generate model String() methods

### DIFF
--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -19,6 +19,7 @@ type modelOptions struct {
 	AllDefinitions             bool     `description:"generate all model definitions regardless of usage in operations"                                      hidden:"deprecated"                          long:"all-definitions"`
 	StructTags                 []string `description:"the struct tags to generate, repeat for multiple (defaults to json)"                                   long:"struct-tags"`
 	RootedErrorPath            bool     `description:"extends validation errors with the type name instead of an empty path, in the case of arrays and maps" long:"rooted-error-path"`
+	WithStringer               bool     `description:"generate a fmt.Stringer String() method on models, rendering field values as JSON (see issue #872)"    long:"with-stringer"`
 }
 
 func (mo modelOptions) apply(opts *generator.GenOpts) {
@@ -30,6 +31,7 @@ func (mo modelOptions) apply(opts *generator.GenOpts) {
 	opts.IgnoreOperations = mo.AllDefinitions
 	opts.StructTags = mo.StructTags
 	opts.WantsRootedErrorPath = mo.RootedErrorPath
+	opts.WantsStringer = mo.WithStringer
 }
 
 // WithModels adds the model options group.

--- a/docs/generate/model.md
+++ b/docs/generate/model.md
@@ -48,6 +48,7 @@ Help Options:
           --keep-spec-order                                                       keep schema properties order identical to spec file
           --struct-tags=                                                          the struct tags to generate, repeat for multiple (defaults to json)
           --rooted-error-path                                                     extends validation errors with the type name instead of an empty path, in the case of arrays and maps
+          --with-stringer                                                         generate a fmt.Stringer String() method on models, rendering field values as JSON (see issue #872)
 ```
 
 Schema generation rules are detailed [here](../reference/models/schemas.md).

--- a/fixtures/bugs/872/872.yaml
+++ b/fixtures/bugs/872/872.yaml
@@ -1,0 +1,29 @@
+swagger: "2.0"
+info:
+  description: 'repro issue #872 - render model field values as a string'
+  title: stringer
+  version: "0.0.0"
+paths:
+  /v1/error:
+    get:
+      produces:
+        - application/json
+      responses:
+        default:
+          description: error
+          schema:
+            $ref: '#/definitions/ModelError'
+
+definitions:
+  ModelError:
+    type: object
+    required:
+      - message
+    properties:
+      message:
+        type: string
+        description: the human readable error message (a required string is generated as a pointer)
+      code:
+        type: integer
+        format: int64
+        description: an optional error code (also generated as a pointer)

--- a/generator/genopts.go
+++ b/generator/genopts.go
@@ -80,6 +80,7 @@ type GenOpts struct {
 	StrictResponders       bool
 	AcceptDefinitionsOnly  bool
 	WantsRootedErrorPath   bool
+	WantsStringer          bool
 	ReturnErrors           bool
 	WithCustomFormatter    bool
 	WithExtraInitialisms   []string

--- a/generator/model.go
+++ b/generator/model.go
@@ -262,6 +262,7 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 		WithXML:                    opts.WithXML,
 		StructTags:                 opts.StructTags,
 		WantsRootedErrorPath:       opts.WantsRootedErrorPath,
+		WantsStringer:              opts.WantsStringer,
 		mangler:                    opts.LanguageOpts.Mangler,
 		pascalize:                  pascalize,
 		jsonify:                    jsonify,
@@ -453,6 +454,7 @@ type schemaGenContext struct {
 	IncludeModel               bool
 	StrictAdditionalProperties bool
 	WantsRootedErrorPath       bool
+	WantsStringer              bool
 	WithXML                    bool
 	Index                      int
 
@@ -1747,6 +1749,7 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	sg.GenSchema.StructTags = sg.StructTags
 	sg.GenSchema.ExtraImports = make(map[string]string)
 	sg.GenSchema.WantsRootedErrorPath = sg.WantsRootedErrorPath
+	sg.GenSchema.WantsStringer = sg.WantsStringer
 	sg.GenSchema.IsElem = sg.IsElem
 	sg.GenSchema.IsProperty = sg.IsProperty
 	sg.GenSchema.GoName = schemaGoName(&sg.Schema, sg.Name, sg.mangler)
@@ -1901,6 +1904,14 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	gs := sg.GenSchema
 	sg.GenSchema.WantsMarshalBinary = !gs.IsInterface && !gs.IsStream && !gs.IsBaseType &&
 		(gs.IsTuple || gs.IsComplexObject || gs.IsAdditionalProperties || (gs.IsPrimitive && gs.IsAliased && gs.IsCustomFormatter && !strings.Contains(gs.Zero(), `("`)))
+
+	// generate a fmt.Stringer String() method when the --with-stringer option is set.
+	// This opt-in renders the model field values (as JSON) rather than the Go syntax
+	// representation, so that pointer properties show their value, not their address.
+	// Restricted to the struct/tuple/map shapes that use a pointer receiver, mirroring
+	// MarshalBinary (see issue #872).
+	sg.GenSchema.WantsStringer = sg.WantsStringer && !gs.IsInterface && !gs.IsStream && !gs.IsBaseType &&
+		(gs.IsTuple || gs.IsComplexObject || gs.IsAdditionalProperties)
 
 	debugLogf("finished gen schema for %q", sg.Name)
 

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -2842,3 +2842,55 @@ func TestIssue2597(t *testing.T) {
 		})
 	})
 }
+
+// TestIssue872 covers the opt-in fmt.Stringer String() method on generated models.
+//
+// The original issue reported that formatting a model with %+v prints pointer
+// addresses for pointer properties (e.g. a required *string) rather than their
+// values. The String() method renders the field values as JSON instead.
+func TestIssue872(t *testing.T) {
+	specDoc, err := loads.Spec("../fixtures/bugs/872/872.yaml")
+	require.NoError(t, err)
+
+	definitions := specDoc.Spec().Definitions
+	const model = "ModelError"
+
+	render := func(t *testing.T, opts *GenOpts) string {
+		t.Helper()
+
+		genModel, err := makeGenDefinition(model, "models", definitions[model], specDoc, opts)
+		require.NoError(t, err)
+
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, opts.templates.MustGet("model").Execute(buf, genModel))
+
+		ct, err := opts.LanguageOpts.FormatContent("model.go", buf.Bytes())
+		require.NoErrorf(t, err, "format error: %v\n%s", err, buf.String())
+
+		return string(ct)
+	}
+
+	t.Run("with WantsStringer option", func(t *testing.T) {
+		opts := opts()
+		opts.WantsStringer = true
+
+		res := render(t, opts)
+
+		// the model gains a fmt.Stringer implementation with a pointer receiver
+		assertInCode(t, "func (m *ModelError) String() string {", res)
+		// it renders field values via the JSON serializer (GlenDC's json.Marshal idea),
+		// reusing the same helper as MarshalBinary - so pointer fields print their value
+		assertInCode(t, "jsonutils.WriteJSON(m)", res)
+		// it must NOT format the model with the Go-syntax verbs that leak pointer addresses
+		assertRegexpNotInCode(t, `String\(\)[\s\S]*fmt\.Sprintf\(\s*"%\+?v"`, res)
+	})
+
+	t.Run("without WantsStringer option (default)", func(t *testing.T) {
+		opts := opts()
+
+		res := render(t, opts)
+
+		// opt-in: the default output is unchanged, no String() method is emitted
+		assertNotInCode(t, "func (m *ModelError) String() string {", res)
+	})
+}

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -103,6 +103,7 @@ type GenSchema struct {
 	IncludeModel               bool
 	Default                    any
 	WantsMarshalBinary         bool // do we generate MarshalBinary interface?
+	WantsStringer              bool // do we generate the fmt.Stringer String() method?
 	StructTags                 []string
 	ExtraImports               map[string]string // non-standard imports detected when using external types
 	ExternalDocs               *spec.ExternalDocumentation

--- a/generator/template_repo.go
+++ b/generator/template_repo.go
@@ -140,6 +140,7 @@ func defaultAssets() map[string][]byte {
 		"allofserializer.gotmpl":                MustAsset("templates/serializers/allofserializer.gotmpl"),
 		"basetypeserializer.gotmpl":             MustAsset("templates/serializers/basetypeserializer.gotmpl"),
 		"marshalbinaryserializer.gotmpl":        MustAsset("templates/serializers/marshalbinaryserializer.gotmpl"),
+		"stringerserializer.gotmpl":             MustAsset("templates/serializers/stringerserializer.gotmpl"),
 		"schemaserializer.gotmpl":               MustAsset("templates/serializers/schemaserializer.gotmpl"),
 		"subtypeserializer.gotmpl":              MustAsset("templates/serializers/subtypeserializer.gotmpl"),
 		"tupleserializer.gotmpl":                MustAsset("templates/serializers/tupleserializer.gotmpl"),

--- a/generator/templates/schema.gotmpl
+++ b/generator/templates/schema.gotmpl
@@ -112,6 +112,9 @@ func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperti
 {{- if .WantsMarshalBinary }}
   {{ template "marshalBinarySerializer" . }}
 {{- end }}
+{{- if .WantsStringer }}
+  {{ template "stringerSerializer" . }}
+{{- end }}
 {{- define "mapOrSliceGetter" }}{{/* signature for AdditionalProperties and AdditionalItems getter funcs */}}
   {{- if not .IsBaseType }}
     {{- if .HasAdditionalProperties }}

--- a/generator/templates/serializers/stringerserializer.gotmpl
+++ b/generator/templates/serializers/stringerserializer.gotmpl
@@ -1,0 +1,16 @@
+{{ define "stringerSerializer" }}
+// String implements the fmt.Stringer interface.
+//
+// It renders the field values of this {{ humanize .Name }} as JSON, so that pointer
+// properties show their value rather than their address when formatted with %s or %v.
+func ({{.ReceiverName}} *{{ .GoName }}) String() string {
+  if {{ .ReceiverName }} == nil {
+    return "null"
+  }
+  b, err := jsonutils.WriteJSON({{ .ReceiverName }})
+  if err != nil {
+    return err.Error()
+  }
+  return string(b)
+}
+{{- end }}


### PR DESCRIPTION
## Summary

Generated models have no `fmt.Stringer`, so printing one with `%v` / `%+v` shows pointer addresses instead of field values (#872).

This adds a **`--with-stringer`** generator option that emits a `String()` method rendering the model as JSON — the approach @GlenDC proposed and @casualjim / @fredbi were OK with in the issue thread.

It is **opt-in**: without the flag, generation output is byte-for-byte unchanged (the default example fixtures are untouched), so existing users are unaffected. With the flag, each model gets a `String()` that marshals it to JSON.

(The issue's original `%+v` client-error complaint was already fixed separately in `response.gotmpl`; this addresses the remaining ask — giving the models themselves a Stringer.)

Added a generator test (`TestIssue872`) covering the option both on and off.

Closes #872
