### PR TITLE
docs: add killed-process troubleshooting

### DIFF
--- a/docs/usage/generate.md
+++ b/docs/usage/generate.md
@@ -54,6 +54,39 @@ Use this checklist when `swagger validate` succeeds locally but generation fails
 | Generated code does not compile after a successful run | Ensure the generated target is a Go module that can resolve the generated dependencies | In a new target, run `go mod init` and `go mod tidy` after generation |
 | `goimports` or formatting-related failures appear | Verify Go is installed and available on `PATH` in the same shell running `swagger` | Run `go version` before retrying generation |
 | Operations or models are missing | Check that the spec validates and that flags such as `--operation`, `--model`, `--include-tag`, or `--exclude-tag` match the spec exactly | Start without selection flags, then add them back one at a time |
+| The shell only prints `zsh: killed` or `Killed` during generation | The operating system probably terminated `swagger` with `SIGKILL`, most often because the process exceeded available memory or a configured resource limit | Check memory pressure and limits before assuming the spec is invalid |
+
+### `zsh: killed` or `Killed` during generation
+
+If `swagger generate ...` exits with only `zsh: killed` on macOS or `Killed` on Linux, the message is emitted by the shell after the operating system terminates the process. The process usually does not get a chance to print a Go panic or a go-swagger error.
+
+Common causes include:
+
+- memory pressure while flattening or expanding a large spec with many `$ref`, `allOf`, or generated operations;
+- the kernel out-of-memory killer selecting the `swagger` process on Linux;
+- a per-shell or CI resource limit such as `ulimit -v`, `ulimit -m`, `ulimit -t`, or a container memory limit;
+- running generation together with other memory-heavy tasks in the same job.
+
+Useful checks on macOS:
+
+```sh
+ulimit -a
+vm_stat
+/usr/bin/time -l swagger generate server -f ./api/swagger.yml --target ./gen
+```
+
+Useful checks on Linux:
+
+```sh
+ulimit -a
+free -h
+dmesg -T | tail -50
+/usr/bin/time -v swagger generate server -f ./api/swagger.yml --target ./gen
+```
+
+To reduce peak memory use, try validating the same input first, closing other memory-heavy processes, increasing the CI/container memory limit, and generating from a smaller or pre-flattened spec when practical. If the command uses selection flags, retry without them and then add `--operation`, `--model`, `--include-tag`, or `--exclude-tag` back one at a time.
+
+When reporting this problem, include the exact `swagger generate` command, `swagger version`, Go version if the binary was built from source, operating system, available memory or CI/container limit, `ulimit -a`, whether the spec is public, and any OOM evidence from `dmesg`, the macOS Console, or the CI logs.
 
 A minimal validation-first flow is:
 
@@ -67,4 +100,4 @@ go mod tidy
 go test ./...
 ```
 
-When reporting an issue, include the exact `swagger` command, the path to the spec as passed with `-f`, the current working directory, and the validation output. Those details usually determine whether the failure is a spec problem, a path problem, or a generated-code setup problem.
+When reporting an issue, include the exact `swagger` command, the path to the spec as passed with `-f`, the current working directory, and the validation output. Those details usually determine whether the failure is a spec problem, a path problem, a resource-limit problem, or a generated-code setup problem.


### PR DESCRIPTION
## Summary
- add troubleshooting guidance for `zsh: killed` / `Killed` during `swagger generate`
- document likely resource-limit and memory-pressure causes
- add macOS and Linux diagnostic commands and issue-reporting details

References #3171.

## Test plan
- Docs-only change; no code tests run.
- Reviewed the rendered Markdown diff locally.