### PR TITLE
fix: honor anonymous security alternatives

### DIFF
--- a/fixtures/bugs/1214/fixture-1214.yaml
+++ b/fixtures/bugs/1214/fixture-1214.yaml
@@ -74,3 +74,13 @@ paths:
       responses:
         default:
           description: Generic Out
+  /optional-sec:
+    get:
+      security:
+        - {}
+        - A: []
+      operationId: optionalSecOp
+      description: no description
+      responses:
+        default:
+          description: Generic Out

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -166,7 +166,7 @@ func (o *operationGenerator) Generate() error {
 		APIPackage:          o.APIPackage, // defaults to main operations package
 		DefaultProduces:     o.DefaultProduces,
 		DefaultConsumes:     o.DefaultConsumes,
-		Authed:              len(o.Analyzed.SecurityRequirementsFor(&o.Operation)) > 0,
+		Authed:              requiresAuthentication(o.Analyzed.SecurityRequirementsFor(&o.Operation)),
 		Security:            o.Analyzed.SecurityRequirementsFor(&o.Operation),
 		SecurityDefinitions: o.Analyzed.SecurityDefinitionsFor(&o.Operation),
 		RootAPIPackage:      o.GenOpts.LanguageOpts.ManglePackageName(o.ServerPackage, defaultServerTarget),
@@ -1072,6 +1072,9 @@ func (b *codeGenOpBuilder) makeSecurityRequirements(_ string) []GenSecurityRequi
 
 	securityRequirements := make([]GenSecurityRequirements, 0, len(b.Security))
 	for _, req := range b.Security {
+		if isAnonymousSecurityRequirement(req) {
+			continue
+		}
 		jointReq := make(GenSecurityRequirements, 0, len(req))
 		for _, j := range req {
 			scopes := j.Scopes
@@ -1086,6 +1089,20 @@ func (b *codeGenOpBuilder) makeSecurityRequirements(_ string) []GenSecurityRequi
 		securityRequirements = append(securityRequirements, jointReq)
 	}
 	return securityRequirements
+}
+
+func requiresAuthentication(securityRequirements [][]analysis.SecurityRequirement) bool {
+	if len(securityRequirements) == 0 {
+		return false
+	}
+	return !slices.ContainsFunc(securityRequirements, func(requirement []analysis.SecurityRequirement) bool {
+		return isAnonymousSecurityRequirement(requirement)
+	})
+}
+
+func isAnonymousSecurityRequirement(requirement []analysis.SecurityRequirement) bool {
+	return len(requirement) == 0 ||
+		len(requirement) == 1 && requirement[0].Name == "" && len(requirement[0].Scopes) == 0
 }
 
 // cloneSchema returns a deep copy of a schema.

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -1167,6 +1167,22 @@ func TestGenSecurityRequirements(t *testing.T) {
 	genRequirements := b.makeSecurityRequirements("o")
 	assert.NotNil(t, genRequirements)
 	assert.Empty(t, genRequirements)
+	assert.False(t, requiresAuthentication(b.Security))
+
+	operation = "optionalSecOp"
+	b, err = opBuilder(operation, "../fixtures/bugs/1214/fixture-1214.yaml")
+	require.NoError(t, err)
+
+	b.Security = b.Analyzed.SecurityRequirementsFor(&b.Operation)
+	genRequirements = b.makeSecurityRequirements("o")
+	assert.Len(t, genRequirements, 1)
+	assert.Equal(t, GenSecurityRequirements{
+		GenSecurityRequirement{
+			Name:   "A",
+			Scopes: []string{},
+		},
+	}, genRequirements[0])
+	assert.False(t, requiresAuthentication(b.Security))
 
 	operation = "nosecOp"
 	b, err = opBuilder(operation, "../fixtures/bugs/1214/fixture-1214-2.yaml")
@@ -1175,6 +1191,7 @@ func TestGenSecurityRequirements(t *testing.T) {
 	b.Security = b.Analyzed.SecurityRequirementsFor(&b.Operation)
 	genRequirements = b.makeSecurityRequirements("o")
 	assert.Nil(t, genRequirements)
+	assert.False(t, requiresAuthentication(b.Security))
 }
 
 func TestGenerateServerOperation(t *testing.T) {

--- a/generator/support.go
+++ b/generator/support.go
@@ -350,7 +350,7 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 			continue // operation filtered according to CLI params
 		}
 
-		bldr.Authed = len(a.Analyzed.SecurityRequirementsFor(o)) > 0
+		bldr.Authed = requiresAuthentication(a.Analyzed.SecurityRequirementsFor(o))
 		bldr.Security = a.Analyzed.SecurityRequirementsFor(o)
 		bldr.SecurityDefinitions = a.Analyzed.SecurityDefinitionsFor(o)
 		bldr.RootAPIPackage = a.GenOpts.LanguageOpts.ManglePackageName(a.ServerPackage, defaultServerTarget)


### PR DESCRIPTION
Summary
- Treat empty or blank analyzed security requirements as anonymous alternatives when setting generated operation auth.
- Skip anonymous placeholders from generated security requirement metadata.
- Add regression coverage for `security: [{}, { A: [] }]`.

Relates to #1446.

Validation
- `go test ./generator -run TestGenSecurityRequirements`
- `git diff --check`
