### PR TITLE
fix(codegen): makes producers/consumers stable across generations.

### DIFF
--- a/fixtures/bugs/3394/swagger.yaml
+++ b/fixtures/bugs/3394/swagger.yaml
@@ -1,0 +1,71 @@
+swagger: "2.0"
+
+info:
+  title: Internal
+  version: 0.0.0
+
+consumes:
+  - application/json
+
+produces:
+  - application/json
+  - application/protobuf+json
+
+schemes:
+  - http
+
+definitions:
+  request:
+    type: object
+    required:
+      - interface_name
+    properties:
+      interface_name:
+        type: string
+        default: eth0
+        x-nullable: false
+
+paths:
+  /protobuf/{device_type}/{serial}/TYPE_REQUEST/{id}:
+    post:
+      summary: request protobuf
+      operationId: reqProto
+      produces: # use protojson to encode a proto.Message instead of Go stdlib json
+          - application/protobuf+json
+      parameters:
+        - in: path
+          name: device_type
+          type: string
+          required: true
+          description: the device type
+        - in: path
+          name: serial
+          type: integer
+          format: uint32
+          required: true
+          description: the device serial number
+        - in: path
+          name: id
+          type: integer
+          format: uint32
+          required: true
+          description: The ID of the request. Only responses to this ID will be returned.
+        - in: body
+          name: request
+          schema:
+            $ref: "#/definitions/request"
+      responses:
+        200:
+          description: |-
+            Protobuf JSON representation of Response, 64 bit integers are strings.
+          schema:
+            type: object
+        404:
+          description: device not found
+        500:
+          description: internal API error
+        502:
+          description: error communicating with database
+        504:
+          description: error communicating with device
+

--- a/generator/media.go
+++ b/generator/media.go
@@ -4,6 +4,7 @@
 package generator
 
 import (
+	"iter"
 	"regexp"
 	"slices"
 	"sort"
@@ -18,31 +19,38 @@ const (
 	multipartForm  = "multipartform"
 )
 
-var mediaTypeNames = map[*regexp.Regexp]string{
-	regexp.MustCompile("application/.*json"):                jsonSerializer,
-	regexp.MustCompile("application/.*yaml"):                "yaml",
-	regexp.MustCompile("application/.*protobuf"):            "protobuf",
-	regexp.MustCompile("application/.*capnproto"):           "capnproto",
-	regexp.MustCompile("application/.*thrift"):              "thrift",
-	regexp.MustCompile("(?:application|text)/.*xml"):        "xml",
-	regexp.MustCompile("text/.*markdown"):                   "markdown",
-	regexp.MustCompile("text/.*html"):                       "html",
-	regexp.MustCompile("text/.*csv"):                        "csv",
-	regexp.MustCompile("text/.*tsv"):                        "tsv",
-	regexp.MustCompile("text/.*javascript"):                 "js",
-	regexp.MustCompile("text/.*css"):                        "css",
-	regexp.MustCompile("text/.*plain"):                      "txt",
-	regexp.MustCompile("application/.*octet-stream"):        "bin",
-	regexp.MustCompile("application/.*tar"):                 "tar",
-	regexp.MustCompile("application/.*gzip"):                "gzip",
-	regexp.MustCompile("application/.*gz"):                  "gzip",
-	regexp.MustCompile("application/.*raw-stream"):          "bin",
-	regexp.MustCompile("application/x-www-form-urlencoded"): "urlform",
-	regexp.MustCompile("application/javascript"):            "txt",
-	regexp.MustCompile("multipart/form-data"):               multipartForm,
-	regexp.MustCompile("image/.*"):                          "bin",
-	regexp.MustCompile("audio/.*"):                          "bin",
-	regexp.MustCompile("application/pdf"):                   "bin",
+type mediaMatcher struct {
+	rex  *regexp.Regexp
+	name string
+}
+
+func mediaTypeNames() iter.Seq[mediaMatcher] {
+	return slices.Values([]mediaMatcher{
+		{rex: regexp.MustCompile("application/.*json"), name: jsonSerializer},
+		{rex: regexp.MustCompile("application/.*yaml"), name: "yaml"},
+		{rex: regexp.MustCompile("application/.*protobuf"), name: "protobuf"},
+		{rex: regexp.MustCompile("application/.*capnproto"), name: "capnproto"},
+		{rex: regexp.MustCompile("application/.*thrift"), name: "thrift"},
+		{rex: regexp.MustCompile("(?:application|text)/.*xml"), name: "xml"},
+		{rex: regexp.MustCompile("text/.*markdown"), name: "markdown"},
+		{rex: regexp.MustCompile("text/.*html"), name: "html"},
+		{rex: regexp.MustCompile("text/.*csv"), name: "csv"},
+		{rex: regexp.MustCompile("text/.*tsv"), name: "tsv"},
+		{rex: regexp.MustCompile("text/.*javascript"), name: "js"},
+		{rex: regexp.MustCompile("text/.*css"), name: "css"},
+		{rex: regexp.MustCompile("text/.*plain"), name: "txt"},
+		{rex: regexp.MustCompile("application/.*octet-stream"), name: "bin"},
+		{rex: regexp.MustCompile("application/.*tar"), name: "tar"},
+		{rex: regexp.MustCompile("application/.*gzip"), name: "gzip"},
+		{rex: regexp.MustCompile("application/.*gz"), name: "gzip"},
+		{rex: regexp.MustCompile("application/.*raw-stream"), name: "bin"},
+		{rex: regexp.MustCompile("application/x-www-form-urlencoded"), name: "urlform"},
+		{rex: regexp.MustCompile("application/javascript"), name: "txt"},
+		{rex: regexp.MustCompile("multipart/form-data"), name: multipartForm},
+		{rex: regexp.MustCompile("image/.*"), name: "bin"},
+		{rex: regexp.MustCompile("audio/.*"), name: "bin"},
+		{rex: regexp.MustCompile("application/pdf"), name: "bin"},
+	})
 }
 
 var knownProducers = map[string]string{
@@ -68,11 +76,12 @@ var knownConsumers = map[string]string{
 }
 
 func wellKnownMime(tn string) (string, bool) {
-	for k, v := range mediaTypeNames {
-		if k.MatchString(tn) {
-			return v, true
+	for matcher := range mediaTypeNames() {
+		if matcher.rex.MatchString(tn) {
+			return matcher.name, true
 		}
 	}
+
 	return "", false
 }
 

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -753,9 +753,15 @@ func (g *GenApp) UseModernMode() bool {
 // GenSerGroups sorted representation of serializer groups.
 type GenSerGroups []GenSerGroup
 
-func (g GenSerGroups) Len() int           { return len(g) }
-func (g GenSerGroups) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
-func (g GenSerGroups) Less(i, j int) bool { return g[i].Name < g[j].Name }
+func (g GenSerGroups) Len() int      { return len(g) }
+func (g GenSerGroups) Swap(i, j int) { g[i], g[j] = g[j], g[i] }
+func (g GenSerGroups) Less(i, j int) bool {
+	if g[i].Name == g[j].Name {
+		return g[i].MediaType < g[j].MediaType
+	}
+
+	return g[i].Name < g[j].Name
+}
 
 // NumSerializers yields the total number of serializer entries in this group.
 func (g GenSerGroups) NumSerializers() int {


### PR DESCRIPTION
* fixes #3394

The issue in #3394 is two-fold:
1. Even though detected producers/consumers are sorted, their detection relies on a map of regexp, which evaluation is not ordered
2. Regular expressions are evaluated in a match-first manner, but a given string may match several expressions and return a different result

Example: application/protobuf+json may match ".*protobuf" and "*.json" resulting in a different match depending on the order in which these expressions are matched, which is random.

Fix: replace the map by a slice - match is now deterministic and a ".*json" always predate a ".*protobuf", so "application/protobuf+json" is detected as a json producer.

An "application/protobuf" producer would define a producer for protobuf.

Notice that the default json producer won't be able to handle the differences between both mime types, so a custom producer should be introduced to handle _both_ application/json and
application/protobuf+json.