### PR TITLE
feat: support streaming multipart forms on generated servers

### DIFF
--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -119,3 +119,32 @@ case the PublicListTravelsError will be returned, otherwise the PublicListTravel
 
 The code generator has written the remaining code to render that response with the headers etc.
 
+## Streaming multipart forms
+
+A server operation may opt out of generated `formData` binding and hand the
+multipart request stream directly to its handler. Mark one of the operation's
+file parameters with `x-go-server-streaming: true`:
+
+```yaml
+consumes:
+  - multipart/form-data
+parameters:
+  - name: file
+    in: formData
+    type: file
+    x-go-server-streaming: true
+```
+
+For the generated server, this extension applies to the complete multipart
+form. Generated code does not pre-read the first file and does not bind or
+validate individual `formData` parameters. Instead, the operation params expose
+a `*runtime.MultipartFormStream`. The handler owns sequential traversal with
+`NextFile()`, application-specific validation, and the decision to call
+`Drain()` or `Close()`.
+
+Other parameter locations, such as path, query and header parameters, continue
+to be generated and validated normally. Client generation is unchanged.
+
+The stream records fields and file metadata discovered so far. Parts that occur
+later in the request are not visible until the handler consumes or closes the
+current file and advances the stream.

--- a/fixtures/codegen/streaming-form-invalid.yml
+++ b/fixtures/codegen/streaming-form-invalid.yml
@@ -1,0 +1,31 @@
+swagger: "2.0"
+info:
+  title: Invalid streaming multipart form fixture
+  version: "1.0.0"
+consumes:
+  - multipart/form-data
+produces:
+  - application/json
+paths:
+  /invalid-type:
+    post:
+      operationId: invalidStreamingType
+      parameters:
+        - name: file
+          in: formData
+          type: file
+          x-go-server-streaming: "yes"
+      responses:
+        "204":
+          description: uploaded
+  /invalid-parameter:
+    post:
+      operationId: invalidStreamingParameter
+      parameters:
+        - name: token
+          in: query
+          type: string
+          x-go-server-streaming: true
+      responses:
+        "204":
+          description: uploaded

--- a/fixtures/codegen/streaming-form.yml
+++ b/fixtures/codegen/streaming-form.yml
@@ -1,0 +1,46 @@
+swagger: "2.0"
+info:
+  title: Streaming multipart form fixture
+  version: "1.0.0"
+consumes:
+  - multipart/form-data
+produces:
+  - application/json
+paths:
+  /stream:
+    post:
+      operationId: streamingUpload
+      parameters:
+        - name: token
+          in: query
+          type: string
+          required: true
+        - name: description
+          in: formData
+          type: string
+          required: true
+        - name: file
+          in: formData
+          type: file
+          required: true
+          x-go-server-streaming: true
+        - name: attachment
+          in: formData
+          type: file
+      responses:
+        "204":
+          description: uploaded
+  /regular:
+    post:
+      operationId: bufferedUpload
+      parameters:
+        - name: description
+          in: formData
+          type: string
+        - name: file
+          in: formData
+          type: file
+          required: true
+      responses:
+        "204":
+          description: uploaded

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -260,6 +260,11 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	var hasQueryParams, hasPathParams, hasHeaderParams, hasFormParams, hasFileParams, hasFormValueParams, hasBodyParams bool
 	paramsForOperation := b.Analyzed.ParamsFor(b.Method, b.Path)
 
+	hasStreamingForm, err := streamingFormEnabled(paramsForOperation, b.Method, b.Path)
+	if err != nil {
+		return GenOperation{}, err
+	}
+
 	idMapping, timeoutName, ctxName, err := b.paramMappings(paramsForOperation)
 	if err != nil {
 		return GenOperation{}, err
@@ -302,6 +307,12 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 	sort.Sort(pp)
 	sort.Sort(hp)
 	sort.Sort(fp)
+
+	serverParams := serverParameters(params, hasStreamingForm)
+	multipartFormName := ""
+	if hasStreamingForm {
+		multipartFormName = deconflictMultipartFormName(serverParams)
+	}
 
 	var srs responses
 	if operation.Responses != nil {
@@ -415,6 +426,7 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 		DefaultImports:       b.DefaultImports,
 		Imports:              b.Imports,
 		Params:               params,
+		ServerParams:         serverParams,
 		Summary:              trimBOM(operation.Summary),
 		QueryParams:          qp,
 		PathParams:           pp,
@@ -427,7 +439,9 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 		HasFormValueParams:   hasFormValueParams,
 		HasFileParams:        hasFileParams,
 		HasBodyParams:        hasBodyParams,
+		HasStreamingForm:     hasStreamingForm,
 		HasStreamingResponse: hasStreamingResponse,
+		MultipartFormName:    multipartFormName,
 		Authorized:           b.Authed,
 		Security:             b.makeSecurityRequirements(receiver), // resolved security requirements, for codegen
 		SecurityDefinitions:  b.makeSecuritySchemes(receiver),
@@ -874,6 +888,57 @@ func (b *codeGenOpBuilder) MakeBodyParameterItemsAndMaps(res *GenParameter, it *
 	return items
 }
 
+func streamingFormEnabled(params map[string]spec.Parameter, method, path string) (bool, error) {
+	enabled := false
+	for _, param := range params {
+		raw, found := param.Extensions[xGoServerStreaming]
+		if !found {
+			continue
+		}
+
+		streaming, ok := raw.(bool)
+		if !ok {
+			return false, fmt.Errorf(`%s %s, parameter %q: %q must be a boolean, not a %T`,
+				method, path, param.Name, xGoServerStreaming, raw)
+		}
+		if !streaming {
+			continue
+		}
+		if param.In != formData || param.Type != file {
+			return false, fmt.Errorf(`%s %s, parameter %q: %q may only be enabled on a formData file parameter`,
+				method, path, param.Name, xGoServerStreaming)
+		}
+		enabled = true
+	}
+
+	return enabled, nil
+}
+
+func serverParameters(params GenParameters, streamingForm bool) GenParameters {
+	if !streamingForm {
+		return params
+	}
+
+	serverParams := make(GenParameters, 0, len(params))
+	for _, param := range params {
+		if param.IsFormParam() {
+			continue
+		}
+		serverParams = append(serverParams, param)
+	}
+
+	return serverParams
+}
+
+func deconflictMultipartFormName(params GenParameters) string {
+	seenIDs := make(map[string]any, len(params))
+	for _, param := range params {
+		seenIDs[strings.ToLower(param.ID)] = struct{}{}
+	}
+
+	return rename(multipartFormNamePreferences)(seenIDs, multipartFormNamePreferences[0], 0)
+}
+
 // paramMappings yields a map of safe parameter names for an operation.
 func (b *codeGenOpBuilder) paramMappings(params map[string]spec.Parameter) (map[string]map[string]string, string, string, error) {
 	idMapping := map[string]map[string]string{
@@ -963,6 +1028,15 @@ var (
 		"operationContext",
 		"opContext",
 		"operContext",
+	}
+
+	multipartFormNamePreferences = []string{
+		"MultipartForm",
+		"RequestMultipartForm",
+		"HTTPMultipartForm",
+		"SwaggerMultipartForm",
+		"OperationMultipartForm",
+		"OpMultipartForm",
 	}
 )
 

--- a/generator/parameter_test.go
+++ b/generator/parameter_test.go
@@ -4232,3 +4232,130 @@ func TestGenParameter_Issue2448_Integers(t *testing.T) {
 	assertInCode(t, `if err := validate.MultipleOfUint("ui3", "query", uint64(*o.Ui3), 10); err != nil {`, res)
 	assertInCode(t, `if err := validate.MultipleOf("ui4", "query", float64(*o.Ui4), 10.5); err != nil {`, res)
 }
+
+func TestGenParameter_StreamingMultipartForm(t *testing.T) {
+	defer discardOutput()()
+
+	b, err := opBuilder("streamingUpload", "../fixtures/codegen/streaming-form.yml")
+	require.NoError(t, err)
+
+	op, err := b.MakeOperation()
+	require.NoError(t, err)
+	require.TrueT(t, op.HasStreamingForm)
+	assert.EqualT(t, "MultipartForm", op.MultipartFormName)
+	assert.Len(t, op.Params, 4)
+	assert.Len(t, op.ServerParams, 1)
+	assert.EqualT(t, "token", op.ServerParams[0].Name)
+
+	opts := opts()
+
+	t.Run("server binding hands the stream to the handler", func(t *testing.T) {
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, opts.templates.MustGet("serverParameter").Execute(buf, op))
+
+		formatted, err := opts.LanguageOpts.FormatContent("streaming_upload_parameters.go", buf.Bytes())
+		require.NoErrorf(t, err, "unexpected format error: %s\n%s", err, buf.String())
+
+		code := string(formatted)
+		assertInCode(t, "MultipartForm *runtime.MultipartFormStream", code)
+		assertInCode(t, "multipartForm, err := runtime.NewMultipartFormStream(", code)
+		assertInCode(t, "runtime.MultipartFormStreamMaxBody(StreamingUploadMaxBodySize)", code)
+		assertInCode(t, "o.MultipartForm = multipartForm", code)
+		assertInCode(t, "Token string", code)
+		assertInCode(t, `o.bindToken(qToken, qhkToken, route.Formats)`, code)
+
+		assertNotInCode(t, "runtime.BindForm(", code)
+		assertNotInCode(t, "MaxParseMemory", code)
+		assertNotInCode(t, "Description *string", code)
+		assertNotInCode(t, "File *runtime.File", code)
+		assertNotInCode(t, "Attachment *runtime.File", code)
+		assertNotInCode(t, "bindFile", code)
+		assertNotInCode(t, "bindAttachment", code)
+
+		validationIndex := strings.Index(code, "if len(res) > 0")
+		streamIndex := strings.Index(code, "runtime.NewMultipartFormStream(")
+		require.NotEqual(t, -1, validationIndex)
+		require.NotEqual(t, -1, streamIndex)
+		assert.TrueT(t, validationIndex < streamIndex)
+	})
+
+	t.Run("client binding remains unchanged", func(t *testing.T) {
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, opts.templates.MustGet("clientParameter").Execute(buf, op))
+
+		formatted, err := opts.LanguageOpts.FormatContent("streaming_upload_client_parameters.go", buf.Bytes())
+		require.NoErrorf(t, err, "unexpected format error: %s\n%s", err, buf.String())
+
+		code := string(formatted)
+		assertInCode(t, "Description string", code)
+		assertInCode(t, "File runtime.NamedReadCloser", code)
+		assertInCode(t, "Attachment runtime.NamedReadCloser", code)
+		assertNotInCode(t, "MultipartFormStream", code)
+	})
+}
+
+func TestGenParameter_BufferedMultipartFormUnaffected(t *testing.T) {
+	defer discardOutput()()
+
+	b, err := opBuilder("bufferedUpload", "../fixtures/codegen/streaming-form.yml")
+	require.NoError(t, err)
+
+	op, err := b.MakeOperation()
+	require.NoError(t, err)
+	require.FalseT(t, op.HasStreamingForm)
+
+	buf := bytes.NewBuffer(nil)
+	opts := opts()
+	require.NoError(t, opts.templates.MustGet("serverParameter").Execute(buf, op))
+
+	formatted, err := opts.LanguageOpts.FormatContent("buffered_upload_parameters.go", buf.Bytes())
+	require.NoErrorf(t, err, "unexpected format error: %s\n%s", err, buf.String())
+
+	code := string(formatted)
+	assertInCode(t, "runtime.BindForm(", code)
+	assertInCode(t, "BufferedUploadMaxParseMemory", code)
+	assertInCode(t, "File io.ReadCloser", code)
+	assertInCode(t, "o.File = &runtime.File{Data: file, Header: header}", code)
+	assertNotInCode(t, "MultipartFormStream", code)
+}
+
+func TestGenParameter_StreamingMultipartFormExtensionValidation(t *testing.T) {
+	defer discardOutput()()
+
+	tests := []struct {
+		name      string
+		operation string
+		contains  string
+	}{
+		{
+			name:      "extension must be boolean",
+			operation: "invalidStreamingType",
+			contains:  `"x-go-server-streaming" must be a boolean`,
+		},
+		{
+			name:      "extension must mark a form file",
+			operation: "invalidStreamingParameter",
+			contains:  `"x-go-server-streaming" may only be enabled on a formData file parameter`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := opBuilder(test.operation, "../fixtures/codegen/streaming-form-invalid.yml")
+			require.NoError(t, err)
+
+			_, err = b.MakeOperation()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, test.contains)
+		})
+	}
+}
+
+func TestGenParameter_StreamingMultipartFormNameIsDeconflicted(t *testing.T) {
+	params := GenParameters{
+		{ID: "MultipartForm", Location: "query"},
+		{ID: "File", Location: formData},
+	}
+
+	assert.EqualT(t, "RequestMultipartForm", deconflictMultipartFormName(params))
+}

--- a/generator/server_test.go
+++ b/generator/server_test.go
@@ -78,6 +78,27 @@ func TestServer_MultipartForm(t *testing.T) {
 	assertInCode(t, "api.MultipartformConsumer = runtime.ByteStreamConsumer()", string(formatted))
 }
 
+func TestServer_StreamingMultipartForm(t *testing.T) {
+	defer discardOutput()()
+
+	gen, err := testAppGenerator(t, "../fixtures/codegen/streaming-form.yml", "streaming multipart")
+	require.NoError(t, err)
+
+	app, err := gen.makeCodegenApp()
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, app.GenOpts.templates.MustGet("serverConfigureapi").Execute(buf, app))
+
+	formatted, err := app.GenOpts.LanguageOpts.FormatContent("configure_streaming_multipart.go", buf.Bytes())
+	require.NoErrorf(t, err, buf.String())
+
+	code := string(formatted)
+	assertInCode(t, "operations.StreamingUploadMaxBodySize = 32 << 20", code)
+	assertNotInCode(t, "operations.StreamingUploadMaxParseMemory", code)
+	assertInCode(t, "operations.BufferedUploadMaxParseMemory = 32 << 20", code)
+}
+
 func TestServer_InvalidSpec(t *testing.T) {
 	defer discardOutput()()
 

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -639,6 +639,7 @@ type GenOperation struct {
 	DefaultResponse  *GenResponse
 
 	Params               GenParameters
+	ServerParams         GenParameters
 	QueryParams          GenParameters
 	PathParams           GenParameters
 	HeaderParams         GenParameters
@@ -650,7 +651,9 @@ type GenOperation struct {
 	HasFormValueParams   bool
 	HasFileParams        bool
 	HasBodyParams        bool
+	HasStreamingForm     bool
 	HasStreamingResponse bool
+	MultipartFormName    string
 
 	Schemes              []string
 	ExtraSchemes         []string

--- a/generator/templates/server/configureapi.gotmpl
+++ b/generator/templates/server/configureapi.gotmpl
@@ -128,7 +128,10 @@ func configureAPI(api *{{.APIPackageAlias}}.{{ pascalize .Name }}API) http.Handl
   {{- $package := .Package }}
   {{- $apipackagealias := .APIPackageAlias }}
   {{- range .Operations }}
-    {{- if .HasFormParams }}
+    {{- if .HasStreamingForm }}
+  // You may change here the maximum body size for this streaming multipart form. Below is the default (32 MB).
+  // {{ if ne .Package $package }}{{ .PackageAlias }}{{ else }}{{ $apipackagealias }}{{ end }}.{{ pascalize .Name }}MaxBodySize = 32 << 20
+    {{- else if .HasFormParams }}
   // You may change here the memory limit for this multipart form parser. Below is the default (32 MB).
   // {{ if ne .Package $package }}{{ .PackageAlias }}{{ else }}{{ $apipackagealias }}{{ end }}.{{ pascalize .Name }}MaxParseMemory = 32 << 20
     {{- end }}

--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -319,6 +319,7 @@ import (
 )
 
 {{- if .HasFormParams }}
+{{- if not .HasStreamingForm }}
 
 // {{ pascalize .Name }}MaxParseMemory sets the maximum size in bytes for
 // the multipart form parser for this operation.
@@ -326,6 +327,7 @@ import (
 // The default value is 32 MB.
 // The multipart parser stores up to this + 10MB.
 var {{ pascalize .Name }}MaxParseMemory int64 = 32 << 20
+{{- end }}
 
 // {{ pascalize .Name }}MaxBodySize caps the size of the form body.
 //
@@ -334,17 +336,17 @@ var {{ pascalize .Name }}MaxBodySize int64 = 32 << 20
 {{- end }}
 
 // New{{ pascalize .Name }}Params creates a new {{ pascalize .Name }}Params object
-{{- if .Params.HasSomeDefaults }}
+{{- if .ServerParams.HasSomeDefaults }}
 // with the default values initialized.
 {{- else }}
 //
 // There are no default values defined in the spec.
 {{- end }}
 func New{{ pascalize .Name }}Params() {{ pascalize .Name }}Params {
-{{ if .Params.HasSomeDefaults }}
+{{ if .ServerParams.HasSomeDefaults }}
   var (
   // initialize parameters with default values
-  {{ range .Params }}
+  {{ range .ServerParams }}
       {{ if .HasDefault -}}
           {{ if not .IsFileParam }}{{ varname .ID}}Default =
               {{- if and .IsPrimitive .IsCustomFormatter (not (stringContains .Zero "(\"" )) }}{{ .Zero }}{{/* strfmt type initializer requires UnmarshalText(), e.g. Date, Datetime, Duration */}}
@@ -363,7 +365,7 @@ func New{{ pascalize .Name }}Params() {{ pascalize .Name }}Params {
   {{- end }}
   )
 
-{{ range .Params }}{{ if .HasDefault -}}{{- /* carry out UnmarshalText initialization strategy */ -}}
+{{ range .ServerParams }}{{ if .HasDefault -}}{{- /* carry out UnmarshalText initialization strategy */ -}}
       {{ if and .IsPrimitive .IsCustomFormatter (not (stringContains .Zero "(\"")) }}{{ varname .ID}}Default.UnmarshalText([]byte({{ printf "%q" .Default }}))
       {{ else if .IsArray -}}
           {{ if or ( and .Child.IsPrimitive .Child.IsCustomFormatter ) .Child.IsArray -}}
@@ -377,7 +379,7 @@ func New{{ pascalize .Name }}Params() {{ pascalize .Name }}Params {
   {{ end -}}
 {{- end }}
 {{ end }}
-  return {{ pascalize .Name }}Params{ {{ range .Params }}{{ if .HasDefault }}
+  return {{ pascalize .Name }}Params{ {{ range .ServerParams }}{{ if .HasDefault }}
     {{ .ID}}: {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}&{{ end }}{{ varname .ID }}Default,
   {{ end }}{{ end }} }
 }
@@ -389,7 +391,14 @@ func New{{ pascalize .Name }}Params() {{ pascalize .Name }}Params {
 type {{ pascalize .Name }}Params struct {
   // HTTP Request Object
   HTTPRequest *http.Request `json:"-"`
-  {{- range .Params }}
+  {{- if .HasStreamingForm }}
+
+  // {{ .MultipartFormName }} is the lazily consumed multipart form stream.
+  //
+  // The handler owns traversal, validation and closing or draining this stream.
+  {{ .MultipartFormName }} *runtime.MultipartFormStream `json:"-"`
+  {{- end }}
+  {{- range .ServerParams }}
 
   {{- if .Description }}
 {{ lineComment .Description }}
@@ -422,11 +431,11 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
 {{- if .HasQueryParams }}
   qs := runtime.Values(r.URL.Query())
 {{- end }}
-{{- if .HasFormParams }}
+{{- if and .HasFormParams (not .HasStreamingForm) }}
   isBlocking, err := runtime.BindForm(r,
     runtime.BindFormMaxParseMemory({{ pascalize .Name }}MaxParseMemory),
     runtime.BindFormMaxBody({{ pascalize .Name }}MaxBodySize),
-  {{- range .Params }}
+  {{- range .ServerParams }}
     {{- if .IsFileParam }}
     runtime.BindFormFile({{ .Path }}, {{ or .Required (not .IsNullable) }}, {{ .ReceiverName }}.bind{{ .ID }}),
     {{- end }}
@@ -445,7 +454,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
   {{- end }}
 {{- end }}
 
-{{ range .Params }}
+{{ range .ServerParams }}
   {{- if not .IsArray }}
     {{- if .IsQueryParam }}
 
@@ -542,11 +551,22 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}Params) BindRequest(r *http.Requ
   if len(res) > 0 {
     return errors.CompositeValidationError(res...)
   }
+{{- if .HasStreamingForm }}
+
+  multipartForm, err := runtime.NewMultipartFormStream(
+    r,
+    runtime.MultipartFormStreamMaxBody({{ pascalize .Name }}MaxBodySize),
+  )
+  if err != nil {
+    return err
+  }
+  {{ .ReceiverName }}.{{ .MultipartFormName }} = multipartForm
+{{- end }}
   return nil
 }
 
 {{- $className := (pascalize .Name) }}
-{{ range .Params }}
+{{ range .ServerParams }}
   {{- if .IsFileParam }}
 // bind{{ .ID }} validates file parameter File1 and assigns it as a *runtime.File on success.
 //

--- a/generator/types.go
+++ b/generator/types.go
@@ -36,17 +36,18 @@ const (
 
 // Extensions supported by go-swagger.
 const (
-	xClass        = "x-class"         // class name used by discriminator
-	xGoCustomTag  = "x-go-custom-tag" // additional tag for serializers on struct fields
-	xGoName       = "x-go-name"       // name of the generated go variable
-	xGoType       = "x-go-type"       // reuse existing type (do not generate)
-	xIsNullable   = "x-isnullable"
-	xNullable     = "x-nullable" // turns the schema into a pointer
-	xOmitEmpty    = "x-omitempty"
-	xSchemes      = "x-schemes" // additional schemes supported for operations (server generation)
-	xOrder        = "x-order"   // sort order for properties (or any schema)
-	xGoJSONString = "x-go-json-string"
-	xGoEnumCI     = "x-go-enum-ci" // make string enumeration case-insensitive
+	xClass             = "x-class"         // class name used by discriminator
+	xGoCustomTag       = "x-go-custom-tag" // additional tag for serializers on struct fields
+	xGoName            = "x-go-name"       // name of the generated go variable
+	xGoType            = "x-go-type"       // reuse existing type (do not generate)
+	xIsNullable        = "x-isnullable"
+	xNullable          = "x-nullable" // turns the schema into a pointer
+	xOmitEmpty         = "x-omitempty"
+	xSchemes           = "x-schemes" // additional schemes supported for operations (server generation)
+	xOrder             = "x-order"   // sort order for properties (or any schema)
+	xGoJSONString      = "x-go-json-string"
+	xGoEnumCI          = "x-go-enum-ci"          // make string enumeration case-insensitive
+	xGoServerStreaming = "x-go-server-streaming" // stream multipart form payloads directly to server handlers
 
 	xGoOperationTag = "x-go-operation-tag" // additional tag to override generation in operation groups
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-openapi/errors v0.22.8
 	github.com/go-openapi/inflect v0.21.6
 	github.com/go-openapi/loads v0.25.0
-	github.com/go-openapi/runtime v0.32.6
+	github.com/go-openapi/runtime v0.32.7-0.20260724174133-f44e6731289f
 	github.com/go-openapi/runtime/server-middleware v0.32.6
 	github.com/go-openapi/spec v0.22.9
 	github.com/go-openapi/strfmt v0.27.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-openapi/errors v0.22.8
 	github.com/go-openapi/inflect v0.21.6
 	github.com/go-openapi/loads v0.25.0
-	github.com/go-openapi/runtime v0.32.7-0.20260724174133-f44e6731289f
+	github.com/go-openapi/runtime v0.33.0
 	github.com/go-openapi/runtime/server-middleware v0.32.6
 	github.com/go-openapi/spec v0.22.9
 	github.com/go-openapi/strfmt v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,8 @@ github.com/go-openapi/jsonreference v1.0.0 h1:jlmTr6torcd1YgDQvSfNmRtKzYDO4FGBkr
 github.com/go-openapi/jsonreference v1.0.0/go.mod h1:jtwdyGbJk0Xhe5Y+rwtglQP6Sb1WZST4rT32LWB+sv0=
 github.com/go-openapi/loads v0.25.0 h1:74Bc2snfaVlsHzwdQj/3gsA9XJz3daXTJVs+4ZaK7jI=
 github.com/go-openapi/loads v0.25.0/go.mod h1:JFBw4SIB9+PTIFHDfcXuSSy5h6aWzjtUCrPYyx3qWU8=
-github.com/go-openapi/runtime v0.32.6 h1:hrcTTF8P7ZZr2Majzq11I65QtL/s85o7Q+zJf+AvFN4=
-github.com/go-openapi/runtime v0.32.6/go.mod h1:+rsupH3+TFKqmFysqkmgBOTxpVJV8eV+j9myvvea2Xw=
-github.com/go-openapi/runtime v0.32.7-0.20260724174133-f44e6731289f h1:NITRGLRjdL0p1Qcgj7wmPYjQrsrm1egITXS3C9a7ie8=
-github.com/go-openapi/runtime v0.32.7-0.20260724174133-f44e6731289f/go.mod h1:+rsupH3+TFKqmFysqkmgBOTxpVJV8eV+j9myvvea2Xw=
+github.com/go-openapi/runtime v0.33.0 h1:Dd3Oj2ig+WH8ckK95l0Wn2V8a4bH/UqWPRZVT0vc8yU=
+github.com/go-openapi/runtime v0.33.0/go.mod h1:+rsupH3+TFKqmFysqkmgBOTxpVJV8eV+j9myvvea2Xw=
 github.com/go-openapi/runtime/server-middleware v0.32.6 h1:IGTYzybyFrUeSqQEwwO1y/9KnOk4QsabFNtAQtIHxDE=
 github.com/go-openapi/runtime/server-middleware v0.32.6/go.mod h1:OQHTBqMGquJShXhPYQ62yAqDMtC1rYpsEwldNWjYKhA=
 github.com/go-openapi/spec v0.22.9 h1:/vKIFDcGKp0ktZWGbym/tJEWbk6/XOEmAVU0kqKMH+w=

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/go-openapi/loads v0.25.0 h1:74Bc2snfaVlsHzwdQj/3gsA9XJz3daXTJVs+4ZaK7
 github.com/go-openapi/loads v0.25.0/go.mod h1:JFBw4SIB9+PTIFHDfcXuSSy5h6aWzjtUCrPYyx3qWU8=
 github.com/go-openapi/runtime v0.32.6 h1:hrcTTF8P7ZZr2Majzq11I65QtL/s85o7Q+zJf+AvFN4=
 github.com/go-openapi/runtime v0.32.6/go.mod h1:+rsupH3+TFKqmFysqkmgBOTxpVJV8eV+j9myvvea2Xw=
+github.com/go-openapi/runtime v0.32.7-0.20260724174133-f44e6731289f h1:NITRGLRjdL0p1Qcgj7wmPYjQrsrm1egITXS3C9a7ie8=
+github.com/go-openapi/runtime v0.32.7-0.20260724174133-f44e6731289f/go.mod h1:+rsupH3+TFKqmFysqkmgBOTxpVJV8eV+j9myvvea2Xw=
 github.com/go-openapi/runtime/server-middleware v0.32.6 h1:IGTYzybyFrUeSqQEwwO1y/9KnOk4QsabFNtAQtIHxDE=
 github.com/go-openapi/runtime/server-middleware v0.32.6/go.mod h1:OQHTBqMGquJShXhPYQ62yAqDMtC1rYpsEwldNWjYKhA=
 github.com/go-openapi/spec v0.22.9 h1:/vKIFDcGKp0ktZWGbym/tJEWbk6/XOEmAVU0kqKMH+w=


### PR DESCRIPTION
## Summary

Adds opt-in server-side streaming for `multipart/form-data` operations.

A file parameter may enable streaming with:

```yaml
parameters:
  - name: file
    in: formData
    type: file
    x-go-server-streaming: true
```

When enabled, the generated server binder passes the complete multipart request to the operation handler as a `*runtime.MultipartFormStream` instead of eagerly binding the form with `runtime.BindForm`.

Fixes #3407.

## Motivation

The existing generated server binding parses the complete multipart form before invoking the handler. This prevents applications from processing large uploads while the request body is still being received.

The streaming runtime implementation was introduced in go-openapi/runtime#507. This PR integrates that API into go-swagger code generation.

## Generated server behavior

For an operation with `x-go-server-streaming: true`:

- the extension applies to the complete multipart form;
- generated `formData` fields are not added to the server params struct;
- the params struct exposes a `*runtime.MultipartFormStream`;
- path, query and header parameters continue to be generated and validated normally;
- the handler owns multipart traversal and application-specific validation;
- the handler must call `Drain()` or `Close()` when processing is complete;
- the generated body-size limit remains configurable;
- the buffered multipart memory-limit setting is not generated.

Required fields, accepted field names, multiplicity and other form-specific rules are intentionally left to the handler because multipart parts are consumed sequentially.

Client generation remains unchanged.

Operations without the extension continue to use the existing buffered multipart binding.

## Extension validation

`x-go-server-streaming` must:

- be a boolean;
- be enabled only on a `formData` parameter of type `file`.

Invalid usage fails during generation with an operation and parameter-specific error.

## Compatibility

This is opt-in and does not change existing generated server or client behavior.

Regular multipart operations continue to use `runtime.BindForm`.

## Tests

Added coverage for:

- generated streaming server binding;
- preservation of query parameter binding and validation;
- unchanged client generation;
- unchanged buffered multipart generation;
- invalid extension types and locations;
- generated field-name conflict resolution;
- streaming-specific `configureAPI` output.

A black-box integration example that verifies the handler receives file bytes before the client completes the request body is available in go-swagger/examples#71.

## Dependency

This PR currently references the merged runtime implementation through its upstream pseudo-version:

```text
github.com/go-openapi/runtime v0.32.7-0.20260724174133-f44e6731289f
```

It can be replaced with the corresponding tagged runtime release when that release becomes available.
