### PR TITLE
feat(generator): generate const block for array-item enum values

### DIFF
--- a/fixtures/bugs/1203/fixture-1203.yaml
+++ b/fixtures/bugs/1203/fixture-1203.yaml
@@ -1,0 +1,25 @@
+swagger: "2.0"
+info:
+  title: "enum array items must generate a const block"
+  version: "0.0.1"
+paths:
+  "/":
+    get:
+      responses:
+        200:
+          description: ok
+          schema:
+            $ref: '#/definitions/Foo'
+
+definitions:
+  Foo:
+    type: object
+    properties:
+      roles:
+        type: array
+        items:
+          type: string
+          enum:
+            - Admin
+            - User
+            - SuperAdmin

--- a/generator/moreschemavalidation_fixtures_test.go
+++ b/generator/moreschemavalidation_fixtures_test.go
@@ -11768,3 +11768,18 @@ func initFixture3141() {
 			`.ContextValidate(ctx, formats); err != nil {`,
 		}, noLines, noLines)
 }
+
+func initFixture1203() {
+	f := newModelFixture("../fixtures/bugs/1203/fixture-1203.yaml", "enum array items must generate a const block")
+	flattenRun := f.AddRun(false).WithMinimalFlatten(true)
+
+	flattenRun.AddExpectations("foo.go", []string{
+		`const (`,
+		`	// FooRolesItemsAdmin captures enum value "Admin"`,
+		`	FooRolesItemsAdmin string = "Admin"`,
+		`	// FooRolesItemsUser captures enum value "User"`,
+		`	FooRolesItemsUser string = "User"`,
+		`	// FooRolesItemsSuperAdmin captures enum value "SuperAdmin"`,
+		`	FooRolesItemsSuperAdmin string = "SuperAdmin"`,
+	}, todo, noLines, noLines)
+}

--- a/generator/moreschemavalidation_test.go
+++ b/generator/moreschemavalidation_test.go
@@ -293,6 +293,9 @@ func initModelFixtures() {
 
 	// x-go-type novalidation hint must also be honored by ContextValidate
 	initFixture3141()
+
+	// enum array items must generate a const block
+	initFixture1203()
 }
 
 /* Template initTxxx() to prepare and load a fixture:

--- a/generator/templates/schemavalidator.gotmpl
+++ b/generator/templates/schemavalidator.gotmpl
@@ -855,6 +855,17 @@ func ({{ .ReceiverName }} {{ if not .IsPrimitive }}*{{ end }}{{ if .IsExported }
 }
   {{ end }}
   {{ if .ItemsEnum }}
+    {{ if (eq .Items.SwaggerType "string") }}
+      {{ $gotype := .Items.GoType }}
+      {{ $modelname := .GoName }}
+const (
+      {{ range .ItemsEnum }}
+      {{- $variant := print $modelname "Items" (pascalize (cleanupEnumVariant .)) }}
+  // {{ $variant }} captures enum value {{ printf "%q" . }}
+	{{ $variant }} {{ $gotype }} = {{ printf "%q" . }}
+      {{ end }}
+)
+    {{ end }}
 var {{ camelize .Name }}ItemsEnum []any
 
 func init() {
@@ -994,6 +1005,17 @@ func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else 
 }
       {{ end }}
       {{ if .ItemsEnum }}
+        {{ if (eq .Items.SwaggerType "string") }}
+          {{ $gotype := .Items.GoType }}
+          {{ $propname := .GoName }}
+const (
+          {{ range .ItemsEnum }}
+          {{- $variant := print ($.GoName) $propname "Items" (pascalize (cleanupEnumVariant .)) }}
+  // {{ $variant }} captures enum value {{ printf "%q" . }}
+	{{ $variant }} {{ $gotype }} = {{ printf "%q" . }}
+          {{ end }}
+)
+        {{ end }}
 var {{ camelize $.Name }}{{ .GoName }}ItemsEnum []any
 func init() {
   var res []{{ template "dereffedSchemaType" .Items }}
@@ -1116,6 +1138,17 @@ func ({{ .ReceiverName }} *{{ if $.Discriminates }}{{ camelize $.Name }}{{ else 
 }
         {{ end }}
         {{ if .ItemsEnum }}
+          {{ if (eq .Items.SwaggerType "string") }}
+            {{ $gotype := .Items.GoType }}
+            {{ $propname := .GoName }}
+const (
+            {{ range .ItemsEnum }}
+            {{- $variant := print ($.GoName) $propname "Items" (pascalize (cleanupEnumVariant .)) }}
+  // {{ $variant }} captures enum value {{ printf "%q" . }}
+	{{ $variant }} {{ $gotype }} = {{ printf "%q" . }}
+            {{ end }}
+)
+          {{ end }}
 var {{ camelize $.Name }}{{ .GoName }}ItemsEnum []any
 
 func init() {


### PR DESCRIPTION
## Summary

Fixes #1203.

A scalar property with `enum` already gets a Go `const` block generated for its values (e.g. `FooStatusPending`). An array property whose *items* declare `enum` (`type: array, items: {type: string, enum: [...]}`) never got the equivalent consts — only the `{{ .GoName }}ItemsEnum` var/`init()`/validate-function plumbing used internally for runtime validation was generated. Users referencing enum values from other code (e.g. `models.FooRolesItemsAdmin`) had nothing to reference.

## Fix

Added the same `const (...)` block generation (gated on `Items.SwaggerType == "string"`, matching the existing restriction for scalar enum consts) to the three places array-item enums are rendered in `generator/templates/schemavalidator.gotmpl`: top-level schema, property, and allOf-nested property.

Variant naming follows the existing per-property enum const convention with an added `Items` segment, matching what was proposed in the issue thread: `FooRolesItemsAdmin` for property `roles` enum value `Admin` on model `Foo`.

## Test plan

- [x] New fixture `fixtures/bugs/1203/fixture-1203.yaml` (spec from the issue).
- [x] New `initFixture1203` in `generator/moreschemavalidation_fixtures_test.go`, wired into `TestMoreModelValidations`, asserting the generated `const` block.
- [x] Verified the new test fails against the unpatched template (no `const` block generated) and passes with the fix.
- [x] Manually generated the model and ran `go build` on the output to confirm the generated Go code compiles.
- [x] `go test ./generator/...` (schema-validation fixtures suite) green.
- [x] `gofmt -l` / `go vet ./generator/...` clean.