### PR TITLE
feat(generator): add --with-go-run to invoke swagger via go run in //go:generate

### DIFF
--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	FlagStrategy           string `choice:"go-flags"                                                               choice:"pflag"                 choice:"flag"    default:"go-flags"                                      description:"the strategy to provide flags for the server" long:"flag-strategy"`
 	CompatibilityMode      string `choice:"modern"                                                                 choice:"intermediate"          default:"modern" description:"the compatibility mode for the tls server" long:"compatibility-mode"`
 	RegenerateConfigureAPI bool   `description:"Force regeneration of configureapi.go"                             long:"regenerate-configureapi"`
+	WithGoRunGoGenerate    bool   `description:"emit //go:generate directives that invoke swagger via 'go run' instead of assuming a pre-installed binary (see issue #3000)" long:"with-go-run"`
 
 	Name string `description:"the name of the application, defaults to a mangled value of info.title" long:"name" short:"A"`
 	// TODO(fredbi): CmdName string `long:"cmd-name" short:"A" description:"the name of the server command, when main is generated (defaults to {name}-server)"`
@@ -77,6 +78,7 @@ func (s *Server) apply(opts *generator.GenOpts) {
 	opts.FlagStrategy = s.FlagStrategy
 	opts.CompatibilityMode = s.CompatibilityMode
 	opts.RegenerateConfigureAPI = s.RegenerateConfigureAPI
+	opts.WithGoRunGoGenerate = s.WithGoRunGoGenerate
 
 	opts.Name = s.Name
 	opts.MainPackage = s.MainTarget

--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -39,6 +39,8 @@ func TestGenerateAndTest(t *testing.T) {
 
 func generateServerFixtures() map[string]generateFixture {
 	return map[string]generateFixture{
+		"go_run_generate_3000":             fixtureServerGoRunGenerate3000(),
+		"go_run_generate_default_3000":     fixtureServerGoRunGenerateDefault3000(),
 		"issue 1943":                       fixtureServer1943(),
 		"packages_mangling":                fixtureServerPackageMangling(),
 		"packages_flattening":              fixtureServerPackageFlattening(),
@@ -560,6 +562,39 @@ func fixtureServerTagPackageName3143() generateFixture {
 				require.DirExists(t, filepath.Join(target, "restapi", "operations", "trailingv2"))
 				t.Run("should tidy go mod", gentest.GoModTidy(target))
 				t.Run("building generated server", gentest.GoBuild(location))
+			}
+		},
+	}
+}
+
+func fixtureServerGoRunGenerate3000() generateFixture {
+	return generateFixture{
+		spec: "../fixtures/bugs/2111/fixture-2111.yaml",
+		prepare: func(t *testing.T, spec, target string) *GenOpts {
+			g := defaultServerOpts(t, spec, target)
+			g.WithGoRunGoGenerate = true
+
+			return g
+		},
+		verify: func(target string) func(*testing.T) {
+			return func(t *testing.T) {
+				content, err := os.ReadFile(filepath.Join(target, "restapi", "configure_unsafe_tag_names.go"))
+				require.NoError(t, err)
+				require.Contains(t, string(content), "//go:generate go run github.com/go-swagger/go-swagger/cmd/swagger generate server")
+			}
+		},
+	}
+}
+
+func fixtureServerGoRunGenerateDefault3000() generateFixture {
+	return generateFixture{
+		spec: "../fixtures/bugs/2111/fixture-2111.yaml",
+		verify: func(target string) func(*testing.T) {
+			return func(t *testing.T) {
+				content, err := os.ReadFile(filepath.Join(target, "restapi", "configure_unsafe_tag_names.go"))
+				require.NoError(t, err)
+				require.Contains(t, string(content), "//go:generate swagger generate server")
+				require.NotContains(t, string(content), "go run github.com/go-swagger/go-swagger/cmd/swagger")
 			}
 		},
 	}

--- a/generator/genopts.go
+++ b/generator/genopts.go
@@ -40,6 +40,7 @@ type GenOpts struct {
 	PropertiesSpecOrder        bool
 	StrictAdditionalProperties bool
 	AllowTemplateOverride      bool
+	WithGoRunGoGenerate        bool
 
 	Spec                   string
 	APIPackage             string

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -380,6 +380,23 @@ func (g *GenOpts) SpecPath() string {
 	return specRel
 }
 
+// GoGenerateCommand returns the command invoked by the //go:generate directive
+// emitted in generated server files.
+//
+// By default this is the bare "swagger" binary, which assumes it is
+// pre-installed and available on $PATH. When WithGoRunGoGenerate is set, the
+// tool is instead invoked via "go run", following the tools.go pattern for
+// tracking build tool dependencies (see issue #3000), so `go generate` works
+// without requiring a separately installed swagger binary.
+//
+// This method is used by templates, e.g. with {{ .GoGenerateCommand }}
+func (g *GenOpts) GoGenerateCommand() string {
+	if g.WithGoRunGoGenerate {
+		return "go run github.com/go-swagger/go-swagger/cmd/swagger"
+	}
+	return "swagger"
+}
+
 // titleOrDefault infers a name for the app from the title of the spec.
 func titleOrDefault(lang *language.Options, specDoc *loads.Document, name, defaultName string) string {
 	if strings.TrimSpace(name) == "" {

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -389,7 +389,7 @@ func (g *GenOpts) SpecPath() string {
 // tracking build tool dependencies (see issue #3000), so `go generate` works
 // without requiring a separately installed swagger binary.
 //
-// This method is used by templates, e.g. with {{ .GoGenerateCommand }}
+// This method is used by templates, e.g. with {{ .GoGenerateCommand }}.
 func (g *GenOpts) GoGenerateCommand() string {
 	if g.WithGoRunGoGenerate {
 		return "go run github.com/go-swagger/go-swagger/cmd/swagger"

--- a/generator/templates/server/autoconfigureapi.gotmpl
+++ b/generator/templates/server/autoconfigureapi.gotmpl
@@ -22,7 +22,7 @@ import (
 )
 
 {{ with .GenOpts }}
-//go:generate swagger generate server --target {{ .TargetPath }} --name {{ .Name }} --spec {{ .SpecPath }}
+//go:generate {{ .GoGenerateCommand }} generate server --target {{ .TargetPath }} --name {{ .Name }} --spec {{ .SpecPath }}
 {{- if .APIPackage }}{{ if ne .APIPackage "operations" }} --api-package {{ .APIPackage }}{{ end }}{{ end }}
 {{- if .ModelPackage }}{{ if ne .ModelPackage "models" }} --model-package {{ .ModelPackage }}{{ end }}{{ end }}
 {{- if .ServerPackage }}{{ if ne .ServerPackage "restapi"}} --server-package {{ .ServerPackage }}{{ end }}{{ end }}

--- a/generator/templates/server/configureapi.gotmpl
+++ b/generator/templates/server/configureapi.gotmpl
@@ -23,7 +23,7 @@ import (
 )
 
 {{ with .GenOpts }}
-//go:generate swagger generate server --target {{ .TargetPath }} --name {{ .Name }} --spec {{ .SpecPath }}
+//go:generate {{ .GoGenerateCommand }} generate server --target {{ .TargetPath }} --name {{ .Name }} --spec {{ .SpecPath }}
 {{- if .APIPackage }}{{ if ne .APIPackage "operations" }} --api-package {{ .APIPackage }}{{ end }}{{ end }}
 {{- if .ModelPackage }}{{ if ne .ModelPackage "models" }} --model-package {{ .ModelPackage }}{{ end }}{{ end }}
 {{- if .ServerPackage }}{{ if ne .ServerPackage "restapi"}} --server-package {{ .ServerPackage }}{{ end }}{{ end }}


### PR DESCRIPTION
## Summary

Fixes #3000.

Generated server files hard-code `//go:generate swagger generate server ...`, assuming a `swagger` binary is pre-installed and available on `$PATH`. This doesn't fit the common Go pattern of tracking build tools as regular module dependencies (`tools.go`), where the tool would instead be invoked via `go run <module path>`.

## Fix

Added `GenOpts.WithGoRunGoGenerate` (wired to a new `--with-go-run` flag on `generate server`) and `GenOpts.GoGenerateCommand()`, used by `configureapi.gotmpl`/`autoconfigureapi.gotmpl` in place of the hard-coded `swagger` literal:

- default (unchanged): `//go:generate swagger generate server --target ...`
- with `--with-go-run`: `//go:generate go run github.com/go-swagger/go-swagger/cmd/swagger generate server --target ...`

Zero functional risk: this only changes a `//go:generate` comment, which is never compiled - just parsed by `go generate` when explicitly invoked.

## Test plan

- [x] New fixtures `fixtureServerGoRunGenerate3000`/`fixtureServerGoRunGenerateDefault3000` in `generator/generate_test.go`, asserting the generated `configure_*.go` content for both the default and `--with-go-run` cases.
- [x] Verified the new test fails without the fix (still emits the bare `swagger` command) and passes with it.
- [x] Manually generated a server with and without `--with-go-run` and diffed the `//go:generate` line.
- [x] `go test ./generator/...` (full package) green.
- [x] `go build ./...`, `gofmt -l`, `go vet ./...` clean.