### PR TITLE
fix(generator): explicitly register the yamlpc import for yaml producers/consumers

### DIFF
--- a/fixtures/bugs/1603/fixture-1603.yaml
+++ b/fixtures/bugs/1603/fixture-1603.yaml
@@ -1,0 +1,19 @@
+swagger: "2.0"
+info:
+  title: "yamlpc import must be registered explicitly"
+  version: "0.0.1"
+consumes:
+  - application/x-yaml
+produces:
+  - application/json
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object

--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -39,6 +39,7 @@ func TestGenerateAndTest(t *testing.T) {
 
 func generateServerFixtures() map[string]generateFixture {
 	return map[string]generateFixture{
+		"yamlpc_import_1603":               fixtureServerYamlpcImport1603(),
 		"issue 1943":                       fixtureServer1943(),
 		"packages_mangling":                fixtureServerPackageMangling(),
 		"packages_flattening":              fixtureServerPackageFlattening(),
@@ -560,6 +561,23 @@ func fixtureServerTagPackageName3143() generateFixture {
 				require.DirExists(t, filepath.Join(target, "restapi", "operations", "trailingv2"))
 				t.Run("should tidy go mod", gentest.GoModTidy(target))
 				t.Run("building generated server", gentest.GoBuild(location))
+			}
+		},
+	}
+}
+
+func fixtureServerYamlpcImport1603() generateFixture {
+	return generateFixture{
+		spec: "../fixtures/bugs/1603/fixture-1603.yaml",
+		verify: func(target string) func(*testing.T) {
+			return func(t *testing.T) {
+				configureContent, err := os.ReadFile(filepath.Join(target, "restapi", "configure_yamlpc_import_must_be_registered_explicitly.go"))
+				require.NoError(t, err)
+				require.Contains(t, string(configureContent), `"github.com/go-openapi/runtime/yamlpc"`)
+
+				apiContent, err := os.ReadFile(filepath.Join(target, "restapi", "operations", "yamlpc_import_must_be_registered_explicitly_api.go"))
+				require.NoError(t, err)
+				require.Contains(t, string(apiContent), `"github.com/go-openapi/runtime/yamlpc"`)
 			}
 		},
 	}

--- a/generator/media.go
+++ b/generator/media.go
@@ -75,20 +75,22 @@ var knownConsumers = map[string]string{
 	multipartForm:  "runtime.ByteStreamConsumer()",
 }
 
-// registerSerializerImports adds explicit imports for well-known serializer implementations.
-//
-// This prevents code snippets such as "yamlpc.YAMLProducer()" to rely solely on goimports
-// to discover and resolve the import on the local host, which is not guaranteed (#1603).
+// registerSerializerImports adds explicit imports for well-known serializer
+// implementations that live outside the runtime package and are otherwise
+// never registered anywhere: they are referenced only as a raw code snippet
+// (e.g. "yamlpc.YAMLProducer()") in GenSerializer.Implementation, so nothing
+// ever adds their import - the generated file only compiled when goimports
+// happened to resolve it, which is not guaranteed (#1603).
 func registerSerializerImports(imports map[string]string, groups GenSerGroups) {
 	for _, group := range groups {
 		for _, ser := range group.AllSerializers {
 			if strings.HasPrefix(ser.Implementation, "yamlpc.") {
 				imports["yamlpc"] = "github.com/go-openapi/runtime/yamlpc"
 			}
-			// also register runtime import explicitly. It will be pruned if already registered with other defaults.
-			if strings.HasPrefix(ser.Implementation, "runtime.") {
-				imports["runtime"] = "github.com/go-openapi/runtime"
-			}
+			// follow-up(fredbi): we'd also like register runtime import explicitly here.
+			// It should be pruned if already registered with other defaults.
+			// Unfortunately, the way imports are currently resolved produces a duplicate import,
+			// and that issue should be fixed first.
 		}
 	}
 }

--- a/generator/media.go
+++ b/generator/media.go
@@ -75,17 +75,19 @@ var knownConsumers = map[string]string{
 	multipartForm:  "runtime.ByteStreamConsumer()",
 }
 
-// registerSerializerImports adds explicit imports for well-known serializer
-// implementations that live outside the runtime package and are otherwise
-// never registered anywhere: they are referenced only as a raw code snippet
-// (e.g. "yamlpc.YAMLProducer()") in GenSerializer.Implementation, so nothing
-// ever adds their import - the generated file only compiled when goimports
-// happened to resolve it, which is not guaranteed (#1603).
+// registerSerializerImports adds explicit imports for well-known serializer implementations.
+//
+// This prevents code snippets such as "yamlpc.YAMLProducer()" to rely solely on goimports
+// to discover and resolve the import on the local host, which is not guaranteed (#1603).
 func registerSerializerImports(imports map[string]string, groups GenSerGroups) {
 	for _, group := range groups {
 		for _, ser := range group.AllSerializers {
 			if strings.HasPrefix(ser.Implementation, "yamlpc.") {
 				imports["yamlpc"] = "github.com/go-openapi/runtime/yamlpc"
+			}
+			// also register runtime import explicitly. It will be pruned if already registered with other defaults.
+			if strings.HasPrefix(ser.Implementation, "runtime.") {
+				imports["runtime"] = "github.com/go-openapi/runtime"
 			}
 		}
 	}

--- a/generator/media.go
+++ b/generator/media.go
@@ -75,6 +75,22 @@ var knownConsumers = map[string]string{
 	multipartForm:  "runtime.ByteStreamConsumer()",
 }
 
+// registerSerializerImports adds explicit imports for well-known serializer
+// implementations that live outside the runtime package and are otherwise
+// never registered anywhere: they are referenced only as a raw code snippet
+// (e.g. "yamlpc.YAMLProducer()") in GenSerializer.Implementation, so nothing
+// ever adds their import - the generated file only compiled when goimports
+// happened to resolve it, which is not guaranteed (#1603).
+func registerSerializerImports(imports map[string]string, groups GenSerGroups) {
+	for _, group := range groups {
+		for _, ser := range group.AllSerializers {
+			if strings.HasPrefix(ser.Implementation, "yamlpc.") {
+				imports["yamlpc"] = "github.com/go-openapi/runtime/yamlpc"
+			}
+		}
+	}
+}
+
 func wellKnownMime(tn string) (string, bool) {
 	for matcher := range mediaTypeNames() {
 		if matcher.rex.MatchString(tn) {

--- a/generator/support.go
+++ b/generator/support.go
@@ -270,6 +270,8 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 	defaultImports := newImportsBuilder(a.GenOpts).defaultImports()
 
 	imports := make(map[string]string, sensibleDefaultMapAlloc)
+	registerSerializerImports(imports, consumes)
+	registerSerializerImports(imports, produces)
 	alias := deconflictPkg(a.GenOpts.LanguageOpts.ManglePackageName(a.OperationsPackage, defaultOperationsTarget), renameAPIPackage)
 	if !a.GenOpts.IsClient { // we don't want to inject this import for clients
 		imports[alias] = path.Join(


### PR DESCRIPTION
## Summary

Fixes #1603.

`GenSerializer.Implementation` for the `yaml` media type is the raw code snippet `yamlpc.YAMLProducer()`/`yamlpc.YAMLConsumer()`, but nothing ever registered its import (`github.com/go-openapi/runtime/yamlpc`) anywhere in the generated server files. Compilation only succeeded when `goimports` happened to resolve it while scanning packages - several users in the issue thread reported this as flaky/non-deterministic depending on their environment (module cache state, GOPATH vs module mode, etc.), and one traced it specifically to `imports.Process`'s package-scanning behavior.

## Fix

Added `registerSerializerImports` (`generator/media.go`), called from `appGenerator.makeCodegenApp` for both the `consumes` and `produces` serializer groups, which adds the `yamlpc` import explicitly to `GenApp.Imports` whenever a serializer's implementation references it. This mirrors the always-explicit-never-implicit-via-goimports approach already used for the `strfmt` header import fix in #1769 / PR #3424.

## Test plan

- [x] New fixture `fixtures/bugs/1603/fixture-1603.yaml` (`consumes: application/x-yaml`).
- [x] New `fixtureServerYamlpcImport1603` in `generator/generate_test.go`, asserting the `yamlpc` import is present in both `restapi/configure_*.go` and `restapi/operations/*_api.go`.
- [x] Manually generated a server from the fixture spec and confirmed the import line is now present in both files.
- [x] `go test ./generator/...` (full package) green.
- [x] `go build ./...`, `gofmt -l`, `go vet ./...` clean.

**Note on test determinism:** because the original bug's trigger is inherently about `goimports` resolution being flaky depending on the environment, the new regression test cannot be shown to fail on unpatched code in this sandbox - `goimports` reliably resolves it here with a warm module cache. The fix is still correct and strictly more robust than relying on `goimports` for a known, well-defined import; the test asserts the explicit-import invariant going forward rather than reproducing the original flakiness.