### PR TITLE
fix(generator): follow-up on #3426

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
     - gochecknoinits # agree, but breaking
     - godox # temporary
     - gomodguard
-    - gomodguard_v2
+    #- gomodguard_v2
     - ireturn # temporary
     - lll # unclear added value
     - nestif # temporary

--- a/generator/media.go
+++ b/generator/media.go
@@ -75,22 +75,23 @@ var knownConsumers = map[string]string{
 	multipartForm:  "runtime.ByteStreamConsumer()",
 }
 
-// registerSerializerImports adds explicit imports for well-known serializer
-// implementations that live outside the runtime package and are otherwise
-// never registered anywhere: they are referenced only as a raw code snippet
-// (e.g. "yamlpc.YAMLProducer()") in GenSerializer.Implementation, so nothing
-// ever adds their import - the generated file only compiled when goimports
-// happened to resolve it, which is not guaranteed (#1603).
+// registerSerializerImports adds explicit imports for well-known serializer implementations.
+//
+// It ensures that code snippets such as "yamlpc.YAMLProducer()" have explicit imports and do
+// not solely rely on goimports to resolve, which is not guaranteed on the host running the generation.
 func registerSerializerImports(imports map[string]string, groups GenSerGroups) {
 	for _, group := range groups {
 		for _, ser := range group.AllSerializers {
 			if strings.HasPrefix(ser.Implementation, "yamlpc.") {
 				imports["yamlpc"] = "github.com/go-openapi/runtime/yamlpc"
 			}
-			// follow-up(fredbi): we'd also like register runtime import explicitly here.
-			// It should be pruned if already registered with other defaults.
-			// Unfortunately, the way imports are currently resolved produces a duplicate import,
-			// and that issue should be fixed first.
+			// we also want to egister runtime import explicitly here, even though it is likely already
+			// part of the default imports (which may change).
+			//
+			// It should be eventually pruned if already registered with default imports.
+			if strings.HasPrefix(ser.Implementation, "runtime.") {
+				imports["runtime"] = "github.com/go-openapi/runtime"
+			}
 		}
 	}
 }

--- a/generator/model.go
+++ b/generator/model.go
@@ -377,6 +377,12 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 		"validate":    "github.com/go-openapi/validate",
 	}
 
+	imports := findImports(&pg.GenSchema)
+	if err := ensureDedupedImports(defaultImports, imports); err != nil {
+		// guard against internal dev errors
+		return nil, err
+	}
+
 	return &GenDefinition{
 		GenCommon: GenCommon{
 			Copyright:        opts.Copyright,
@@ -388,7 +394,7 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 		DependsOn:      pg.Dependencies,
 		DefaultImports: defaultImports,
 		ExtraSchemas:   gatherExtraSchemas(pg.ExtraSchemas),
-		Imports:        findImports(&pg.GenSchema),
+		Imports:        imports,
 		External:       isExternal(schema),
 	}, nil
 }

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -144,7 +144,12 @@ func (o *operationGenerator) Generate() error {
 
 	apiPackage := o.GenOpts.LanguageOpts.ManglePackagePath(o.GenOpts.APIPackage, defaultOperationsTarget)
 	imports := newImportsBuilder(o.GenOpts).initImports(
-		filepath.Join(o.GenOpts.LanguageOpts.ManglePackagePath(o.GenOpts.ServerPackage, defaultServerTarget), apiPackage))
+		filepath.Join(o.GenOpts.LanguageOpts.ManglePackagePath(o.GenOpts.ServerPackage, defaultServerTarget), apiPackage),
+	)
+	if err := ensureDedupedImports(defaultImports, imports); err != nil {
+		// guard against internal dev errors
+		return err
+	}
 
 	bldr := codeGenOpBuilder{
 		ModelsPackage:       o.ModelsPackage,

--- a/generator/shared.go
+++ b/generator/shared.go
@@ -656,3 +656,48 @@ func concatUnique(collections ...[]string) []string {
 	}
 	return result
 }
+
+// ensureDedupedImports ensures that extra imports are not already in default imports.
+//
+// Besides it also check that:
+//
+//   - the same package is not imported twice with a different alias
+//   - the same alias found in default imports point to the same package
+//
+// It prunes redundant keys from extraImports, or errors if checks don't pass.
+func ensureDedupedImports(defaultImports, extraImports map[string]string) error {
+	pkgIndex := make(map[string]string, len(extraImports))
+	for alias, pkg := range defaultImports {
+		pkgIndex[pkg] = alias
+	}
+
+	for alias, pkg := range extraImports {
+		seenAlias, foundAlias := defaultImports[alias]
+		seenPackage, alreadyImported := pkgIndex[pkg]
+
+		if !foundAlias && !alreadyImported {
+			continue
+		}
+
+		if foundAlias && alias != seenAlias {
+			return fmt.Errorf(
+				"dev error: the same package %q imported with different aliases: %q and %q",
+				pkg, alias, seenAlias,
+			)
+		}
+
+		if alreadyImported && pkg != seenPackage {
+			return fmt.Errorf(
+				"dev error: package aliased as %q points to different packages: %q and %q",
+				alias, pkg, seenPackage,
+			)
+		}
+
+		// true duplicate, consistent with defaultImports: may be safely pruned
+		pkgIndex[pkg] = alias
+
+		delete(extraImports, alias)
+	}
+
+	return nil
+}

--- a/generator/support.go
+++ b/generator/support.go
@@ -312,6 +312,11 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 			}
 		}
 	}
+	if err := ensureDedupedImports(defaultImports, imports); err != nil {
+		// guard against internal dev errors
+		return GenApp{}, err
+	}
+
 	sort.Sort(genModels)
 
 	log.Printf("planning operations (found: %d)", len(a.Operations))

--- a/generator/templates/cli/operation.gotmpl
+++ b/generator/templates/cli/operation.gotmpl
@@ -8,11 +8,10 @@ import (
   "fmt"
 
   httptransport "github.com/go-openapi/runtime/client"
-  {{ imports .DefaultImports }}
-  {{ imports .Imports }}
-
   "github.com/spf13/cobra"
   "github.com/go-openapi/runtime"
+  {{ imports .DefaultImports }}
+  {{ imports .Imports }}
 )
 
 // make{{ cmdName . }} returns a command to handle operation {{ camelize .Name }}

--- a/generator/templates/contrib/stratoscale/server/configureapi.gotmpl
+++ b/generator/templates/contrib/stratoscale/server/configureapi.gotmpl
@@ -18,7 +18,6 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/runtime/security"
-
   {{ imports .DefaultImports }}
   {{ imports .Imports }}
 )

--- a/generator/templates/server/configureapi.gotmpl
+++ b/generator/templates/server/configureapi.gotmpl
@@ -17,7 +17,6 @@ import (
   "github.com/go-openapi/runtime/middleware"
   "github.com/go-openapi/runtime/security"
   "github.com/go-openapi/swag/cmdutils"
-
   {{ imports .DefaultImports }}
   {{ imports .Imports }}
 )

--- a/generator/templates/server/main.gotmpl
+++ b/generator/templates/server/main.gotmpl
@@ -102,7 +102,6 @@ import (
   {{- else }}
   // missing a CLI flag library setting
   {{- end }}
-
   "github.com/go-openapi/loads"
   {{- if .ExcludeSpec }}
   "github.com/go-openapi/loads/fmts"

--- a/generator/templates/server/operation.gotmpl
+++ b/generator/templates/server/operation.gotmpl
@@ -21,7 +21,6 @@ import (
   "github.com/go-openapi/swag/stringutils"
   "github.com/go-openapi/swag/typeutils"
   "github.com/go-openapi/validate"
-
   {{ imports .DefaultImports }}
   {{ imports .Imports }}
 )


### PR DESCRIPTION
This PR adds a dedupe following explicit import additions.

It is desirable that every feature that requires an import adds it independently, without assuming what is or what is not part of the default imports.