### PR TITLE
fix(generator): disallow funcmap to override builtins

### DIFF
--- a/generator/internal/funcmaps/golang/funcmap.go
+++ b/generator/internal/funcmaps/golang/funcmap.go
@@ -9,7 +9,6 @@ package golang
 import (
 	"encoding/json"
 	"fmt"
-	"maps"
 	"math"
 	"path"
 	"path/filepath"
@@ -29,16 +28,23 @@ import (
 	"github.com/go-openapi/swag/stringutils"
 )
 
-// FuncMap returns a template.FuncMap containing all Go-specific template
-// functions that are independent of generator types. Callers typically
-// merge additional entries (e.g. LanguageOpts-dependent or type-dependent
-// functions) on top.
+// FuncMap returns a template.FuncMap containing all Go-specific template functions.
+//
+// Callers typically merge or coalesce additional entries (e.g. LanguageOpts-dependent or type-dependent functions) on top.
+//
+// NOTE: built-in functions are preserved by the [Coalesce] semantics.
 func FuncMap(mangler mangling.NameMangler) template.FuncMap {
 	f := sprig.TxtFuncMap()
+	extra := goswaggerFuncMap(mangler)
+
+	return Coalesce(extra, f)
+}
+
+func goswaggerFuncMap(mangler mangling.NameMangler) template.FuncMap {
 	pascalize := pascalize(mangler)
 	mediaGoName := mediaGoName(mangler)
 
-	extra := template.FuncMap{
+	return template.FuncMap{
 		"pascalize":          pascalize,
 		"camelize":           mangler.ToJSONName,
 		"humanize":           mangler.ToHumanNameLower,
@@ -110,10 +116,6 @@ func FuncMap(mangler mangling.NameMangler) template.FuncMap {
 			return foldReplacer.Replace(in)
 		},
 	}
-
-	maps.Copy(f, extra)
-
-	return f
 }
 
 var foldReplacer = strings.NewReplacer("\n", " ", "\r", "")

--- a/generator/internal/funcmaps/golang/funcmap_test.go
+++ b/generator/internal/funcmaps/golang/funcmap_test.go
@@ -126,7 +126,7 @@ func TestFuncMap(t *testing.T) { //nolint:maintidx // false positive
 		}
 	})
 
-	t.Run("dict should render values as a map", func(t *testing.T) {
+	t.Run("dict (from sprig) should render values as a map", func(t *testing.T) {
 		t.Parallel()
 
 		dict, ok := fm["dict"].(func(...any) (map[string]any, error))
@@ -350,6 +350,17 @@ func TestFuncMap(t *testing.T) { //nolint:maintidx // false positive
 
 		assert.EqualT(t, "no ticks", escapeBackticks("no ticks"))
 		assert.EqualT(t, "has`+\"`\"+`tick", escapeBackticks("has`tick"))
+	})
+
+	t.Run("funcmap should not override builtins", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("slice should be the builtin form", func(t *testing.T) {
+			_, ok := fm["slice"]
+			require.FalseT(t, ok)
+			// builtin signature: func(reflect.Value, ...reflect.Value) (reflect.Value, error)
+			// the signature of the sprig version is: func (interface{}, ...interface{}) interface{}
+		})
 	})
 }
 

--- a/generator/internal/funcmaps/golang/merge.go
+++ b/generator/internal/funcmaps/golang/merge.go
@@ -1,0 +1,85 @@
+package golang
+
+import (
+	"maps"
+	"text/template"
+)
+
+// Merge [template.FuncMap] s into the target [template.FuncMap].
+func Merge(target template.FuncMap, merged ...template.FuncMap) template.FuncMap {
+	return MergeMaps(target, merged...)
+}
+
+// Coalesce [template.FuncMap] s into the target [template.FuncMap].
+//
+// Built-in functions are implied and are therefore always protected from an override.
+func Coalesce(target template.FuncMap, coalesced ...template.FuncMap) template.FuncMap {
+	m := CoalesceMaps(target, coalesced...)
+	for _, builtin := range builtinFuncMap {
+		delete(m, builtin)
+	}
+
+	return m
+}
+
+// builtins holds the name of all built-in functions.
+//
+// These are provided by the text/templates package.
+//
+// See https://pkg.go.dev/text/template@go1.26.5#hdr-Functions
+var builtinFuncMap = []string{
+	"and", "not", "or",
+	"eq", "ge", "gt", "le", "lt", "ne",
+	"call",
+	"index", "slice", "len",
+	"print", "printf", "println",
+	"html", "js", "urlquery",
+}
+
+// MergeMaps merges maps into the target.
+//
+// If the target is nil, a new merged map is created.
+//
+// Merge semantics are: overwrite, last win.
+func MergeMaps[M ~map[K]V, K comparable, V any](target M, merged ...M) M {
+	if target == nil {
+		var c int
+		for _, m := range merged {
+			c += len(m)
+		}
+		target = make(map[K]V, c)
+	}
+
+	for _, m := range merged {
+		maps.Copy(target, m)
+	}
+
+	return target
+}
+
+// CoalesceMaps merges maps into the target.
+//
+// If the target is nil, a new merged map is created.
+//
+// Merge semantics are: coalesce without overwrite, first win.
+func CoalesceMaps[M ~map[K]V, K comparable, V any](target M, coalesced ...M) M {
+	if target == nil {
+		var c int
+		for _, m := range coalesced {
+			c += len(m)
+		}
+		target = make(map[K]V, c)
+	}
+
+	for _, co := range coalesced {
+		for k, v := range co {
+			_, found := target[k]
+			if found {
+				continue
+			}
+			target[k] = v
+		}
+	}
+
+	return target
+}


### PR DESCRIPTION
Template builtins cannot be overriden any longer. This is usually a mistake when integrating large funcmap libraries such as sprig.

* fixes #3087