### PR TITLE
fix(codegen): escape untrusted names in generated struct tags

### DIFF
--- a/generator/internal/funcmaps/golang/funcmap.go
+++ b/generator/internal/funcmaps/golang/funcmap.go
@@ -94,6 +94,32 @@ func goswaggerFuncMap(mangler mangling.NameMangler) template.FuncMap {
 
 			return quoted[1 : len(quoted)-1]
 		},
+		// jsonFieldTag renders a complete `json:"..."` struct tag from a
+		// spec-derived field name, mirroring the whole-tag quoting decision of
+		// GenSchema.PrintTags. Templates that hand-write the backtick tag inline
+		// (server response headers, allOf / discriminator serializers) bypass
+		// PrintTags, so a backtick in the name would otherwise close the raw
+		// string early and inject arbitrary top-level Go. strconv.Quote escapes
+		// the name into the tag value; if the assembled tag can be backquoted it
+		// is emitted as a raw literal (byte-identical to the previous output for
+		// clean names), otherwise the whole tag is rendered as a double-quoted
+		// literal so no breakout is possible.
+		"jsonFieldTag": func(name string, omitEmpty, asString bool) string {
+			value := name
+			if omitEmpty {
+				value += ",omitempty"
+			}
+			if asString {
+				value += ",string"
+			}
+
+			tag := "json:" + strconv.Quote(value)
+			if strconv.CanBackquote(tag) {
+				return "`" + tag + "`"
+			}
+
+			return strconv.Quote(tag)
+		},
 		"flagNameVar": func(in string) string {
 			return fmt.Sprintf("flag%sName", pascalize(in))
 		},

--- a/generator/internal/funcmaps/golang/funcmap_test.go
+++ b/generator/internal/funcmaps/golang/funcmap_test.go
@@ -34,7 +34,7 @@ func TestFuncMap(t *testing.T) { //nolint:maintidx // false positive
 			"dict", "isInteger", "hasPrefix", "stringContains",
 			"trimSpace", "mdBlock", "httpStatus",
 			"cleanupEnumVariant", "gt0",
-			"escapeBackticks",
+			"escapeBackticks", "escapeDoubleQuoted", "jsonFieldTag",
 			"flagNameVar", "flagValueVar", "flagDefaultVar", "flagModelVar", "flagDescriptionVar",
 			"printGoLiteral",
 		} {
@@ -350,6 +350,27 @@ func TestFuncMap(t *testing.T) { //nolint:maintidx // false positive
 
 		assert.EqualT(t, "no ticks", escapeBackticks("no ticks"))
 		assert.EqualT(t, "has`+\"`\"+`tick", escapeBackticks("has`tick"))
+	})
+
+	t.Run("jsonFieldTag should render a safe struct tag", func(t *testing.T) {
+		t.Parallel()
+
+		jsonFieldTag, ok := fm["jsonFieldTag"].(func(string, bool, bool) string)
+		require.TrueT(t, ok)
+		require.NotNil(t, jsonFieldTag)
+
+		// clean names render as a raw backtick literal, byte-identical to the
+		// previous hand-written template output.
+		assert.EqualT(t, "`json:\"name\"`", jsonFieldTag("name", false, false))
+		assert.EqualT(t, "`json:\"name,omitempty\"`", jsonFieldTag("name", true, false))
+		assert.EqualT(t, "`json:\"name,omitempty,string\"`", jsonFieldTag("name", true, true))
+		assert.EqualT(t, "`json:\"name,string\"`", jsonFieldTag("name", false, true))
+
+		// a backtick in the name cannot be represented in a raw literal, so the
+		// whole tag falls back to a double-quoted literal: the injected payload
+		// can no longer close the tag and inject top-level Go.
+		got := jsonFieldTag("evil` }; func init(){ println(\"pwned\") }; var _ = `", false, false)
+		assert.EqualT(t, `"json:\"evil`+"`"+` }; func init(){ println(\\\"pwned\\\") }; var _ = `+"`"+`\""`, got)
 	})
 
 	t.Run("funcmap should not override builtins", func(t *testing.T) {

--- a/generator/sanitize_harness_test.go
+++ b/generator/sanitize_harness_test.go
@@ -139,6 +139,32 @@ func TestSanitizeGenHarness(t *testing.T) {
 		assertNoInjectedDecl(t, opts.Target)
 	})
 
+	t.Run("response header name is contained in struct tag (server)", func(t *testing.T) {
+		target := harnessTarget(t, "hdr-tag-server", "server_test", root)
+		opts := defaultServerOpts(t, "../testdata/codegen/sanitize/response-header-tag-injection.yaml", target)
+
+		// The response header name is emitted into a backtick `json:"..."` struct
+		// tag of a top-level response type (server/responses.gotmpl). A backtick
+		// closes the raw string early and injects a top-level func init() that runs
+		// before main(). jsonFieldTag renders the whole tag with PrintTags
+		// semantics, forcing it to a double-quoted literal so nothing breaks out.
+		require.NoError(t, GenerateServer("", nil, nil, opts))
+		assertNoInjectedDecl(t, opts.Target)
+	})
+
+	t.Run("property name is contained in serializer struct tag (model)", func(t *testing.T) {
+		target := harnessTarget(t, "prop-tag-model", "model_test", root)
+		opts := defaultServerOpts(t, "../testdata/codegen/sanitize/property-name-tag-injection.yaml", target)
+
+		// allOf inheritance and a discriminator route property names through the
+		// serializer struct tags (schemabody.gotmpl / allofserializer.gotmpl),
+		// which hand-write a backtick `json:"..."` tag and bypass PrintTags. A
+		// backtick breaks out of the anonymous struct, yielding invalid Go written
+		// to disk. jsonFieldTag keeps the whole tag in a double-quoted literal.
+		require.NoError(t, GenerateModels([]string{"", ""}, opts))
+		assertNoInjectedDecl(t, filepath.Join(opts.Target, defaultModelsTarget))
+	})
+
 	t.Run("response header name is contained (client)", func(t *testing.T) {
 		target := harnessTarget(t, "names-client", "client_test", root)
 		opts := defaultClientOpts(t, "../testdata/codegen/sanitize/names-injection.yaml", target)

--- a/generator/templates/schemabody.gotmpl
+++ b/generator/templates/schemabody.gotmpl
@@ -152,7 +152,7 @@
   {{ if not (and .IsBaseType .IsExported) }}{{ .GoType }}{{ end }}{{ end }}
   {{ end }}
   {{range .Properties}}{{ if .IsBaseType }}
-  {{ if not $.IsExported }}{{ else }}{{ .GoName}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`{{ end}}
+  {{ if not $.IsExported }}{{ else }}{{ .GoName}} {{ template "schemaType" . }} {{ jsonFieldTag .Name (and (not .Required) .IsEmptyOmitted) .IsJSONString }}{{ end}}
   {{end}}{{ end }}
   {{ if .HasAdditionalProperties }}{{ if and .IsExported }}{{ .AdditionalProperties.GoName }}{{ else }}{{ .AdditionalProperties.GoName }}Field{{ end }} map[string]{{ template "schemaType" .AdditionalProperties }} `json:"-"`
   {{ end }}
@@ -172,7 +172,7 @@
             {{template "structfield" . }}
           {{ end }}
         {{ else }}
-          {{ .GoName }} json.RawMessage `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName }} json.RawMessage {{ jsonFieldTag .Name (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
         {{ end}}
       {{ end }}
       {{ if .HasAdditionalProperties }}
@@ -194,10 +194,10 @@
       {{ if not $.IsExported }}
         {{template "privstructfield" . }}
       {{ else }}
-        {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+        {{ .GoName}} {{ template "schemaType" . }} {{ jsonFieldTag .Name (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
       {{ end}}
     {{ else }}
-      {{ .GoName }} json.RawMessage `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+      {{ .GoName }} json.RawMessage {{ jsonFieldTag .Name (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
     {{end}}
   {{ end }}
   {{ if .HasAdditionalProperties }}
@@ -237,7 +237,7 @@
       {{ if not .IsExported }}
         {{template "privstructfield" . }}
       {{ else }}
-        {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+        {{ .GoName}} {{ template "schemaType" . }} {{ jsonFieldTag .Name (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
       {{ end}}
     {{end}}
   {{ end }}
@@ -269,13 +269,13 @@
   {{ range .AllOf }}
     {{ range .Properties }}
       {{ if .IsBaseType }}
-        {{ .GoName }} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+        {{ .GoName }} {{ template "schemaType" . }} {{ jsonFieldTag .Name (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
       {{ end }}
     {{ end }}
   {{ end }}
   {{ range .Properties }}
     {{ if or (not .IsExported) .IsBaseType }}
-      {{ .GoName }} {{ template "schemaType" . }} `json:"{{ .Name }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+      {{ .GoName }} {{ template "schemaType" . }} {{ jsonFieldTag .Name (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
     {{ end }}
   {{end}}} {
   {{ range .AllOf }}

--- a/generator/templates/serializers/allofserializer.gotmpl
+++ b/generator/templates/serializers/allofserializer.gotmpl
@@ -12,13 +12,13 @@ func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(raw []byte) error {
           {{- if not $.IsExported }}
             {{ template "privstructfield" . }}
           {{- else }}
-            {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+            {{ .GoName}} {{ template "schemaType" . }} {{ jsonFieldTag .OriginalName (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
           {{- end }}
         {{ else }}
           {{ if not $.IsExported }}
             {{ template "privstructfield" . }}
           {{ else }}
-            {{ .GoName}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+            {{ .GoName}} json.RawMessage {{ jsonFieldTag .OriginalName (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
           {{ end }}
         {{ end }}
       {{- end }}
@@ -59,13 +59,13 @@ func ({{.ReceiverName}} *{{ .GoName }}) UnmarshalJSON(raw []byte) error {
         {{- if not $.IsExported }}
           {{ template "privstructfield" . }}
         {{- else }}
-          {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName}} {{ template "schemaType" . }} {{ jsonFieldTag .OriginalName (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
         {{- end }}
       {{- else }}
         {{- if not $.IsExported }}
           {{ template "privstructfield" . }}
         {{- else }}
-          {{ .GoName}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName}} json.RawMessage {{ jsonFieldTag .OriginalName (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
         {{- end }}
       {{- end }}
     {{ end }}
@@ -98,13 +98,13 @@ func ({{.ReceiverName}} {{ .GoName }}) MarshalJSON() ([]byte, error) {
           {{- if not $.IsExported }}
             {{ template "privstructfield" . }}
           {{- else }}
-            {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+            {{ .GoName}} {{ template "schemaType" . }} {{ jsonFieldTag .OriginalName (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
           {{- end }}
         {{- else }}
           {{- if not $.IsExported }}
             {{ template "privstructfield" . }}
           {{- else }}
-            {{ .GoName}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+            {{ .GoName}} json.RawMessage {{ jsonFieldTag .OriginalName (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
             {{- end }}
         {{- end }}
       {{ end }}
@@ -151,13 +151,13 @@ func ({{.ReceiverName}} {{ .GoName }}) MarshalJSON() ([]byte, error) {
         {{- if not $.IsExported }}
           {{ template "privstructfield" . }}
         {{- else }}
-          {{ .GoName}} {{ template "schemaType" . }} `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName}} {{ template "schemaType" . }} {{ jsonFieldTag .OriginalName (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
         {{- end }}
       {{- else }}
         {{- if not $.IsExported }}
           {{ template "privstructfield" . }}
         {{- else }}
-          {{ .GoName}} json.RawMessage `json:"{{ .OriginalName }}{{ if and (not .Required) .IsEmptyOmitted }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+          {{ .GoName}} json.RawMessage {{ jsonFieldTag .OriginalName (and (not .Required) .IsEmptyOmitted) .IsJSONString }}
         {{- end }}
       {{- end }}
     {{ end }}

--- a/generator/templates/server/responses.gotmpl
+++ b/generator/templates/server/responses.gotmpl
@@ -73,7 +73,7 @@ type {{ pascalize .Name }} struct {
 // Min Items: {{ .MinItems }}{{ end }}{{ if .UniqueItems }}
 // Unique: true{{ end }}{{ if .HasDefault }}
 // Default: {{ printGoLiteral .Default }}{{ end }}
-  {{ .ID }} {{ .GoType }} `json:"{{.Name}}{{ if not .Required }},omitempty{{ end }}{{ if .IsJSONString }},string{{ end }}"`
+  {{ .ID }} {{ .GoType }} {{ jsonFieldTag .Name (not .Required) .IsJSONString }}
   {{ end }}
   {{ if .Schema }}{{ with .Schema }}
   {{- if .Description }}

--- a/testdata/codegen/sanitize/property-name-tag-injection.yaml
+++ b/testdata/codegen/sanitize/property-name-tag-injection.yaml
@@ -1,0 +1,41 @@
+# Adversarial fixture: schema property NAMES carry Go breakout payloads aimed at
+# the serializer struct tags. allOf inheritance and a discriminator route the
+# fields through schemabody.gotmpl / serializers/allofserializer.gotmpl, which
+# hand-write a backtick-quoted `json:"..."` tag from the property name and bypass
+# GenSchema.PrintTags. A backtick in the name closes the raw string early; the
+# `;`-separated declarations break out of the (function-scope) anonymous struct.
+# Unlike the top-level response type, this yields invalid Go that is still written
+# to disk rather than a clean init-time RCE, but it is the same missing-escape
+# defect. jsonFieldTag forces the whole tag to a double-quoted literal so the
+# generated source stays valid and inert.
+swagger: "2.0"
+info:
+  title: property name tag injection
+  version: "1.0"
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        "200":
+          description: ok
+          schema:
+            $ref: "#/definitions/Base"
+definitions:
+  Base:
+    type: object
+    discriminator: petType
+    required:
+      - petType
+    properties:
+      petType:
+        type: string
+      'evilbase` }; func init(){ println("PWNED_PROP_BASE") }; type _ struct{ z string `':
+        type: string
+  Cat:
+    allOf:
+      - $ref: "#/definitions/Base"
+      - type: object
+        properties:
+          'evilcat` }; func init(){ println("PWNED_PROP_CHILD") }; type _ struct{ w string `':
+            type: string

--- a/testdata/codegen/sanitize/response-header-tag-injection.yaml
+++ b/testdata/codegen/sanitize/response-header-tag-injection.yaml
@@ -1,0 +1,21 @@
+# Adversarial fixture: a response header NAME carries a Go breakout payload aimed
+# at the server response struct tag (server/responses.gotmpl). The header name is
+# emitted into a backtick-quoted `json:"..."` struct tag of a top-level response
+# type; a backtick closes the raw string early and the `;`-separated declarations
+# become live top-level Go (func init runs at package load — RCE before main).
+# jsonFieldTag renders the whole tag with PrintTags semantics: a backtick in the
+# value forces the tag to a double-quoted literal, so nothing can break out.
+swagger: "2.0"
+info:
+  title: response header tag injection
+  version: "1.0"
+paths:
+  /foo:
+    get:
+      operationId: getFoo
+      responses:
+        "200":
+          description: ok
+          headers:
+            'X-Evil` }; func init(){ println("PWNED_HEADER_TAG") }; func _(){ _ = `':
+              type: string


### PR DESCRIPTION
Response header names and model property names taken from an untrusted OpenAPI document were interpolated raw into hand-written backtick struct tags in the server, allOf and discriminator serializer templates. A backtick in the name closes the raw-string tag early and, in the top-level response type, injects a func init() that runs before main() — a code-injection vulnerability (CWE-94) reachable by generating from a malicious spec.

These templates bypassed GenSchema.PrintTags, the sanitiser used on the regular struct-field path. A new jsonFieldTag funcmap applies the same whole-tag quoting: the value is strconv.Quote'd and the tag falls back to a double-quoted literal when it cannot be backquoted, so a backtick can no longer break out. All fifteen inline tags now route through it.

For names that need no escaping the rendered tag is unchanged, so regenerated output is byte-identical to the current packages.