### PR TITLE
ci: simplified workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: go-openapi/ci-workflows/.github/workflows/auto-merge.yml@ef14d94bfba7bf45458ce6a6afd4a1c75e04ac2a # v0.4.4
+    uses: go-openapi/ci-workflows/.github/workflows/auto-merge.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,5 +19,5 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: go-openapi/ci-workflows/.github/workflows/codeql.yml@ef14d94bfba7bf45458ce6a6afd4a1c75e04ac2a # v0.4.4
+    uses: go-openapi/ci-workflows/.github/workflows/codeql.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
     secrets: inherit

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    uses: go-openapi/ci-workflows/.github/workflows/contributors.yml@ef14d94bfba7bf45458ce6a6afd4a1c75e04ac2a # v0.4.4
+    uses: go-openapi/ci-workflows/.github/workflows/contributors.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
     secrets:
       github-app-id: ${{ secrets.CI_BOT_APP_ID }}
       github-app-private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/doc-latest.yml
+++ b/.github/workflows/doc-latest.yml
@@ -3,26 +3,65 @@ name: "Update latest documentation"
 permissions:
   contents: read
 
+# NOTE: no "paths" filter here on purpose -- see the note in go-test.yml.
+# Filtering happens in the "changes" job below, so "doc completed" reports on every run
+# and stays usable as a required status check.
 on:
   push:
     branches:
-      -  master
-    paths:
-    - docs/**
-    - hack/doc-site/**
-    - .github/workflows/update-doc.yml
+      - master
 
   pull_request:
-    paths:
-    - docs/**
-    - hack/doc-site/**
-    - .github/workflows/update-doc.yml
 
 jobs:
+  changes:
+    # description: |
+    #   Decide whether this run has any documentation to rebuild. Fails open.
+    name: Changes
+    uses: go-openapi/ci-workflows/.github/workflows/doc-changed.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
+    with:
+      # The 'doc' preset follows the go-openapi layout (content under docs/doc-site,
+      # hugo under hack/doc-site). go-swagger keeps its content one level up, directly
+      # under docs/, so it has to be declared here.
+      extra-paths: |
+        docs/**
+        .github/workflows/update-doc.yml
+
   update-doc:
     name: Update latest documentation
+    needs: [changes]
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     permissions:
       contents: read
       pages: write
       id-token: write
     uses: ./.github/workflows/update-doc.yml
+
+  doc-complete:
+    # description: |
+    #   The gate pinned in the branch protection rules: reports on every run, including
+    #   the code-only pull requests where the doc build was skipped. See the equivalent
+    #   note in integration-test.yml.
+    name: doc completed
+    needs: [changes, update-doc]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Report upstream job results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          echo "::group::upstream job results"
+          printenv RESULTS
+          echo "::endgroup::"
+      -
+        name: Fail on any unsuccessful upstream job
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error title=doc::the documentation build failed or was cancelled"
+          exit 1
+      -
+        name: Doc completed
+        run: |
+          echo "::notice title=Success::Documentation is up to date"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -4,26 +4,35 @@ permissions:
   pull-requests: read
   contents: read
 
+# NOTE: no "paths-ignore" here on purpose.
+#
+# A workflow filtered at the trigger level does not start at all on a doc-only pull
+# request, so its status check never reports and branch protection waits forever on
+# "Expected -- waiting for status to be reported".
+#
+# The shared workflow now filters at the JOB level instead: it skips its matrix when
+# nothing relevant changed, which costs the same (a skipped job burns no runner minute)
+# but keeps publishing "tests completed" on every single run.
 on:
   push:
     branches:
-    paths-ignore:
       - master
-      - 'hack/hugo/*'
-      - .github/workflows/update-doc.yml
-      - '*.md'
-      - '**/*.md'
-
 
   pull_request:
-    paths-ignore:
-      - 'hack/hugo/*'
-      - .github/workflows/update-doc.yml
-      - '*.md'
-      - '**/*.md'
 
+defaults:
+  run:
+    shell: bash
 
 jobs:
   test:
-    uses: go-openapi/ci-workflows/.github/workflows/go-test.yml@ef14d94bfba7bf45458ce6a6afd4a1c75e04ac2a # v0.4.4
+    uses: go-openapi/ci-workflows/.github/workflows/go-test.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
+    with:
+      # Disable -race on push & PR runs: go-swagger is a CLI with no impact from race conditions.
+      # We disable it to reduce the surge in CI credits consumption.
+      #
+      # A weekly test run with -race is carried out to identify possible bugs spotted by the race detector.
+      no-race: 'true'
+      # 'go' preset (go sources, go.mod/sum, **/testdata/**, linter config).
+      # Templates are *.gotmpl and are already covered by the preset.
     secrets: inherit

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,27 +7,36 @@ permissions:
 # description: |
 #   Test suite that runs on every commit (on pull requests, on merges to master).
 
+# NOTE: no "paths-ignore" here on purpose -- see the note in go-test.yml.
+# Filtering happens in the "changes" job below, so "Integration tests completed"
+# reports on every run and stays usable as a required status check.
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/*'
-      - 'hack/hugo/*'
-      - .github/workflows/update-doc.yml
-      - '*.md'
-      - '**/*.md'
   push:
     branches:
       - master
-    paths-ignore:
-      - 'docs/*'
-      - 'hack/hugo/*'
-      - .github/workflows/update-doc.yml
-      - '*.md'
-      - '**/*.md'
 
 jobs:
+  changes:
+    # description: |
+    #   Decide whether this run has anything to exercise. Fails open: anything unclear
+    #   runs the whole suite.
+    name: Changes
+    uses: go-openapi/ci-workflows/.github/workflows/changed-paths.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
+    with:
+      preset: go
+      # The docker image ships the built binary, so any go change is already relevant.
+      # These add what the preset cannot know about: the codegen fixture configuration
+      # and the docker build inputs exercised by docker-test.
+      extra-paths: |
+        hack/*.yaml
+        Dockerfile
+        .hadolint.yml
+
   docker-test:
     name: test docker build
+    needs: [changes]
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     uses: ./.github/workflows/build-docker.yml
     with:
       tag_sha: true
@@ -38,6 +47,8 @@ jobs:
     #   Make sure we build and run elementary operations.
     #   The full test suite warrants support for the 2 latest go minor releases.
     name: build test
+    needs: [changes]
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     strategy:
       matrix:
         go: ["oldstable", "stable"]
@@ -76,6 +87,8 @@ jobs:
     #
     #   The test matrix applies to linux only. OS-specific quirks should
     #   be covered by unit tests.
+    needs: [changes]
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     strategy:
       matrix:
         go: ["oldstable", "stable"]
@@ -135,11 +148,41 @@ jobs:
           retention-days: 1
 
   integration-test-complete:
+    # description: |
+    #   This is the gate pinned in the branch protection rules, so it MUST report on every
+    #   run, including the runs where everything else was skipped.
+    #
+    #   Hence "always()" -- with the default condition the job would inherit the skip of its
+    #   dependencies and never report -- and an assertion on the negative: fail on 'failure'
+    #   and 'cancelled', pass on 'skipped'. A job correctly skipped is then indistinguishable
+    #   from a job that had nothing to do.
+    #
+    #   Every job belongs in "needs", "changes" included: a job skipped because ITS dependency
+    #   failed reports 'skipped', so leaving the failing one out would turn the gate green over
+    #   an untested pull request.
+    #
+    #   NOTE: this used to be "if: !cancelled()" with no assertion at all, which reported
+    #   success even when build-test failed.
     name: Integration tests completed
-    needs: [build-test, codegen-test, docker-test]
-    if: ${{ !cancelled() }}
+    needs: [changes, build-test, codegen-test, docker-test]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - name: Tests completed
+      -
+        name: Report upstream job results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
         run: |
-          echo "::notice title=Success:All tests skipped (nothing to do)"
+          echo "::group::upstream job results"
+          printenv RESULTS
+          echo "::endgroup::"
+      -
+        name: Fail on any unsuccessful upstream job
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error title=integration-tests::at least one job failed or was cancelled"
+          exit 1
+      -
+        name: Tests completed
+        run: |
+          echo "::notice title=Success::All integration tests passed"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,56 +3,51 @@ name: docker-dev
 permissions:
   contents: read
 
+# description: |
+#   Builds and publishes the "latest master" development image.
+#
+#   Triggered by the push itself, NOT chained behind the test workflow. The commits
+#   landing here have already been tested as pull requests, and the workflow_run bridge
+#   cost far more than it bought:
+#
+#     * it needed a trust gate, because workflow_run matches head_branch and a fork can
+#       spoof it (a fork branch literally named "master"). A push trigger cannot be
+#       reached from a fork at all, so that whole guard is gone.
+#     * it could not filter on paths: "paths-ignore" is not a supported workflow_run
+#       filter, and a workflow_run event carries no range of changed files, so
+#       changed-paths.yml would have had to fail open and build every time. Triggering on
+#       the push gives us github.event.before, and with it real detection.
+#
+#   Trade-off accepted: a red master still publishes a dev image. These are short-lived
+#   tags (7 days) rebuilt on the next push.
 on:
-  workflow_run:
-    workflows:
-      - 'go test'
-    types:
-      - completed
+  push:
     branches:
       - master
       - 'prepare-release/*'
-    paths-ignore:
-      - 'docs/*'
-      - 'hack/hugo/*'
-      - .github/workflows/update-doc.yml
-      - '**.md'
 
 jobs:
-  on-success:
-    name: Ensure triggering workflow was successful
-    # Trust gate: docker-dev builds and PUSHES signed images using registry
-    # secrets, so it must only run for trusted same-repo triggers. The
-    # workflow_run "branches" filter above matches head_branch, which a fork can
-    # spoof (e.g. a fork branch literally named "master"). Requiring
-    # head_repository to be this repo closes that bypass: a fork PR's
-    # head_repository is the fork, while same-repo pushes and same-repo
-    # prepare-release PRs still pass.
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "The triggering workflow was successful"
-
-  on-failure:
-    name: Triggering workflow was unsuccessful
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "The triggering workflow failed. Stopping here"
-          exit 1
+  changes:
+    # description: |
+    #   Is there anything worth rebuilding an image for? The image ships the compiled
+    #   binary, so any go change counts, plus the docker build inputs themselves.
+    #
+    #   Fails open: anything unclear builds.
+    name: Changes
+    uses: go-openapi/ci-workflows/.github/workflows/changed-paths.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
+    with:
+      preset: go
+      extra-paths: |
+        Dockerfile
+        .hadolint.yml
 
   docker-dev:
     permissions:
       contents: read
       security-events: write
     name: Docker latest master (dev)
-    needs: [on-success]
+    needs: [changes]
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     uses: ./.github/workflows/build-docker.yml
     with:
       push: true

--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -16,5 +16,5 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: go-openapi/ci-workflows/.github/workflows/scanner.yml@ef14d94bfba7bf45458ce6a6afd4a1c75e04ac2a # V0.4.4
+    uses: go-openapi/ci-workflows/.github/workflows/scanner.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # V0.5.1
     secrets: inherit

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -76,16 +76,9 @@ jobs:
         with:
           version: v0.123.8  # <- pin the HUGO version, as they often break things
           extended: true
-          args: >
-            --config hugo.yaml,goswagger.yaml
-            --buildDrafts
-            --cleanDestinationDir
-            --minify
-            --printPathWarnings
-            --ignoreCache
-            --noBuildLock
-            --logLevel info
-            --source ${{ github.workspace }}/hack/doc-site/hugo"
+          # Single line on purpose: the runner does not reliably fold ">" scalars for action
+          # inputs, and hugo would receive the flags with embedded newlines.
+          args: --config hugo.yaml,goswagger.yaml --buildDrafts --cleanDestinationDir --minify --printPathWarnings --ignoreCache --noBuildLock --logLevel info --source ${{ github.workspace }}/hack/doc-site/hugo
       -
         name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/webhook-announcements.yml
+++ b/.github/workflows/webhook-announcements.yml
@@ -51,7 +51,7 @@ on:
 
 jobs:
   announce:
-    uses: go-openapi/ci-workflows/.github/workflows/webhook-announcements.yml@ef14d94bfba7bf45458ce6a6afd4a1c75e04ac2a # v0.4.4
+    uses: go-openapi/ci-workflows/.github/workflows/webhook-announcements.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
     with:
       scanned-markdown: README.md
       # On push: normal before..after diff (empty

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -1,0 +1,21 @@
+name: weekly go test
+
+permissions:
+  pull-requests: read
+  contents: read
+
+on:
+  # weekly test on schedule, with race
+  schedule:
+    - cron: '14 5 * * 3'
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: go-openapi/ci-workflows/.github/workflows/go-test.yml@adf38bd293f1ec3c4785fd09837e23c464e3eaf8 # v0.5.1
+    with:
+      # Neither a schedule nor a dispatch carries a list of changed files, so detection
+      # would fall back on running everything anyway. Saying it explicitly documents the
+      # intent and keeps this run independent of how detection evolves.
+      force-run: 'true'
+    secrets: inherit


### PR DESCRIPTION
Simplified CI workflows, leverage more capable shared workflows.

In particular, this leaves quite a few individual github actions managed by the shared workflows, thus less dependabot noise in this repo.