### PR TITLE
fix(generator): improved error handling on wrong specified target

### DIFF
--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -143,6 +143,7 @@ type sharedOptionsCommon struct {
 	ReturnErrors          bool           `description:"handlers explicitly return an error as the second value"                            group:"shared"                                            long:"return-errors"           short:"e"`
 	Restricted            bool           `description:"Use restricted http client for remote $ref"                                         group:"shared"                                            long:"restricted"`
 	Rooted                string         `description:"Local $ref resolution contained relative to root FS"                                group:"shared"                                            long:"rooted"`
+	EnsureTarget          bool           `description:"Create the target directory if it does not already exist"                           group:"shared"                                            long:"ensure-target"`
 }
 
 func (s sharedOptionsCommon) apply(opts *generator.GenOpts) {
@@ -161,6 +162,7 @@ func (s sharedOptionsCommon) apply(opts *generator.GenOpts) {
 	opts.WithExtraInitialisms = s.AdditionalInitialisms
 	opts.Restricted = s.Restricted
 	opts.Rooted = s.Rooted
+	opts.EnsureTarget = s.EnsureTarget
 }
 
 func setCopyright(copyrightFile string) (string, error) {

--- a/docs/generate/cli.md
+++ b/docs/generate/cli.md
@@ -74,6 +74,7 @@ Help Options:
       -e, --return-errors                                                                    handlers explicitly return an error as the second value
           --restricted                                                                       Use restricted http client for remote $ref
           --rooted=                                                                          Local $ref resolution contained relative to root FS
+          --ensure-target                                                                    Create the target directory if it does not already exist
       -p, --template-plugin=                                                                 the template plugin to use
 
     Options for model generation:

--- a/docs/generate/model.md
+++ b/docs/generate/model.md
@@ -46,6 +46,7 @@ Help Options:
       -e, --return-errors                                                                    handlers explicitly return an error as the second value
           --restricted                                                                       Use restricted http client for remote $ref
           --rooted=                                                                          Local $ref resolution contained relative to root FS
+          --ensure-target                                                                    Create the target directory if it does not already exist
       -p, --template-plugin=                                                                 the template plugin to use
 
     Options for model generation:

--- a/docs/generate/server.md
+++ b/docs/generate/server.md
@@ -73,6 +73,7 @@ Help Options:
       -e, --return-errors                                                                    handlers explicitly return an error as the second value
           --restricted                                                                       Use restricted http client for remote $ref
           --rooted=                                                                          Local $ref resolution contained relative to root FS
+          --ensure-target                                                                    Create the target directory if it does not already exist
       -p, --template-plugin=                                                                 the template plugin to use
 
     Options for model generation:

--- a/generator/client.go
+++ b/generator/client.go
@@ -70,20 +70,25 @@ type clientGenerator struct {
 }
 
 func (c *clientGenerator) Generate() error {
+	importTarget, err := c.GenOpts.LanguageOpts.BaseImport(c.Target)
+	if err != nil {
+		return errTarget(c.Target, err)
+	}
+
 	app, err := c.makeCodegenApp()
 	if err != nil {
 		return err
 	}
 	app.DefaultImports["cli"] = path.Join(
-		c.GenOpts.LanguageOpts.BaseImport(c.Target),
+		importTarget,
 		"cli",
 	)
 	app.DefaultImports["client"] = path.Join(
-		c.GenOpts.LanguageOpts.BaseImport(c.Target),
+		importTarget,
 		"client",
 	)
 	app.DefaultImports["operations"] = path.Join(
-		c.GenOpts.LanguageOpts.BaseImport(c.Target),
+		importTarget,
 		"client",
 		"operations",
 	)
@@ -91,11 +96,11 @@ func (c *clientGenerator) Generate() error {
 	for i := range app.Models {
 		di := app.Models[i].DefaultImports
 		di["models"] = path.Join(
-			c.GenOpts.LanguageOpts.BaseImport(c.Target),
+			importTarget,
 			"models",
 		)
 		di["client"] = path.Join(
-			c.GenOpts.LanguageOpts.BaseImport(c.Target),
+			importTarget,
 			"client",
 		)
 	}

--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -4,6 +4,7 @@
 package generator
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1092,7 +1093,7 @@ func testClientGenOpts() *GenOpts {
 	g := NewGenOpts(ForClient())
 	g.Target = "."
 	if err := ensureMachinery(g); err != nil {
-		panic(err)
+		panic(fmt.Errorf("internal error: options ensureMachinery should not fail in tests: %w", err))
 	}
 
 	return g

--- a/generator/genopts.go
+++ b/generator/genopts.go
@@ -36,6 +36,8 @@ type GenOpts struct {
 	IsClient                   bool
 	machineryBuilt             bool // guards buildMachinery (language opts, func map, templates repo)
 	sectionsResolved           bool // guards resolveSections (default render plan)
+	specNormalized             bool // guards normalize (spec path resolution)
+	targetEnsured              bool // guards ensureTarget (target directory checks)
 	prepared                   bool // guards Prepare
 	PropertiesSpecOrder        bool
 	StrictAdditionalProperties bool
@@ -88,6 +90,7 @@ type GenOpts struct {
 	WithExtraInitialisms   []string
 	Restricted             bool
 	Rooted                 string
+	EnsureTarget           bool // create the target directory when it does not exist
 
 	// Viper carries an optional configuration (typically a `.swagger.{yml,json}`
 	// file). Its `layout:` sections are applied as overrides on top of the

--- a/generator/imports.go
+++ b/generator/imports.go
@@ -3,7 +3,10 @@
 
 package generator
 
-import "path"
+import (
+	"fmt"
+	"path"
+)
 
 // importsBuilder produces the default import maps for generated models and
 // operations. It embeds *GenOpts to reach the package layout, target and
@@ -17,8 +20,12 @@ func newImportsBuilder(g *GenOpts) *importsBuilder {
 }
 
 // defaultImports produces a default map for imports with models.
-func (g *importsBuilder) defaultImports() map[string]string {
-	baseImport := g.LanguageOpts.BaseImport(g.Target)
+func (g *importsBuilder) defaultImports() (map[string]string, error) {
+	baseImport, err := g.LanguageOpts.BaseImport(g.Target)
+	if err != nil {
+		return nil, errTarget(g.Target, err)
+	}
+
 	defaultImports := make(map[string]string, sensibleDefaultMapAlloc)
 
 	var modelsAlias, importPath string
@@ -39,7 +46,7 @@ func (g *importsBuilder) defaultImports() map[string]string {
 	alias, _, target := resolvePrincipal(g.Principal)
 	if alias == "" || target == g.ModelPackage || path.Base(target) == modelsAlias {
 		// if principal is specified with the models generation package, do not import any extra package
-		return defaultImports
+		return defaultImports, nil
 	}
 
 	if pth, _ := path.Split(target); pth != "" {
@@ -49,16 +56,25 @@ func (g *importsBuilder) defaultImports() map[string]string {
 		// if principal is specified with a relative path (no "/", e.g. internal.Principal), assume it is located in generated target
 		defaultImports[alias] = path.Join(baseImport, target)
 	}
-	return defaultImports
+
+	return defaultImports, nil
 }
 
 // initImports produces a default map for import with the specified root for operations.
-func (g *importsBuilder) initImports(operationsPackage string) map[string]string {
-	baseImport := g.LanguageOpts.BaseImport(g.Target)
+func (g *importsBuilder) initImports(operationsPackage string) (map[string]string, error) {
+	baseImport, err := g.LanguageOpts.BaseImport(g.Target)
+	if err != nil {
+		return nil, errTarget(g.Target, err)
+	}
 
 	imports := make(map[string]string, sensibleDefaultMapAlloc)
 	imports[g.LanguageOpts.ManglePackageName(operationsPackage, defaultOperationsTarget)] = path.Join(
 		baseImport,
 		g.LanguageOpts.ManglePackagePath(operationsPackage, defaultOperationsTarget))
-	return imports
+
+	return imports, nil
+}
+
+func errTarget(target string, err error) error {
+	return fmt.Errorf("could not determine import path for target %q. All generated source must reside within a single target tree under GOPATH or a module: %w", target, err)
 }

--- a/generator/internal/language/golang.go
+++ b/generator/internal/language/golang.go
@@ -41,7 +41,7 @@ func GolangOpts(extraInitialisms ...string) *Options {
 	opts.dirNameFunc = defaultGoDirnameFunc()
 	opts.ImportsFunc = defaultGoImportsFunc()
 	opts.ArrayInitializerFunc = defaultGoArrayInitializerFunc()
-	opts.BaseImportFunc = defaultGoBaseImportFunc()
+	opts.BaseImportFunc = defaultGoBaseImportErr
 
 	opts.Init()
 
@@ -108,19 +108,6 @@ func defaultGoArrayInitializerFunc() func(any) (string, error) {
 			return "", err
 		}
 		return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(string(b), "}", ",}"), "[", "{"), "]", ",}"), "{,}", "{}"), nil
-	}
-}
-
-func defaultGoBaseImportFunc() MangleFunc {
-	return func(target string) string {
-		base, err := defaultGoBaseImportErr(target)
-		if err != nil {
-			// NOTE: historically this called log.Fatalln. We now panic to avoid
-			// pulling in generator-specific logging, while preserving the "fail hard" semantics.
-			panic(fmt.Sprintf("base import resolution failed: %v", err))
-		}
-
-		return base
 	}
 }
 

--- a/generator/internal/language/options.go
+++ b/generator/internal/language/options.go
@@ -78,7 +78,7 @@ func FormatOptsWithDefault(opts []FormatOption) FormatOpts {
 // Options describes a target language to the code generator.
 type Options struct {
 	ReservedWords        []string
-	BaseImportFunc       MangleFunc                     `json:"-"`
+	BaseImportFunc       func(string) (string, error)   `json:"-"`
 	ImportsFunc          func(map[string]string) string `json:"-"`
 	ArrayInitializerFunc func(any) (string, error)      `json:"-"`
 	FormatOnly           bool
@@ -200,12 +200,12 @@ func (l *Options) ArrayInitializer(data any) (string, error) {
 }
 
 // BaseImport figures out the base path to generate import statements.
-func (l *Options) BaseImport(tgt string) string {
+func (l *Options) BaseImport(tgt string) (string, error) {
 	if l.BaseImportFunc != nil {
 		return l.BaseImportFunc(tgt)
 	}
 
-	return ""
+	return "", nil
 }
 
 // importAlias extracts the last path component from a package import path.

--- a/generator/internal/language/options_test.go
+++ b/generator/internal/language/options_test.go
@@ -12,7 +12,10 @@ import (
 
 func TestOptions_Init(t *testing.T) {
 	opts := &Options{}
-	assert.Empty(t, opts.BaseImport("x"))
+	baseImport, err := opts.BaseImport("x")
+	require.NoError(t, err)
+	assert.Empty(t, baseImport)
+
 	res, err := opts.FormatContent("x", []byte("y"))
 	require.NoError(t, err)
 	assert.Equal(t, []byte("y"), res)
@@ -71,11 +74,15 @@ func TestOptions_BaseImport(t *testing.T) {
 	// nil func: returns ""
 	o := &Options{}
 	o.Init()
-	assert.Empty(t, o.BaseImport("anything"))
+	baseImport, err := o.BaseImport("anything")
+	require.NoError(t, err)
+	assert.Empty(t, baseImport)
 
 	// with custom func: delegates
-	o.BaseImportFunc = func(s string) string { return "custom/" + s }
-	assert.EqualT(t, "custom/target", o.BaseImport("target"))
+	o.BaseImportFunc = func(s string) (string, error) { return "custom/" + s, nil }
+	custom, err := o.BaseImport("target")
+	require.NoError(t, err)
+	assert.EqualT(t, "custom/target", custom)
 }
 
 func TestFormatOptions(t *testing.T) {

--- a/generator/model.go
+++ b/generator/model.go
@@ -382,11 +382,15 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 		// guard against internal dev errors
 		return nil, err
 	}
+	targetImport, err := opts.LanguageOpts.BaseImport(opts.Target)
+	if err != nil {
+		return nil, errTarget(opts.Target, err)
+	}
 
 	return &GenDefinition{
 		GenCommon: GenCommon{
 			Copyright:        opts.Copyright,
-			TargetImportPath: opts.LanguageOpts.BaseImport(opts.Target),
+			TargetImportPath: targetImport,
 		},
 		Package:        modelPkg,
 		CliPackage:     opts.CliPackage,

--- a/generator/moreschemavalidation_test.go
+++ b/generator/moreschemavalidation_test.go
@@ -5,6 +5,7 @@ package generator
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -133,7 +134,7 @@ func (f *modelFixture) AddRun(expandSpec bool) *modelTestRun {
 	opts.ValidateSpec = false
 	opts.Spec = f.SpecFile
 	if err := ensureMachinery(opts); err != nil {
-		panic(err)
+		panic(fmt.Errorf("internal error: options ensureMachinery should not fail in tests: %w", err))
 	}
 
 	// sets gen options (e.g. flatten vs expand) - full flatten is the default setting for this test (NOT the default CLI option!)

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -140,13 +140,20 @@ type operationGenerator struct {
 
 // Generate a single operation.
 func (o *operationGenerator) Generate() error {
-	defaultImports := newImportsBuilder(o.GenOpts).defaultImports()
+	defaultImports, err := newImportsBuilder(o.GenOpts).defaultImports()
+	if err != nil {
+		return err
+	}
 
 	apiPackage := o.GenOpts.LanguageOpts.ManglePackagePath(o.GenOpts.APIPackage, defaultOperationsTarget)
-	imports := newImportsBuilder(o.GenOpts).initImports(
+	imports, err := newImportsBuilder(o.GenOpts).initImports(
 		filepath.Join(o.GenOpts.LanguageOpts.ManglePackagePath(o.GenOpts.ServerPackage, defaultServerTarget), apiPackage),
 	)
-	if err := ensureDedupedImports(defaultImports, imports); err != nil {
+	if err != nil {
+		return err
+	}
+
+	if err = ensureDedupedImports(defaultImports, imports); err != nil {
 		// guard against internal dev errors
 		return err
 	}
@@ -411,11 +418,15 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 			}
 		}
 	}
+	importTarget, err := b.GenOpts.LanguageOpts.BaseImport(b.GenOpts.Target)
+	if err != nil {
+		return GenOperation{}, errTarget(b.GenOpts.Target, err)
+	}
 
 	return GenOperation{
 		GenCommon: GenCommon{
 			Copyright:        b.GenOpts.Copyright,
-			TargetImportPath: b.GenOpts.LanguageOpts.BaseImport(b.GenOpts.Target),
+			TargetImportPath: importTarget,
 		},
 		Package:              b.GenOpts.LanguageOpts.ManglePackageName(b.APIPackage, defaultOperationsTarget),
 		PackageAlias:         b.APIPackageAlias,
@@ -1203,12 +1214,12 @@ func (b *codeGenOpBuilder) cloneSchema(schema *spec.Schema) *spec.Schema {
 	savedSchema := &spec.Schema{}
 	schemaRep, err := json.Marshal(schema)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("internal error: cannot json marshal a schema: %w", err))
 	}
 
 	err = json.Unmarshal(schemaRep, savedSchema)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("internal error: cannot json unmarshal a schema: %w", err))
 	}
 
 	return savedSchema

--- a/generator/operation_test.go
+++ b/generator/operation_test.go
@@ -6,6 +6,7 @@ package generator
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -441,7 +442,7 @@ func opBuildGetOpts(specName string, withFlatten bool, withMinimalFlatten bool) 
 	}
 	opts.Spec = specName
 	if err := ensureMachinery(opts); err != nil {
-		panic("Cannot initialize GenOpts")
+		panic(fmt.Errorf("internal error: options ensureMachinery should not fail in tests: %w", err))
 	}
 	return opts
 }

--- a/generator/prepare.go
+++ b/generator/prepare.go
@@ -6,6 +6,8 @@ package generator
 import (
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -21,8 +23,8 @@ import (
 // It is the single entry point that turns a freshly populated GenOpts into a
 // fully usable one: it validates the inputs, builds the derived machinery
 // (language options, template func map, templates repository), resolves the
-// render plan (sections), normalizes paths and loads any user-provided
-// templates.
+// render plan (sections), normalizes paths, checks the generation target
+// and loads any user-provided templates.
 //
 // Because every input is known by the time Prepare runs, the derived state is
 // built exactly once, in a deterministic order — which removes the historical
@@ -47,6 +49,12 @@ func (g *GenOpts) Prepare() error {
 	}
 
 	if err := g.normalize(); err != nil {
+		return err
+	}
+
+	// the target is checked after the spec has been resolved,
+	// so a run that fails early doesn't leave an empty target tree behind.
+	if err := g.ensureTarget(); err != nil {
 		return err
 	}
 
@@ -103,7 +111,7 @@ func (g *GenOpts) buildMachinery() {
 	g.funcMap = DefaultFuncMap(g.LanguageOpts)
 	g.templates = templatesrepo.NewRepository(g.funcMap)
 	if err := g.templates.LoadDefaults(defaultAssets()); err != nil {
-		fatal(err)
+		fatal(fmt.Errorf("cannot load default assets: %w", err))
 	}
 	g.templates.SetProtectedTemplates(defaultProtectedTemplates())
 
@@ -181,8 +189,16 @@ func (g *GenOpts) resolveSections() error {
 //
 // Remote specs (http/https) are left untouched. Local specs are located on
 // disk and rewritten to an absolute path.
+//
+// It is guarded so the spec is resolved exactly once.
 func (g *GenOpts) normalize() error {
+	if g.specNormalized {
+		return nil
+	}
+
 	if strings.HasPrefix(g.Spec, "http://") || strings.HasPrefix(g.Spec, "https://") {
+		g.specNormalized = true
+
 		return nil
 	}
 
@@ -196,6 +212,65 @@ func (g *GenOpts) normalize() error {
 	if err != nil {
 		return fmt.Errorf("could not locate spec: %s", g.Spec)
 	}
+
+	g.specNormalized = true
+
+	return nil
+}
+
+// ensureTarget checks that the generation target is a directory this process may write to.
+//
+// An empty target means the current directory. A target that does not exist is an error,
+// unless [GenOpts.EnsureTarget] is set: the directory is then created, with its parents.
+//
+// The check is skipped when dumping the template data ([GenOpts.DumpData]),
+// since nothing is written to the target then.
+//
+// It is guarded so the target is checked exactly once.
+func (g *GenOpts) ensureTarget() error {
+	if g.targetEnsured {
+		return nil
+	}
+
+	if g.Target == "" {
+		g.Target = "."
+	}
+
+	if g.DumpData {
+		return nil
+	}
+
+	info, err := os.Stat(g.Target)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) || !g.EnsureTarget {
+			return fmt.Errorf("could not open target dir %q. Make sure it exists or use --ensure-target: %w", g.Target, err)
+		}
+
+		if err = os.MkdirAll(g.Target, readAllDir); err != nil {
+			return fmt.Errorf("could not create target directory %q: %w", g.Target, err)
+		}
+
+		g.targetEnsured = true
+
+		return nil
+	}
+
+	if !info.IsDir() { // Stat resolves symlinks
+		return fmt.Errorf("target %q already exists and is not a directory. The target must be a writable directory", g.Target)
+	}
+
+	// check that this process may write files there
+	probe, err := os.CreateTemp(g.Target, ".probe-")
+	if err != nil {
+		return fmt.Errorf(
+			"target %q is not writeable. Make sure your command has the proper permissions to write in this folder: %w",
+			g.Target, err,
+		)
+	}
+	_ = probe.Close()
+	_ = os.Remove(probe.Name())
+
+	g.targetEnsured = true
 
 	return nil
 }

--- a/generator/prepare_test.go
+++ b/generator/prepare_test.go
@@ -4,7 +4,11 @@
 package generator
 
 import (
+	"errors"
+	"io/fs"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -133,4 +137,130 @@ func TestPrepare_ValidationFailsBeforeMutation(t *testing.T) {
 	// nothing finalized: machinery not built, options not marked prepared
 	assert.FalseT(t, g.prepared)
 	assert.FalseT(t, g.machineryBuilt)
+}
+
+// TestEnsureTarget asserts the pre-flight check on the generation target: the target
+// must be a directory this process may write to, and is only created when asked for.
+func TestEnsureTarget(t *testing.T) {
+	defer discardOutput()()
+
+	t.Run("should accept an existing writable directory", func(t *testing.T) {
+		g := &GenOpts{Target: t.TempDir()}
+
+		require.NoError(t, g.ensureTarget())
+		assert.TrueT(t, g.targetEnsured)
+	})
+
+	t.Run("should leave no probe file behind", func(t *testing.T) {
+		target := t.TempDir()
+		g := &GenOpts{Target: target}
+
+		require.NoError(t, g.ensureTarget())
+
+		entries, err := os.ReadDir(target)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("should default an empty target to the current directory", func(t *testing.T) {
+		// dump-data mode, so the check stops at the normalization: no probe file is
+		// written in the package directory.
+		g := &GenOpts{Target: "", DumpData: true}
+
+		require.NoError(t, g.ensureTarget())
+		assert.EqualT(t, ".", g.Target)
+	})
+
+	t.Run("with a missing target", func(t *testing.T) {
+		t.Run("should fail and point at the flag", func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "missing")
+			g := &GenOpts{Target: target}
+
+			err := g.ensureTarget()
+			require.ErrorContains(t, err, "--ensure-target")
+			assertNoDir(t, target)
+			assert.FalseT(t, g.targetEnsured)
+		})
+
+		t.Run("should create it, with its parents, when EnsureTarget is set", func(t *testing.T) {
+			target := filepath.Join(t.TempDir(), "a", "b", "c")
+			g := &GenOpts{Target: target, EnsureTarget: true}
+
+			require.NoError(t, g.ensureTarget())
+			assert.DirExists(t, target)
+		})
+	})
+
+	t.Run("should fail when the target is not a directory", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "afile")
+		require.NoError(t, os.WriteFile(target, []byte("x"), readAllFile))
+
+		// EnsureTarget doesn't help here: the path exists, it is just not a directory.
+		g := &GenOpts{Target: target, EnsureTarget: true}
+
+		require.ErrorContains(t, g.ensureTarget(), "is not a directory")
+	})
+
+	t.Run("should fail when the target is not writable", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("file modes don't govern write access on windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root writes to a read-only directory")
+		}
+
+		target := filepath.Join(t.TempDir(), "readonly")
+		const readOnlyDir = 0o500
+		require.NoError(t, os.Mkdir(target, readOnlyDir))
+		t.Cleanup(func() {
+			_ = os.Chmod(target, readableDir) // so the temp dir may be cleaned up
+		})
+
+		g := &GenOpts{Target: target}
+
+		require.ErrorContains(t, g.ensureTarget(), "is not writeable")
+	})
+
+	t.Run("should skip the check when dumping data", func(t *testing.T) {
+		// nothing is written to the target in that mode
+		target := filepath.Join(t.TempDir(), "missing")
+		g := &GenOpts{Target: target, DumpData: true}
+
+		require.NoError(t, g.ensureTarget())
+		assertNoDir(t, target)
+	})
+
+	t.Run("should check the target only once", func(t *testing.T) {
+		target := t.TempDir()
+		g := &GenOpts{Target: target}
+		require.NoError(t, g.ensureTarget())
+
+		// the guard holds even though the target is now gone
+		require.NoError(t, os.RemoveAll(target))
+		require.NoError(t, g.ensureTarget())
+	})
+}
+
+// TestPrepare_TargetCheckedAfterSpec asserts that Prepare resolves the spec before it
+// touches the target, so a run that fails early leaves no target tree behind.
+func TestPrepare_TargetCheckedAfterSpec(t *testing.T) {
+	defer discardOutput()()
+
+	target := filepath.Join(t.TempDir(), "target")
+	g := &GenOpts{
+		Spec:         filepath.Join("..", "testdata", "codegen", "nosuchspec.yml"),
+		Target:       target,
+		EnsureTarget: true,
+	}
+
+	require.Error(t, g.Prepare())
+	assertNoDir(t, target)
+}
+
+// assertNoDir asserts that nothing exists at path.
+func assertNoDir(t *testing.T, path string) {
+	t.Helper()
+
+	_, err := os.Stat(path)
+	assert.TrueTf(t, errors.Is(err, fs.ErrNotExist), "expected %q not to exist", path)
 }

--- a/generator/renderer.go
+++ b/generator/renderer.go
@@ -201,7 +201,12 @@ func (g *renderer) write(t *TemplateOpts, data any) error {
 	var writeerr error
 
 	if !t.SkipFormat {
-		baseImport := g.LanguageOpts.BaseImport(g.Target)
+		var baseImport string
+
+		baseImport, err = g.LanguageOpts.BaseImport(g.Target)
+		if err != nil {
+			return errTarget(g.Target, err)
+		}
 
 		formatted, err = g.LanguageOpts.FormatContent(
 			filepath.Join(dir, fname), content,

--- a/generator/shared_test.go
+++ b/generator/shared_test.go
@@ -5,6 +5,7 @@ package generator
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -74,7 +75,7 @@ func opts() *GenOpts {
 	g.IncludeValidator = true
 	g.IncludeModel = true
 	if err := ensureMachinery(g); err != nil {
-		panic(err)
+		panic(fmt.Errorf("internal error: options ensureMachinery should not fail in tests: %w", err))
 	}
 
 	return g
@@ -85,7 +86,7 @@ func testGenOpts() *GenOpts {
 	g.Target = "."
 	g.ExcludeSpec = true
 	if err := ensureMachinery(g); err != nil {
-		panic(err)
+		panic(fmt.Errorf("internal error: options ensureMachinery should not fail in tests: %w", err))
 	}
 
 	return g
@@ -780,7 +781,9 @@ func TestDefaultImports(t *testing.T) {
 			t.Parallel()
 			err := ensureMachinery(fixture.Opts)
 			require.NoError(t, err)
-			imports := newImportsBuilder(fixture.Opts).defaultImports()
+
+			imports, err := newImportsBuilder(fixture.Opts).defaultImports()
+			require.NoError(t, err)
 			require.Equalf(t, fixture.Expected, imports, "unexpected imports generated with fixture %q[%d]", fixture.Title, i)
 		})
 	}

--- a/generator/spec.go
+++ b/generator/spec.go
@@ -294,12 +294,12 @@ func WithAutoXOrder(specPath string) string {
 
 	data, err := loading.LoadFromFileOrHTTP(specPath)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("could not load YAML doc for %q: %w", specPath, err))
 	}
 
 	yamlDoc, err := BytesToYAMLv2Doc(data)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("could not convert YAML doc: %w", err))
 	}
 
 	if defs, ok := lookFor(yamlDoc, "definitions"); ok {
@@ -312,18 +312,19 @@ func WithAutoXOrder(specPath string) string {
 
 	out, err := yamlv2.Marshal(yamlDoc)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("could not marshal yaml doc: %w", err))
 	}
 
 	tmpDir, err := os.MkdirTemp("", "go-swagger-")
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("could not create temporary directory: %w", err))
 	}
 
 	tmpFile := filepath.Join(tmpDir, filepath.Base(specPath))
 	if err := os.WriteFile(tmpFile, out, readableFile); err != nil {
-		panic(err)
+		panic(fmt.Errorf("could not write temporary file %q: %w", tmpFile, err))
 	}
+
 	return tmpFile
 }
 
@@ -338,6 +339,7 @@ func BytesToYAMLv2Doc(data []byte) (any, error) {
 	if err := yamlv2.Unmarshal(data, &document); err != nil {
 		return nil, err
 	}
+
 	return document, nil
 }
 

--- a/generator/support.go
+++ b/generator/support.go
@@ -52,7 +52,17 @@ func GenerateMarkdown(output string, modelNames, operationIDs []string, opts *Ge
 	if err := opts.resolveSections(); err != nil {
 		return err
 	}
-	if opts.Target != "" && opts.Target != "." {
+
+	// the output path is resolved against the target, so the spec and the target are
+	// resolved here rather than left to Prepare. Both steps run exactly once.
+	if err := opts.normalize(); err != nil {
+		return err
+	}
+	if err := opts.ensureTarget(); err != nil {
+		return err
+	}
+
+	if opts.Target != "." {
 		output = filepath.Join(opts.Target, output)
 	}
 	MarkdownSectionOpts(opts, output)
@@ -215,7 +225,11 @@ func (a *appGenerator) GenerateSupport(ap *GenApp) error {
 		app = &ca
 	}
 
-	baseImport := a.GenOpts.LanguageOpts.BaseImport(a.Target)
+	baseImport, err := a.GenOpts.LanguageOpts.BaseImport(a.Target)
+	if err != nil {
+		return errTarget(a.Target, err)
+	}
+
 	serverPath := path.Join(baseImport,
 		a.GenOpts.LanguageOpts.ManglePackagePath(a.ServerPackage, defaultServerTarget))
 
@@ -266,8 +280,14 @@ func (a *appGenerator) makeCodegenApp() (GenApp, error) {
 
 	log.Println("generation target", a.Target)
 
-	baseImport := a.GenOpts.LanguageOpts.BaseImport(a.Target)
-	defaultImports := newImportsBuilder(a.GenOpts).defaultImports()
+	baseImport, err := a.GenOpts.LanguageOpts.BaseImport(a.Target)
+	if err != nil {
+		return GenApp{}, errTarget(a.Target, err)
+	}
+	defaultImports, err := newImportsBuilder(a.GenOpts).defaultImports()
+	if err != nil {
+		return GenApp{}, err
+	}
 
 	imports := make(map[string]string, sensibleDefaultMapAlloc)
 	registerSerializerImports(imports, consumes)

--- a/generator/support_test.go
+++ b/generator/support_test.go
@@ -173,7 +173,8 @@ func TestBaseImport(t *testing.T) {
 				t.Setenv("GOPATH", item.gopath)
 
 				// Test (baseImport always with /)
-				actualpath := opts.LanguageOpts.BaseImport(item.targetpath)
+				actualpath, err := opts.LanguageOpts.BaseImport(item.targetpath)
+				require.NoError(t, err)
 				require.EqualTf(t, item.expectedpath, actualpath, "baseImport(%s): expected %s, actual %s", item.targetpath, item.expectedpath, actualpath)
 			})
 		})
@@ -201,6 +202,29 @@ func TestGenerateMarkdown(t *testing.T) {
 				t.Logf("Code expected did not match in codegenfile %s for expected line %d: %q", output, line, expectedCode[line])
 			}
 		}
+	})
+
+	// the markdown output path is resolved against the target before Prepare runs,
+	// so GenerateMarkdown carries out the target checks itself.
+	t.Run("with an unusable target", func(t *testing.T) {
+		t.Run("should fail on a missing target", func(t *testing.T) {
+			opts := testGenOpts()
+			opts.Spec = "../testdata/enhancements/184/fixture-184.yaml"
+			opts.Target = filepath.Join(t.TempDir(), "missing")
+
+			err := GenerateMarkdown("markdown.md", nil, nil, opts)
+			require.ErrorContains(t, err, "--ensure-target")
+		})
+
+		t.Run("should not create the target when the spec cannot be found", func(t *testing.T) {
+			opts := testGenOpts()
+			opts.Spec = "../testdata/enhancements/184/nosuchfixture.yaml"
+			opts.Target = filepath.Join(t.TempDir(), "missing")
+			opts.EnsureTarget = true
+
+			require.Error(t, GenerateMarkdown("markdown.md", nil, nil, opts))
+			assertNoDir(t, opts.Target)
+		})
 	})
 
 	t.Run("should handle new lines in descriptions", func(t *testing.T) {


### PR DESCRIPTION
go-swagger used to simply recover from a panic when it cannot resolve its target generation directory. Usually this is just because the folder is not created.

* adds a pre-flight check on the existence of a writable target directory
* exits gracefully, without a panic stack trace
* handles other errors preventing the generator from finding a proper base import path for the components it generates
* doc: update CLI usage to --ensure-target flag
* test: added unit tests for the new initialization checks

This addresses the UX part of #1813 and #1680, but _does not_ allow arbitrary location for parts of the generation (as asked by #1813): all generated components must still reside in the same source tree (either within GOPATH, or within a module).

* contributes to #1813
* contributes to #1680