### PR TITLE
fix(generate): accept the swagger spec as a command argument

### DIFF
--- a/cmd/swagger/commands/generate/cli.go
+++ b/cmd/swagger/commands/generate/cli.go
@@ -14,9 +14,14 @@ type Cli struct {
 	CliPackage string `default:"cli" description:"the package to save the cli specific code"                   long:"cli-package"`
 }
 
+// Usage documents the spec argument in the help message.
+func (c Cli) Usage() string {
+	return usageWithSpec("cli")
+}
+
 // Execute runs this command.
-func (c *Cli) Execute(_ []string) error {
-	return createSwagger(c)
+func (c *Cli) Execute(args []string) error {
+	return createSwagger(c, args)
 }
 
 // apply options.

--- a/cmd/swagger/commands/generate/client.go
+++ b/cmd/swagger/commands/generate/client.go
@@ -31,9 +31,14 @@ type Client struct {
 	Name string `description:"the name of the application, defaults to a mangled value of info.title" long:"name" short:"A"`
 }
 
+// Usage documents the spec argument in the help message.
+func (c Client) Usage() string {
+	return usageWithSpec("client")
+}
+
 // Execute runs this command.
-func (c *Client) Execute(_ []string) error {
-	return createSwagger(c)
+func (c *Client) Execute(args []string) error {
+	return createSwagger(c, args)
 }
 
 // apply options.

--- a/cmd/swagger/commands/generate/markdown.go
+++ b/cmd/swagger/commands/generate/markdown.go
@@ -18,9 +18,14 @@ type Markdown struct {
 	Output flags.Filename `default:"markdown.md" description:"the file to write the generated markdown." long:"output" short:""`
 }
 
+// Usage documents the spec argument in the help message.
+func (m Markdown) Usage() string {
+	return usageWithSpec("markdown")
+}
+
 // Execute runs this command.
-func (m *Markdown) Execute(_ []string) error {
-	return createSwagger(m)
+func (m *Markdown) Execute(args []string) error {
+	return createSwagger(m, args)
 }
 
 // apply options.

--- a/cmd/swagger/commands/generate/markdown_test.go
+++ b/cmd/swagger/commands/generate/markdown_test.go
@@ -24,3 +24,35 @@ func TestMarkdown(t *testing.T) {
 	m.Output = flags.Filename("markdown.md")
 	require.NoError(t, m.Execute([]string{}))
 }
+
+func TestMarkdownSpecArgument(t *testing.T) {
+	spec := filepath.Join(testBase(), "testdata", "enhancements", "184", "fixture-184.yaml")
+
+	newCmd := func(t *testing.T) *generate.Markdown {
+		t.Helper()
+
+		m := &generate.Markdown{}
+		_, _ = flags.ParseArgs(m, []string{"--skip-validation"})
+		m.Shared.Target = flags.Filename(t.TempDir())
+		m.Output = flags.Filename("markdown.md")
+
+		return m
+	}
+
+	t.Run("should generate with the spec passed as an argument", func(t *testing.T) {
+		m := newCmd(t)
+		require.NoError(t, m.Execute([]string{spec}))
+		require.FileExists(t, filepath.Join(string(m.Shared.Target), "markdown.md"))
+	})
+
+	t.Run("should not accept the spec twice", func(t *testing.T) {
+		m := newCmd(t)
+		m.Shared.Spec = flags.Filename(spec)
+		require.Error(t, m.Execute([]string{spec}))
+	})
+
+	t.Run("should not accept extra arguments", func(t *testing.T) {
+		m := newCmd(t)
+		require.Error(t, m.Execute([]string{spec, spec}))
+	})
+}

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -55,8 +55,13 @@ type Model struct {
 	AcceptDefinitionsOnly bool     `description:"accepts a partial swagger spec with only the definitions key"                   long:"accept-definitions-only"`
 }
 
+// Usage documents the spec argument in the help message.
+func (m Model) Usage() string {
+	return usageWithSpec("model")
+}
+
 // Execute generates a model file.
-func (m *Model) Execute(_ []string) error {
+func (m *Model) Execute(args []string) error {
 	if m.Shared.DumpData && len(append(m.Name, m.Models.Models...)) > 1 {
 		return errors.New("only 1 model at a time is supported for dumping data")
 	}
@@ -64,7 +69,7 @@ func (m *Model) Execute(_ []string) error {
 	if m.Models.ExistingModels != "" {
 		log.Println("warning: Ignoring existing-models flag when generating models.")
 	}
-	return createSwagger(m)
+	return createSwagger(m, args)
 }
 
 // apply options.

--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -52,13 +52,18 @@ type Operation struct {
 	Name []string `description:"the operations to generate, repeat for multiple (defaults to all). Same as --operations" long:"name" short:"n"`
 }
 
+// Usage documents the spec argument in the help message.
+func (o Operation) Usage() string {
+	return usageWithSpec("operation")
+}
+
 // Execute generates a model file.
-func (o *Operation) Execute(_ []string) error {
+func (o *Operation) Execute(args []string) error {
 	if o.Shared.DumpData && len(append(o.Name, o.Operations.Operations...)) > 1 {
 		return errors.New("only 1 operation at a time is supported for dumping data")
 	}
 
-	return createSwagger(o)
+	return createSwagger(o, args)
 }
 
 // apply options.

--- a/cmd/swagger/commands/generate/server.go
+++ b/cmd/swagger/commands/generate/server.go
@@ -47,9 +47,14 @@ type Server struct {
 	WithContext bool `description:"handlers get a context as first arg (deprecated)" long:"with-context"`
 }
 
+// Usage documents the spec argument in the help message.
+func (s Server) Usage() string {
+	return usageWithSpec("server")
+}
+
 // Execute runs this command.
-func (s *Server) Execute(_ []string) error {
-	return createSwagger(s)
+func (s *Server) Execute(args []string) error {
+	return createSwagger(s, args)
 }
 
 // apply options.

--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -126,6 +126,14 @@ func (w WithShared) getConfigFile() string {
 	return string(w.Shared.ConfigFile)
 }
 
+// usageWithSpec builds the usage line of a code generation command, which takes the spec
+// either with --spec or as its single argument.
+//
+// It replaces the "[<command>-OPTIONS]" placeholder the flags parser renders by default.
+func usageWithSpec(command string) string {
+	return fmt.Sprintf("[%s-OPTIONS] [spec]", command)
+}
+
 type sharedOptionsCommon struct {
 	FlattenCmdOptions
 
@@ -177,7 +185,35 @@ func setCopyright(copyrightFile string) (string, error) {
 	return string(bytebuffer), nil
 }
 
-func createSwagger(s sharedCommand) error {
+// specFromArgs resolves the spec passed as a command line argument.
+//
+// Code generation commands accept the spec either with --spec (-f) or as a single
+// argument, like the validate, expand, flatten, mixin and diff commands do.
+func specFromArgs(opts *generator.GenOpts, args []string) error {
+	switch {
+	case len(args) == 0:
+		return nil
+
+	case len(args) > 1:
+		return fmt.Errorf(
+			"too many arguments: this command takes at most one swagger spec, but got %d: %v",
+			len(args), args,
+		)
+
+	case opts.Spec != "":
+		return fmt.Errorf(
+			"the swagger spec is specified twice: as --spec %q and as the argument %q. Use one or the other",
+			opts.Spec, args[0],
+		)
+
+	default:
+		opts.Spec = args[0]
+
+		return nil
+	}
+}
+
+func createSwagger(s sharedCommand, args []string) error {
 	var (
 		cfg *viper.Viper
 		err error
@@ -197,6 +233,10 @@ func createSwagger(s sharedCommand) error {
 	// finalizes the options in Prepare.
 	opts := generator.NewGenOpts(generator.WithViper(cfg))
 	s.apply(opts)
+
+	if err = specFromArgs(opts, args); err != nil {
+		return err
+	}
 
 	opts.Copyright, err = setCopyright(opts.Copyright)
 	if err != nil {

--- a/cmd/swagger/commands/generate/shared_test.go
+++ b/cmd/swagger/commands/generate/shared_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-openapi/testify/v2/require"
 
 	"github.com/go-openapi/analysis"
+
+	"github.com/go-swagger/go-swagger/generator"
 )
 
 func TestMain(m *testing.M) {
@@ -167,6 +169,37 @@ other: abc
 			}
 		})
 	}
+}
+
+func Test_Shared_SpecFromArgs(t *testing.T) {
+	t.Run("without argument, the spec should be left untouched", func(t *testing.T) {
+		opts := &generator.GenOpts{Spec: "swagger.yaml"}
+		require.NoError(t, specFromArgs(opts, nil))
+		assert.Equal(t, "swagger.yaml", opts.Spec)
+	})
+
+	t.Run("a single argument should be taken as the spec", func(t *testing.T) {
+		opts := &generator.GenOpts{}
+		require.NoError(t, specFromArgs(opts, []string{"swagger.yaml"}))
+		assert.Equal(t, "swagger.yaml", opts.Spec)
+	})
+
+	t.Run("the spec should not be specified twice", func(t *testing.T) {
+		opts := &generator.GenOpts{Spec: "flagged.yaml"}
+		err := specFromArgs(opts, []string{"argued.yaml"})
+		require.Error(t, err)
+		assert.StringContainsT(t, err.Error(), "flagged.yaml")
+		assert.StringContainsT(t, err.Error(), "argued.yaml")
+		assert.Equal(t, "flagged.yaml", opts.Spec)
+	})
+
+	t.Run("extra arguments should be rejected", func(t *testing.T) {
+		opts := &generator.GenOpts{}
+		err := specFromArgs(opts, []string{"swagger.yaml", "extra.yaml"})
+		require.Error(t, err)
+		assert.StringContainsT(t, err.Error(), "too many arguments")
+		assert.Empty(t, opts.Spec)
+	})
 }
 
 func resetDefaultOpts() *analysis.FlattenOpts {

--- a/cmd/swagger/commands/generate/support.go
+++ b/cmd/swagger/commands/generate/support.go
@@ -21,9 +21,14 @@ type Support struct {
 	Name string `description:"the name of the application, defaults to a mangled value of info.title" long:"name" short:"A"`
 }
 
+// Usage documents the spec argument in the help message.
+func (s Support) Usage() string {
+	return usageWithSpec("support")
+}
+
 // Execute generates the supporting files file.
-func (s *Support) Execute(_ []string) error {
-	return createSwagger(s)
+func (s *Support) Execute(args []string) error {
+	return createSwagger(s, args)
 }
 
 // apply options.

--- a/docs/generate/cli.md
+++ b/docs/generate/cli.md
@@ -15,7 +15,7 @@ This toolkit can generate a CLI to interact with your server
 ### CLI usage
 ```
 Usage:
-  swagger [OPTIONS] generate cli [cli-OPTIONS]
+  swagger [OPTIONS] generate cli [cli-OPTIONS] [spec]
 
 generate a command line client tool from the swagger spec
 

--- a/docs/generate/client.md
+++ b/docs/generate/client.md
@@ -109,7 +109,7 @@ func main() {
 
 ```
 Usage:
-  swagger [OPTIONS] generate client [client-OPTIONS]
+  swagger [OPTIONS] generate client [client-OPTIONS] [spec]
 
 generate all the files for a client library
 

--- a/docs/generate/model.md
+++ b/docs/generate/model.md
@@ -9,7 +9,7 @@ weight: 40
 
 ```
 Usage:
-  swagger [OPTIONS] generate model [model-OPTIONS]
+  swagger [OPTIONS] generate model [model-OPTIONS] [spec]
 
 generate one or more models from the swagger spec
 

--- a/docs/generate/server.md
+++ b/docs/generate/server.md
@@ -21,7 +21,7 @@ You can provide your own router implementation should you so desire it's abstrac
 
 ```
 Usage:
-  swagger [OPTIONS] generate server [server-OPTIONS]
+  swagger [OPTIONS] generate server [server-OPTIONS] [spec]
 
 generate all the files for a server application
 

--- a/docs/usage/generate.md
+++ b/docs/usage/generate.md
@@ -36,6 +36,21 @@ Available commands:
   support    generate supporting files like the main function and the api builder
 ```
 
+### Specifying the spec
+
+Every generation command but `spec` takes the swagger document either with the `--spec` (`-f`) flag or as its
+single argument, like `validate`, `expand`, `flatten`, `mixin` and `diff` do:
+
+```sh
+swagger generate markdown ./api/swagger.yml
+swagger generate markdown --spec ./api/swagger.yml
+```
+
+Specifying it both ways at once, or passing more than one argument, is an error.
+When neither is given, `swagger.json`, `swagger.yml` and `swagger.yaml` are looked up in the current directory.
+
+The `spec` command is the exception: it generates a spec _from_ Go source, so its arguments are the packages to scan.
+
 For code generation targets (`cli`, `client`, `model`, `operation`, `server`, `support`), read more [here](../generate/).
 
 For spec generation targets (`spec`), read more [there](../generate-spec/).

--- a/docs/usage/markdown.md
+++ b/docs/usage/markdown.md
@@ -24,7 +24,7 @@ Known limitations:
 
 ```
 Usage:
-  swagger [OPTIONS] generate markdown [markdown-OPTIONS]
+  swagger [OPTIONS] generate markdown [markdown-OPTIONS] [spec]
 
 generate a markdown representation from the swagger spec
 

--- a/generator/spec.go
+++ b/generator/spec.go
@@ -213,9 +213,12 @@ func (g *specAnalyzer) securityOptions() []loading.Option {
 	return loadingOptions
 }
 
+// defaultSpecNames are the spec files looked up in the current directory when none is specified.
+var defaultSpecNames = []string{"swagger.json", "swagger.yml", "swagger.yaml"}
+
 // findSwaggerSpec fetches a default swagger spec if none is provided.
 func findSwaggerSpec(nm string) (string, error) {
-	specs := []string{"swagger.json", "swagger.yml", "swagger.yaml"}
+	specs := defaultSpecNames
 	if nm != "" {
 		specs = []string{nm}
 	}
@@ -235,9 +238,27 @@ func findSwaggerSpec(nm string) (string, error) {
 		break
 	}
 	if name == "" {
-		return "", errors.New("couldn't find a swagger spec")
+		return "", errSpecNotFound(nm)
 	}
 	return name, nil
+}
+
+// errSpecNotFound tells the user which spec could not be found: the one they named,
+// or the ones looked up by default in the current directory.
+func errSpecNotFound(nm string) error {
+	if nm != "" {
+		return fmt.Errorf("could not find the swagger spec %q", nm)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "the current directory"
+	}
+
+	return fmt.Errorf(
+		"could not find a swagger spec: none of %s in %s. Specify the spec with --spec (-f) or as an argument",
+		strings.Join(defaultSpecNames, ", "), cwd,
+	)
 }
 
 // WithAutoXOrder amends the spec to specify property order as they appear

--- a/generator/spec_test.go
+++ b/generator/spec_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-openapi/testify/v2/assert"
 	"github.com/go-openapi/testify/v2/require"
 
 	"github.com/go-openapi/analysis"
@@ -79,6 +80,23 @@ func TestSpec_FindSwaggerSpec(t *testing.T) {
 	require.Error(t, keepErr(findSwaggerSpec("nowhere")))
 	require.Error(t, keepErr(findSwaggerSpec(filepath.Join("..", "testdata"))))
 	require.NoError(t, keepErr(findSwaggerSpec(filepath.Join("..", "testdata", "codegen", "shipyard.yml"))))
+
+	t.Run("a spec that is not found should be named", func(t *testing.T) {
+		_, err := findSwaggerSpec("nowhere")
+		require.Error(t, err)
+		assert.StringContainsT(t, err.Error(), `"nowhere"`)
+	})
+
+	t.Run("a failed lookup should tell where it looked", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		_, err := findSwaggerSpec("")
+		require.Error(t, err)
+		for _, name := range defaultSpecNames {
+			assert.StringContainsT(t, err.Error(), name)
+		}
+		assert.StringContainsT(t, err.Error(), "--spec")
+	})
 }
 
 func TestSpec_Issue1621(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-openapi/codescan v0.36.3
 	github.com/go-openapi/errors v0.22.8
 	github.com/go-openapi/inflect v1.0.0
-	github.com/go-openapi/loads v0.25.0
+	github.com/go-openapi/loads v0.25.1
 	github.com/go-openapi/runtime v0.33.0
 	github.com/go-openapi/runtime/server-middleware v0.33.0
 	github.com/go-openapi/spec v0.22.9

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/jsonreference v1.0.0 h1:jlmTr6torcd1YgDQvSfNmRtKzYDO4FGBkrAdlAVWnpY=
 github.com/go-openapi/jsonreference v1.0.0/go.mod h1:jtwdyGbJk0Xhe5Y+rwtglQP6Sb1WZST4rT32LWB+sv0=
-github.com/go-openapi/loads v0.25.0 h1:74Bc2snfaVlsHzwdQj/3gsA9XJz3daXTJVs+4ZaK7jI=
-github.com/go-openapi/loads v0.25.0/go.mod h1:JFBw4SIB9+PTIFHDfcXuSSy5h6aWzjtUCrPYyx3qWU8=
+github.com/go-openapi/loads v0.25.1 h1:toKQdIDLxlqfKLLGUUmUsiTd5/X0Chzvde9EGYQP/Ac=
+github.com/go-openapi/loads v0.25.1/go.mod h1:33Hen4tsKXHL45TyYojvfD5fZUFN4O1y4r/XhsRW2zc=
 github.com/go-openapi/runtime v0.33.0 h1:Dd3Oj2ig+WH8ckK95l0Wn2V8a4bH/UqWPRZVT0vc8yU=
 github.com/go-openapi/runtime v0.33.0/go.mod h1:+rsupH3+TFKqmFysqkmgBOTxpVJV8eV+j9myvvea2Xw=
 github.com/go-openapi/runtime/server-middleware v0.33.0 h1:ZFUNyaa2eUs9DhLd6MTe/QRsuxeYn4Lq0C8iAoY13XE=


### PR DESCRIPTION
Every generation command but "spec" now takes the swagger document either with --spec (-f) or as its single argument, the way validate, expand, flatten, mixin and diff already do. Giving it both ways at once, or passing more than one argument, is an error naming the offending values.

The argument used to be collected by the flags parser and ignored, so "swagger generate markdown ./api/swagger.yml" silently fell back to looking up swagger.{json,yml,yaml} in the current directory, and failed there. "swagger generate spec" is unaffected: its arguments are the packages to scan.

That failure is now explicit: the lookup quotes the file it could not open, or lists the names it tried, the directory it searched and how to pass a spec.

go-openapi/loads moves to v0.25.1, so a spec that cannot be loaded reports its cause once, on a single line, instead of repeating the package sentinel for every link of the loader chain.