### PR TITLE
fix(cli): advertise only the options each command actually uses

### DIFF
--- a/cmd/swagger/commands/expand.go
+++ b/cmd/swagger/commands/expand.go
@@ -30,6 +30,13 @@ type ExpandSpec struct {
 	Format  string         `choice:"yaml"                                                                          choice:"json"  default:"json" description:"the format for the spec document" long:"format"`
 }
 
+// Usage documents the spec argument in the help message.
+//
+// It replaces the "[expand-OPTIONS]" placeholder the flags parser renders by default.
+func (c ExpandSpec) Usage() string {
+	return "[expand-OPTIONS] {spec}"
+}
+
 // Execute expands the spec.
 func (c *ExpandSpec) Execute(args []string) error {
 	if len(args) != 1 {

--- a/cmd/swagger/commands/flatten.go
+++ b/cmd/swagger/commands/flatten.go
@@ -25,6 +25,13 @@ type FlattenSpec struct {
 	Format  string         `choice:"yaml"                                                                          choice:"json"  default:"json" description:"the format for the spec document" long:"format"`
 }
 
+// Usage documents the spec argument in the help message.
+//
+// It replaces the "[flatten-OPTIONS]" placeholder the flags parser renders by default.
+func (c FlattenSpec) Usage() string {
+	return "[flatten-OPTIONS] {spec}"
+}
+
 // Execute flattens the spec.
 func (c *FlattenSpec) Execute(args []string) error {
 	if len(args) != 1 {

--- a/cmd/swagger/commands/flatten_test.go
+++ b/cmd/swagger/commands/flatten_test.go
@@ -78,6 +78,36 @@ func TestCmd_FlattenKeepNames_Issue2334(t *testing.T) {
 	require.StringContainsT(t, spec, "Baz:")
 }
 
+// TestCmd_FlattenFlags asserts that the flatten command does not offer --with-custom-formatter:
+// it selects a go import processor, and this command writes a spec.
+func TestCmd_FlattenFlags(t *testing.T) {
+	_, err := flags.ParseArgs(&FlattenSpec{}, []string{"--with-flatten=full"})
+	require.NoError(t, err)
+
+	_, err = flags.ParseArgs(&FlattenSpec{}, []string{"--with-custom-formatter"})
+	require.Error(t, err)
+}
+
+// TestCmd_SpecArgumentUsage asserts that the commands taking their spec as an argument say so in
+// their usage line, instead of leaving the bare "[<command>-OPTIONS]" placeholder.
+func TestCmd_SpecArgumentUsage(t *testing.T) {
+	for _, toPin := range []struct {
+		name     string
+		usager   interface{ Usage() string }
+		expected string
+	}{
+		{name: "flatten", usager: FlattenSpec{}, expected: "[flatten-OPTIONS] {spec}"},
+		{name: "expand", usager: ExpandSpec{}, expected: "[expand-OPTIONS] {spec}"},
+		{name: "validate", usager: ValidateSpec{}, expected: "[validate-OPTIONS] {spec}"},
+		{name: "mixin", usager: MixinSpec{}, expected: "[mixin-OPTIONS] {primary spec} {mixin spec}..."},
+	} {
+		tc := toPin
+		t.Run(tc.name, func(t *testing.T) {
+			assert.EqualT(t, tc.expected, tc.usager.Usage())
+		})
+	}
+}
+
 func testValidRefs(t *testing.T, v executable) {
 	t.Helper()
 

--- a/cmd/swagger/commands/generate/markdown.go
+++ b/cmd/swagger/commands/generate/markdown.go
@@ -10,10 +10,14 @@ import (
 )
 
 // Markdown generates a markdown representation of the spec.
+//
+// This command documents the API as it is generated, but generates no go code: it only exposes
+// the options that bear on the markdown it produces. The options that shape go source, such as
+// --struct-tags or --strict-responders, are left out.
 type Markdown struct {
-	WithShared
-	WithModels
-	WithOperations
+	Shared     markdownSharedOptions  `group:"Options for reading the spec and writing the documentation"`
+	Models     modelOptionsCommon     `group:"Options for selecting the documented models"`
+	Operations operationOptionsCommon `group:"Options for selecting the documented operations"`
 
 	Output flags.Filename `default:"markdown.md" description:"the file to write the generated markdown." long:"output" short:""`
 }
@@ -26,6 +30,10 @@ func (m Markdown) Usage() string {
 // Execute runs this command.
 func (m *Markdown) Execute(args []string) error {
 	return createSwagger(m, args)
+}
+
+func (m Markdown) getConfigFile() string {
+	return string(m.Shared.ConfigFile)
 }
 
 // apply options.

--- a/cmd/swagger/commands/generate/markdown_test.go
+++ b/cmd/swagger/commands/generate/markdown_test.go
@@ -4,6 +4,8 @@
 package generate_test
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -55,4 +57,91 @@ func TestMarkdownSpecArgument(t *testing.T) {
 		m := newCmd(t)
 		require.Error(t, m.Execute([]string{spec, spec}))
 	})
+}
+
+// TestMarkdownFlags asserts the flag set of the markdown command: it exposes the options that
+// bear on the generated document, and none of those that only shape generated go code.
+func TestMarkdownFlags(t *testing.T) {
+	t.Run("should expose the options that alter the generated markdown", func(t *testing.T) {
+		for _, arg := range []string{
+			"--spec=swagger.yaml", "--skip-validation", "--with-expand", "--with-flatten=full",
+			"--restricted", "--rooted=.",
+			"--output=doc.md", "--target=.", "--ensure-target",
+			"--template-dir=.", "--config-file=cfg.yaml", "--allow-template-override",
+			"--additional-initialism=ABC", "--dump-data",
+			"--model=Pet", "--keep-spec-order", "--all-definitions",
+			"--operation=addPet", "--tags=pet", "--skip-tag-packages",
+		} {
+			_, err := flags.ParseArgs(&generate.Markdown{}, []string{arg})
+			require.NoErrorf(t, err, "expected the markdown command to accept %q", arg)
+		}
+	})
+
+	t.Run("should not expose the options that only shape generated go code", func(t *testing.T) {
+		for _, arg := range []string{
+			"--copyright-file=LICENSE", "--template=stratoscale", "--strict-responders",
+			"--return-errors", "--with-custom-formatter",
+			"--model-package=models", "--existing-models=github.com/foo/bar",
+			"--strict-additional-properties", "--struct-tags=yaml", "--rooted-error-path",
+			"--with-stringer", "--no-default-omit-empty",
+			"--api-package=operations", "--with-enum-ci",
+		} {
+			_, err := flags.ParseArgs(&generate.Markdown{}, []string{arg})
+			require.Errorf(t, err, "expected the markdown command to reject %q", arg)
+		}
+	})
+
+	t.Run("should keep the full flag set on the code generation commands", func(t *testing.T) {
+		for _, arg := range []string{
+			"--copyright-file=LICENSE", "--strict-responders", "--return-errors",
+			"--with-custom-formatter", "--struct-tags=yaml", "--with-stringer", "--with-enum-ci",
+			"--model-package=models", "-m=models", "--api-package=operations", "-a=operations",
+		} {
+			_, err := flags.ParseArgs(&generate.Server{}, []string{arg})
+			require.NoErrorf(t, err, "expected the server command to accept %q", arg)
+		}
+	})
+}
+
+func TestMarkdownDumpData(t *testing.T) {
+	m := &generate.Markdown{}
+	_, _ = flags.ParseArgs(m, []string{"--skip-validation"})
+	m.Shared.Spec = flags.Filename(filepath.Join(testBase(), "testdata", "enhancements", "184", "fixture-184.yaml"))
+	m.Shared.Target = flags.Filename(t.TempDir())
+	m.Shared.DumpData = true
+	m.Output = flags.Filename("markdown.md")
+
+	// the dump is larger than a pipe buffer, so it is captured through a file rather than
+	// with cmdtest.CatchStdOut.
+	dump := filepath.Join(t.TempDir(), "dump.json")
+	dumped := captureStdOutToFile(t, dump, func() error { return m.Execute([]string{}) })
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(dumped, &data))
+	require.Contains(t, data, "Models")
+
+	_, err := os.Stat(filepath.Join(string(m.Shared.Target), "markdown.md"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// captureStdOutToFile redirects the standard output to a file while runnable executes,
+// and returns what was written.
+func captureStdOutToFile(t *testing.T, name string, runnable func() error) []byte {
+	t.Helper()
+
+	fakeStdout, err := os.Create(name)
+	require.NoError(t, err)
+
+	realStdout := os.Stdout
+	os.Stdout = fakeStdout
+	runErr := runnable()
+	os.Stdout = realStdout
+
+	require.NoError(t, fakeStdout.Close())
+	require.NoError(t, runErr)
+
+	captured, err := os.ReadFile(name)
+	require.NoError(t, err)
+
+	return captured
 }

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -10,30 +10,51 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
-type modelOptions struct {
-	ModelPackage               string   `default:"models"                                                                                                           description:"the package to save the models" long:"model-package"   short:"m"`
-	Models                     []string `description:"specify a model to include in generation, repeat for multiple (defaults to all)"                              long:"model"                                 short:"M"`
+// modelOptionsCommon selects the models to render and the order they are rendered in.
+//
+// These options bear on any rendering of the models, go code or not.
+type modelOptionsCommon struct {
+	Models         []string `description:"specify a model to include in generation, repeat for multiple (defaults to all)" long:"model"           short:"M"`
+	KeepSpecOrder  bool     `description:"keep schema properties order identical to spec file"                             long:"keep-spec-order"`
+	AllDefinitions bool     `description:"generate all model definitions regardless of usage in operations"                hidden:"deprecated"    long:"all-definitions"`
+}
+
+func (mo modelOptionsCommon) apply(opts *generator.GenOpts) {
+	opts.Models = mo.Models
+	opts.PropertiesSpecOrder = mo.KeepSpecOrder
+	opts.IgnoreOperations = mo.AllDefinitions
+}
+
+// modelCodegenOptions only bear on the go code generated for models, starting with the
+// package this code is written to.
+type modelCodegenOptions struct {
+	ModelPackage               string   `default:"models"                                                                                                           description:"the package to save the models" long:"model-package" short:"m"`
 	ExistingModels             string   `description:"use pre-generated models e.g. github.com/foobar/model"                                                        long:"existing-models"`
 	StrictAdditionalProperties bool     `description:"disallow extra properties when additionalProperties is set to false"                                          long:"strict-additional-properties"`
-	KeepSpecOrder              bool     `description:"keep schema properties order identical to spec file"                                                          long:"keep-spec-order"`
-	AllDefinitions             bool     `description:"generate all model definitions regardless of usage in operations"                                             hidden:"deprecated"                          long:"all-definitions"`
 	StructTags                 []string `description:"the struct tags to generate, repeat for multiple (defaults to json)"                                          long:"struct-tags"`
 	RootedErrorPath            bool     `description:"extends validation errors with the type name instead of an empty path, in the case of arrays and maps"        long:"rooted-error-path"`
 	WithStringer               bool     `description:"generate a fmt.Stringer String() method on models, rendering field values as JSON (see issue #872)"           long:"with-stringer"`
 	NoDefaultOmitEmpty         bool     `description:"do not default to omitempty struct tags unless x-omitempty is explicitly set on a property (see issue #2386)" long:"no-default-omit-empty"`
 }
 
-func (mo modelOptions) apply(opts *generator.GenOpts) {
+func (mo modelCodegenOptions) apply(opts *generator.GenOpts) {
 	opts.ModelPackage = mo.ModelPackage
-	opts.Models = mo.Models
 	opts.ExistingModels = mo.ExistingModels
 	opts.StrictAdditionalProperties = mo.StrictAdditionalProperties
-	opts.PropertiesSpecOrder = mo.KeepSpecOrder
-	opts.IgnoreOperations = mo.AllDefinitions
 	opts.StructTags = mo.StructTags
 	opts.WantsRootedErrorPath = mo.RootedErrorPath
 	opts.WantsStringer = mo.WithStringer
 	opts.NoDefaultOmitEmpty = mo.NoDefaultOmitEmpty
+}
+
+type modelOptions struct {
+	modelOptionsCommon
+	modelCodegenOptions
+}
+
+func (mo modelOptions) apply(opts *generator.GenOpts) {
+	mo.modelOptionsCommon.apply(opts)
+	mo.modelCodegenOptions.apply(opts)
 }
 
 // WithModels adds the model options group.

--- a/cmd/swagger/commands/generate/operation.go
+++ b/cmd/swagger/commands/generate/operation.go
@@ -9,22 +9,43 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
-type operationOptions struct {
-	Operations []string `description:"specify an operation to include, repeat for multiple (defaults to all)" long:"operation"                                 short:"O"`
-	Tags       []string `description:"the tags to include, if not specified defaults to all"                  group:"operations"                               long:"tags"`
-	APIPackage string   `default:"operations"                                                                 description:"the package to save the operations" long:"api-package" short:"a"`
-	WithEnumCI bool     `description:"allow case-insensitive enumerations"                                    long:"with-enum-ci"`
+// operationOptionsCommon selects the operations to render and how they are grouped.
+//
+// These options bear on any rendering of the operations, go code or not.
+type operationOptionsCommon struct {
+	Operations []string `description:"specify an operation to include, repeat for multiple (defaults to all)" long:"operation"   short:"O"`
+	Tags       []string `description:"the tags to include, if not specified defaults to all"                  group:"operations" long:"tags"`
 
 	// tags handling
 	SkipTagPackages bool `description:"skips the generation of tag-based operation packages, resulting in a flat generation" long:"skip-tag-packages"`
 }
 
-func (oo operationOptions) apply(opts *generator.GenOpts) {
+func (oo operationOptionsCommon) apply(opts *generator.GenOpts) {
 	opts.Operations = oo.Operations
 	opts.Tags = oo.Tags
+	opts.SkipTagPackages = oo.SkipTagPackages
+}
+
+// operationCodegenOptions only bear on the go code generated for operations, starting with
+// the package this code is written to.
+type operationCodegenOptions struct {
+	APIPackage string `default:"operations"                              description:"the package to save the operations" long:"api-package" short:"a"`
+	WithEnumCI bool   `description:"allow case-insensitive enumerations" long:"with-enum-ci"`
+}
+
+func (oo operationCodegenOptions) apply(opts *generator.GenOpts) {
 	opts.APIPackage = oo.APIPackage
 	opts.AllowEnumCI = oo.WithEnumCI
-	opts.SkipTagPackages = oo.SkipTagPackages
+}
+
+type operationOptions struct {
+	operationOptionsCommon
+	operationCodegenOptions
+}
+
+func (oo operationOptions) apply(opts *generator.GenOpts) {
+	oo.operationOptionsCommon.apply(opts)
+	oo.operationCodegenOptions.apply(opts)
 }
 
 // WithOperations adds the operations options group.

--- a/cmd/swagger/commands/generate/shared.go
+++ b/cmd/swagger/commands/generate/shared.go
@@ -28,9 +28,8 @@ const (
 
 // FlattenCmdOptions determines options to the flatten spec preprocessing.
 type FlattenCmdOptions struct {
-	WithExpand          bool     `description:"expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)" group:"shared" long:"with-expand"`
-	WithFlatten         []string `choice:"minimal"                                                                                  choice:"full"  choice:"expand"              choice:"verbose" choice:"noverbose" choice:"remove-unused" choice:"keep-names" default:"minimal" default:"verbose" description:"flattens all $ref's in spec prior to generation" group:"shared" long:"with-flatten"`
-	WithCustomFormatter bool     `description:"use faster custom contributed go import processing instead of the standard one"      group:"shared" long:"with-custom-formatter"`
+	WithExpand  bool     `description:"expands all $ref's in the spec (shorthand to --with-flatten=expand)" group:"shared" long:"with-expand"`
+	WithFlatten []string `choice:"minimal"                                                                  choice:"full"  choice:"expand"    choice:"verbose" choice:"noverbose" choice:"remove-unused" choice:"keep-names" default:"minimal" default:"verbose" description:"flattens all $ref's in the spec" group:"shared" long:"with-flatten"`
 }
 
 // SetFlattenOptions builds flatten options from command line args.
@@ -134,43 +133,95 @@ func usageWithSpec(command string) string {
 	return fmt.Sprintf("[%s-OPTIONS] [spec]", command)
 }
 
-type sharedOptionsCommon struct {
+// specOptions determine how the swagger spec is located, loaded and preprocessed.
+//
+// They apply to every command that generates something out of a spec, whether it is go code or not.
+type specOptions struct {
 	FlattenCmdOptions
 
-	Spec                  flags.Filename `description:"the spec file to use (default swagger.{json,yml,yaml})"                             group:"shared"                                            long:"spec"                    short:"f"`
-	Target                flags.Filename `default:"./"                                                                                     description:"the base directory for generating the files" group:"shared"                 long:"target"   short:"t"`
-	Template              string         `choice:"stratoscale"                                                                             description:"load contributed templates"                  group:"shared"                 long:"template"`
+	Spec           flags.Filename `description:"the spec file to use (default swagger.{json,yml,yaml})" group:"shared" long:"spec"            short:"f"`
+	SkipValidation bool           `description:"skips validation of spec prior to generation"           group:"shared" long:"skip-validation"`
+	Restricted     bool           `description:"Use restricted http client for remote $ref"             group:"shared" long:"restricted"`
+	Rooted         string         `description:"Local $ref resolution contained relative to root FS"    group:"shared" long:"rooted"`
+}
+
+func (s specOptions) apply(opts *generator.GenOpts) {
+	opts.Spec = string(s.Spec)
+	opts.ValidateSpec = !s.SkipValidation
+	opts.FlattenOpts = s.SetFlattenOptions(opts.FlattenOpts)
+	opts.Restricted = s.Restricted
+	opts.Rooted = s.Rooted
+}
+
+// outputOptions determine where the generated artifacts are written and which templates render them.
+//
+// They apply to every command that generates something out of a spec, whether it is go code or not.
+type outputOptions struct {
+	Target                flags.Filename `default:"./"                                                                                     description:"the base directory for generating the files" group:"shared"                 long:"target" short:"t"`
 	TemplateDir           flags.Filename `description:"alternative template override directory"                                            group:"shared"                                            long:"template-dir"            short:"T"`
 	ConfigFile            flags.Filename `description:"configuration file to use for overriding template options"                          group:"shared"                                            long:"config-file"             short:"C"`
-	CopyrightFile         flags.Filename `description:"copyright file used to add copyright header"                                        group:"shared"                                            long:"copyright-file"          short:"r"`
 	AdditionalInitialisms []string       `description:"consecutive capitals that should be considered intialisms"                          group:"shared"                                            long:"additional-initialism"`
 	AllowTemplateOverride bool           `description:"allows overriding protected templates"                                              group:"shared"                                            long:"allow-template-override"`
-	SkipValidation        bool           `description:"skips validation of spec prior to generation"                                       group:"shared"                                            long:"skip-validation"`
 	DumpData              bool           `description:"when present dumps the json for the template generator instead of generating files" group:"shared"                                            long:"dump-data"`
-	StrictResponders      bool           `description:"Use strict type for the handler return value"                                       long:"strict-responders"`
-	ReturnErrors          bool           `description:"handlers explicitly return an error as the second value"                            group:"shared"                                            long:"return-errors"           short:"e"`
-	Restricted            bool           `description:"Use restricted http client for remote $ref"                                         group:"shared"                                            long:"restricted"`
-	Rooted                string         `description:"Local $ref resolution contained relative to root FS"                                group:"shared"                                            long:"rooted"`
 	EnsureTarget          bool           `description:"Create the target directory if it does not already exist"                           group:"shared"                                            long:"ensure-target"`
 }
 
-func (s sharedOptionsCommon) apply(opts *generator.GenOpts) {
-	opts.Spec = string(s.Spec)
-	opts.Target = string(s.Target)
-	opts.Template = s.Template
-	opts.TemplateDir = string(s.TemplateDir)
-	opts.AllowTemplateOverride = s.AllowTemplateOverride
-	opts.ValidateSpec = !s.SkipValidation
-	opts.DumpData = s.DumpData
-	opts.FlattenOpts = s.SetFlattenOptions(opts.FlattenOpts)
-	opts.Copyright = string(s.CopyrightFile)
-	opts.StrictResponders = s.StrictResponders
-	opts.ReturnErrors = s.ReturnErrors
-	opts.WithCustomFormatter = s.WithCustomFormatter
-	opts.WithExtraInitialisms = s.AdditionalInitialisms
-	opts.Restricted = s.Restricted
-	opts.Rooted = s.Rooted
-	opts.EnsureTarget = s.EnsureTarget
+func (o outputOptions) apply(opts *generator.GenOpts) {
+	opts.Target = string(o.Target)
+	opts.TemplateDir = string(o.TemplateDir)
+	opts.AllowTemplateOverride = o.AllowTemplateOverride
+	opts.DumpData = o.DumpData
+	opts.WithExtraInitialisms = o.AdditionalInitialisms
+	opts.EnsureTarget = o.EnsureTarget
+}
+
+// goCodegenOptions only bear on the go code that is generated.
+//
+// Commands that do not produce go source, such as "generate markdown", do not expose them.
+type goCodegenOptions struct {
+	Template            string         `choice:"stratoscale"                                                                         description:"load contributed templates" group:"shared"               long:"template"`
+	CopyrightFile       flags.Filename `description:"copyright file used to add copyright header"                                    group:"shared"                           long:"copyright-file"        short:"r"`
+	StrictResponders    bool           `description:"Use strict type for the handler return value"                                   long:"strict-responders"`
+	ReturnErrors        bool           `description:"handlers explicitly return an error as the second value"                        group:"shared"                           long:"return-errors"         short:"e"`
+	WithCustomFormatter bool           `description:"use faster custom contributed go import processing instead of the standard one" group:"shared"                           long:"with-custom-formatter"`
+}
+
+func (g goCodegenOptions) apply(opts *generator.GenOpts) {
+	opts.Template = g.Template
+	opts.Copyright = string(g.CopyrightFile)
+	opts.StrictResponders = g.StrictResponders
+	opts.ReturnErrors = g.ReturnErrors
+	opts.WithCustomFormatter = g.WithCustomFormatter
+}
+
+// sharedOptions are the options common to all code generation commands.
+type sharedOptions struct {
+	specOptions
+	outputOptions
+	goCodegenOptions
+	pluginOptions
+}
+
+func (s sharedOptions) apply(opts *generator.GenOpts) {
+	s.specOptions.apply(opts)
+	s.outputOptions.apply(opts)
+	s.goCodegenOptions.apply(opts)
+	s.pluginOptions.apply(opts)
+}
+
+// markdownSharedOptions are the shared options that bear on the generated markdown.
+//
+// The markdown command generates no go code, so it leaves out [goCodegenOptions].
+type markdownSharedOptions struct {
+	specOptions
+	outputOptions
+	pluginOptions
+}
+
+func (s markdownSharedOptions) apply(opts *generator.GenOpts) {
+	s.specOptions.apply(opts)
+	s.outputOptions.apply(opts)
+	s.pluginOptions.apply(opts)
 }
 
 func setCopyright(copyrightFile string) (string, error) {

--- a/cmd/swagger/commands/generate/sharedopts_nonwin.go
+++ b/cmd/swagger/commands/generate/sharedopts_nonwin.go
@@ -11,14 +11,12 @@ import (
 	"github.com/go-swagger/go-swagger/generator"
 )
 
-type sharedOptions struct {
-	sharedOptionsCommon
-
-	// TemplatePlugin option is not available on windows, since it relies on go plugins.
+// pluginOptions exposes the template plugin, which relies on go plugins and is therefore
+// not available on windows.
+type pluginOptions struct {
 	TemplatePlugin flags.Filename `description:"the template plugin to use" group:"shared" long:"template-plugin" short:"p"`
 }
 
-func (s sharedOptions) apply(opts *generator.GenOpts) {
-	opts.TemplatePlugin = string(s.TemplatePlugin)
-	s.sharedOptionsCommon.apply(opts)
+func (p pluginOptions) apply(opts *generator.GenOpts) {
+	opts.TemplatePlugin = string(p.TemplatePlugin)
 }

--- a/cmd/swagger/commands/generate/sharedopts_win.go
+++ b/cmd/swagger/commands/generate/sharedopts_win.go
@@ -6,6 +6,10 @@
 
 package generate
 
-type sharedOptions struct {
-	sharedOptionsCommon
-}
+import "github.com/go-swagger/go-swagger/generator"
+
+// pluginOptions exposes no option on windows: the template plugin relies on go plugins,
+// which windows does not support.
+type pluginOptions struct{}
+
+func (p pluginOptions) apply(_ *generator.GenOpts) {}

--- a/cmd/swagger/commands/mixin.go
+++ b/cmd/swagger/commands/mixin.go
@@ -39,6 +39,13 @@ type MixinSpec struct {
 	IgnoreConflicts        bool           `description:"Ignore conflict"                                                                                            long:"ignore-conflicts"`
 }
 
+// Usage documents the spec arguments in the help message.
+//
+// It replaces the "[mixin-OPTIONS]" placeholder the flags parser renders by default.
+func (c MixinSpec) Usage() string {
+	return "[mixin-OPTIONS] {primary spec} {mixin spec}..."
+}
+
 // Execute runs the mixin command which merges Swagger 2.0 specs into
 // one spec
 //

--- a/cmd/swagger/commands/validate.go
+++ b/cmd/swagger/commands/validate.go
@@ -30,6 +30,13 @@ type ValidateSpec struct {
 	StopOnError  bool `description:"when present will not continue validation after critical errors are found" long:"stop-on-error"`
 }
 
+// Usage documents the spec argument in the help message.
+//
+// It replaces the "[validate-OPTIONS]" placeholder the flags parser renders by default.
+func (c ValidateSpec) Usage() string {
+	return "[validate-OPTIONS] {spec}"
+}
+
 // Execute validates the spec.
 func (c *ValidateSpec) Execute(args []string) error {
 	if len(args) == 0 {

--- a/docs/generate/cli.md
+++ b/docs/generate/cli.md
@@ -53,10 +53,10 @@ Help Options:
                                                                                              code (default: cli)
 
     Options common to all code generation commands:
-          --with-expand                                                                      expands all $ref's in spec prior to generation (shorthand
-                                                                                             to --with-flatten=expand)
-          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in spec prior to generation (default:
-                                                                                             minimal, verbose)
+          --with-expand                                                                      expands all $ref's in the spec (shorthand to
+                                                                                             --with-flatten=expand)
+          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in the spec (default: minimal,
+                                                                                             verbose)
           --with-custom-formatter                                                            use faster custom contributed go import processing
                                                                                              instead of the standard one
       -f, --spec=                                                                            the spec file to use (default swagger.{json,yml,yaml})

--- a/docs/generate/client.md
+++ b/docs/generate/client.md
@@ -141,8 +141,8 @@ Help Options:
           --allow-template-override                                               allows overriding protected templates
           --skip-validation                                                       skips validation of spec prior to generation
           --dump-data                                                             when present dumps the json for the template generator instead of generating files
-          --with-expand                                                           expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
-          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in spec prior to generation (default: minimal, verbose)
+          --with-expand                                                           expands all $ref's in the spec (shorthand to --with-flatten=expand)
+          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused]    flattens all $ref's in the spec (default: minimal, verbose)
           --with-custom-formatter                                                 use faster custom contributed go import processing instead of the standard one
 
 

--- a/docs/generate/model.md
+++ b/docs/generate/model.md
@@ -25,10 +25,10 @@ Help Options:
           --accept-definitions-only                                               accepts a partial swagger spec wih only the definitions key
 
     Options common to all code generation commands:
-          --with-expand                                                                      expands all $ref's in spec prior to generation (shorthand
-                                                                                             to --with-flatten=expand)
-          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in spec prior to generation (default:
-                                                                                             minimal, verbose)
+          --with-expand                                                                      expands all $ref's in the spec (shorthand to
+                                                                                             --with-flatten=expand)
+          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in the spec (default: minimal,
+                                                                                             verbose)
           --with-custom-formatter                                                            use faster custom contributed go import processing
                                                                                              instead of the standard one
       -f, --spec=                                                                            the spec file to use (default swagger.{json,yml,yaml})

--- a/docs/generate/server.md
+++ b/docs/generate/server.md
@@ -52,10 +52,10 @@ Help Options:
           --with-context                                                          handlers get a context as first arg (deprecated)
 
     Options common to all code generation commands:
-          --with-expand                                                                      expands all $ref's in spec prior to generation (shorthand
-                                                                                             to --with-flatten=expand)
-          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in spec prior to generation (default:
-                                                                                             minimal, verbose)
+          --with-expand                                                                      expands all $ref's in the spec (shorthand to
+                                                                                             --with-flatten=expand)
+          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in the spec (default: minimal,
+                                                                                             verbose)
           --with-custom-formatter                                                            use faster custom contributed go import processing
                                                                                              instead of the standard one
       -f, --spec=                                                                            the spec file to use (default swagger.{json,yml,yaml})

--- a/docs/usage/expand.md
+++ b/docs/usage/expand.md
@@ -17,7 +17,7 @@ To expand a specification:
 
 ```
 Usage:
-  swagger [OPTIONS] expand [expand-OPTIONS]
+  swagger [OPTIONS] expand [expand-OPTIONS] {spec}
 
 expands the $refs in a swagger document to inline schemas
 

--- a/docs/usage/flatten.md
+++ b/docs/usage/flatten.md
@@ -26,7 +26,7 @@ To flatten a specification:
 
 ```
 Usage:
-  swagger [OPTIONS] flatten [flatten-OPTIONS]
+  swagger [OPTIONS] flatten [flatten-OPTIONS] {spec}
 
 expand the remote references in a spec and move inline schemas to definitions, after flattening there are no complex inlined anymore
 
@@ -38,9 +38,9 @@ Help Options:
   -h, --help                                                                                 Show this help message
 
 [flatten command options]
+          --with-expand                                                                      expands all $ref's in the spec (shorthand to --with-flatten=expand)
+          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in the spec (default: minimal, verbose)
           --compact                                                                          applies to JSON formatted specs. When present, doesn't prettify the json
       -o, --output=                                                                          the file to write to
           --format=[yaml|json]                                                               the format for the spec document (default: json)
-          --with-expand                                                                      expands all $ref's in spec prior to generation (shorthand to --with-flatten=expand)
-          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in spec prior to generation (default: minimal, verbose)
 ```

--- a/docs/usage/markdown.md
+++ b/docs/usage/markdown.md
@@ -20,6 +20,12 @@ defined as standalone models (documented as "inlined schemas").
 Known limitations:
 * validations are not rendered, for the sake of brevity
 
+Since this command generates no go code, it only takes the options that bear on the document it
+produces. The options that shape go source, such as `--struct-tags` or `--strict-responders`, are
+not available here, and neither are the ones naming the packages the code is written to
+(`--model-package`, `--api-package`): the "Go type" column always reports the conventional
+`models` and `operations` layout.
+
 ### Usage
 
 ```
@@ -29,52 +35,47 @@ Usage:
 generate a markdown representation from the swagger spec
 
 Application Options:
-  -q, --quiet                                                                     silence logs
-      --log-output=LOG-FILE                                                       redirect logs to file
+  -q, --quiet                                                                                silence logs
+      --log-output=LOG-FILE                                                                  redirect logs to file
 
 Help Options:
-  -h, --help                                                                      Show this help message
+  -h, --help                                                                                 Show this help message
 
 [markdown command options]
-          --output=                                                               the file to write the generated markdown. (default: markdown.md)
+          --output=                                                                          the file to write the generated markdown. (default:
+                                                                                             markdown.md)
 
-    Options common to all code generation commands:
-          --with-expand                                                                      expands all $ref's in spec prior to generation (shorthand
-                                                                                             to --with-flatten=expand)
-          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in spec prior to generation (default:
-                                                                                             minimal, verbose)
-          --with-custom-formatter                                                            use faster custom contributed go import processing
-                                                                                             instead of the standard one
+    Options for reading the spec and writing the documentation:
+          --with-expand                                                                      expands all $ref's in the spec (shorthand to
+                                                                                             --with-flatten=expand)
+          --with-flatten=[minimal|full|expand|verbose|noverbose|remove-unused|keep-names]    flattens all $ref's in the spec (default: minimal,
+                                                                                             verbose)
       -f, --spec=                                                                            the spec file to use (default swagger.{json,yml,yaml})
-      -t, --target=                                                                          the base directory for generating the files (default: ./)
-          --template=[stratoscale]                                                           load contributed templates
-      -T, --template-dir=                                                                    alternative template override directory
-      -C, --config-file=                                                                     configuration file to use for overriding template options
-      -r, --copyright-file=                                                                  copyright file used to add copyright header
-          --additional-initialism=                                                           consecutive capitals that should be considered intialisms
-          --allow-template-override                                                          allows overriding protected templates
           --skip-validation                                                                  skips validation of spec prior to generation
-          --dump-data                                                                        when present dumps the json for the template generator
-                                                                                             instead of generating files
-          --strict-responders                                                                Use strict type for the handler return value
-      -e, --return-errors                                                                    handlers explicitly return an error as the second value
           --restricted                                                                       Use restricted http client for remote $ref
           --rooted=                                                                          Local $ref resolution contained relative to root FS
+      -t, --target=                                                                          the base directory for generating the files (default: ./)
+      -T, --template-dir=                                                                    alternative template override directory
+      -C, --config-file=                                                                     configuration file to use for overriding template options
+          --additional-initialism=                                                           consecutive capitals that should be considered intialisms
+          --allow-template-override                                                          allows overriding protected templates
+          --dump-data                                                                        when present dumps the json for the template generator
+                                                                                             instead of generating files
+          --ensure-target                                                                    Create the target directory if it does not already exist
       -p, --template-plugin=                                                                 the template plugin to use
 
-    Options for model generation:
-      -m, --model-package=                                                        the package to save the models (default: models)
-      -M, --model=                                                                specify a model to include in generation, repeat for multiple (defaults to
-                                                                                  all)
-          --existing-models=                                                      use pre-generated models e.g. github.com/foobar/model
-          --strict-additional-properties                                          disallow extra properties when additionalProperties is set to false
-          --keep-spec-order                                                       keep schema properties order identical to spec file
-          --struct-tags=                                                          the struct tags to generate, repeat for multiple (defaults to json)
+    Options for selecting the documented models:
+      -M, --model=                                                                           specify a model to include in generation, repeat for
+                                                                                             multiple (defaults to all)
+          --keep-spec-order                                                                  keep schema properties order identical to spec file
 
-    Options for operation generation:
-      -O, --operation=                                                            specify an operation to include, repeat for multiple (defaults to all)
-          --tags=                                                                 the tags to include, if not specified defaults to all
-      -a, --api-package=                                                          the package to save the operations (default: operations)
-          --with-enum-ci                                                          allow case-insensitive enumerations
-          --skip-tag-packages                                                     skips the generation of tag-based operation packages, resulting in a flat generation
+    Options for selecting the documented operations:
+      -O, --operation=                                                                       specify an operation to include, repeat for multiple
+                                                                                             (defaults to all)
+          --tags=                                                                            the tags to include, if not specified defaults to all
+          --skip-tag-packages                                                                skips the generation of tag-based operation packages,
+                                                                                             resulting in a flat generation
 ```
+
+`--dump-data` dumps the data handed to the template instead of rendering it, which is how you find
+out what a custom markdown template passed with `--template-dir` can use.

--- a/docs/usage/mixin.md
+++ b/docs/usage/mixin.md
@@ -17,7 +17,7 @@ To mixin several specifications:
 
 ```
 Usage:
-  swagger [OPTIONS] mixin [mixin-OPTIONS]
+  swagger [OPTIONS] mixin [mixin-OPTIONS] {primary spec} {mixin spec}...
 
 merge additional specs into first/primary spec by copying their paths and definitions
 

--- a/docs/usage/validate.md
+++ b/docs/usage/validate.md
@@ -15,7 +15,7 @@ To validate a specification:
 
 ```
 Usage:
-  swagger [OPTIONS] validate [validate-OPTIONS]
+  swagger [OPTIONS] validate [validate-OPTIONS] {spec}
 
 validate the provided swagger document against a swagger spec
 

--- a/generator/support.go
+++ b/generator/support.go
@@ -254,6 +254,10 @@ func (a *appGenerator) GenerateMarkdown() error {
 		return err
 	}
 
+	if a.DumpData {
+		return dumpData(os.Stdout, app)
+	}
+
 	return newRenderer(a.GenOpts).renderApplication(&app)
 }
 


### PR DESCRIPTION
The command help listed options the commands never read, and hid the arguments they require.

generate markdown:
- it embedded the full code generation option set, 38 flags for a command that renders a document and generates no go code. The fourteen that left its output byte for byte identical are gone: --struct-tags, --with-stringer, --strict-responders, --copyright-file and the like, along with --model-package and --api-package, which name the packages generated code is written to. What shapes the document stays, and the option groups are titled for what they select rather than "options common to all code generation commands".
- --dump-data was accepted and silently ignored. It now dumps the template data, which is how a custom template passed with --template-dir finds out what it can use.

flatten:
- --with-custom-formatter selects a go import processor, and this command writes a spec: the field moved out of FlattenCmdOptions.
- --with-expand and --with-flatten no longer claim to act "prior to generation".

flatten, expand, validate and mixin:
- all require their swagger document as an argument, but rendered the bare "[<command>-OPTIONS]" placeholder without ever mentioning it. They name it now, as diff already did.

The shared option groups are split along the same line, between what any command reading a spec needs and what only shapes go source. The generation commands keep their exact flag set.