### PR TITLE
security(docker): update base image to patch golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
 
-# NOTE: the shipped image keeps the go toolchain on purpose -- swagger shells out to it
-# (go list, import resolution) at runtime. Slimming this down to a plain alpine breaks
-# codegen and codescan.
-FROM golang:alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS base
-RUN apk --no-cache add \
-      ca-certificates=20260611-r0 \
-      shared-mime-info=2.4-r7 \
-      mailcap=2.1.54-r0 \
-      git=2.54.0-r0 \
-      build-base=0.5-r4 \
-      binutils-gold=2.45.1-r1
+FROM golang:alpine@sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816 AS base
 
 # --platform=$BUILDPLATFORM pins this stage to the machine running the build: the go build
 # below cross-compiles through GOOS/GOARCH with CGO off, so running it under QEMU for
@@ -38,6 +28,9 @@ RUN mkdir -p bin &&\
   LDFLAGS="$LDFLAGS -X github.com/go-swagger/go-swagger/cmd/swagger/commands.Version=${tag_name}" &&\
   CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags osusergo,netgo -o bin/swagger -ldflags "$LDFLAGS" ./cmd/swagger
 
+# NOTE: the shipped image keeps the go toolchain on purpose -- swagger shells out to it
+# (go list, import resolution) at runtime. Slimming this down to a plain alpine breaks
+# codegen and codescan.
 FROM base
 LABEL maintainer="Frédéric BIDON <fredbi@yahoo.com> (@fredbi)"
 COPY --from=build /work/bin/swagger /usr/bin/swagger

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It provide tools to work with swagger specifications.
 
 You may join the discord community by clicking the invite link on the discord badge. [![Discord Channel][discord-badge]][discord-url].
 
+* **2026-08-15** : Docker image users - shipping **v0.36.4 to address critical vulnerability in golang**
 * **2026-08-11** : v0.36.3 lands soon (ETA 08/14)
   * codegen fixes
   * spec gen updates deferred to v0.36.4 (~ 08/21: faster scanner, enhanced TUI tool)


### PR DESCRIPTION
This PR upgrades the base image to publish Docker images.
It addresses recently uncovered vulnerabilities in go1.26.5.

We are going to cut a release v0.36.4 specifically to publish a patched image (alpine 3.24, go1.26.6)