### PR TITLE
Generate optional getters for all fields

### DIFF
--- a/cmd/swagger/commands/generate/markdown_test.go
+++ b/cmd/swagger/commands/generate/markdown_test.go
@@ -83,7 +83,7 @@ func TestMarkdownFlags(t *testing.T) {
 			"--return-errors", "--with-custom-formatter",
 			"--model-package=models", "--existing-models=github.com/foo/bar",
 			"--strict-additional-properties", "--struct-tags=yaml", "--rooted-error-path",
-			"--with-stringer", "--no-default-omit-empty",
+			"--with-stringer", "--generate-getters", "--no-default-omit-empty",
 			"--api-package=operations", "--with-enum-ci",
 		} {
 			_, err := flags.ParseArgs(&generate.Markdown{}, []string{arg})
@@ -94,7 +94,7 @@ func TestMarkdownFlags(t *testing.T) {
 	t.Run("should keep the full flag set on the code generation commands", func(t *testing.T) {
 		for _, arg := range []string{
 			"--copyright-file=LICENSE", "--strict-responders", "--return-errors",
-			"--with-custom-formatter", "--struct-tags=yaml", "--with-stringer", "--with-enum-ci",
+			"--with-custom-formatter", "--struct-tags=yaml", "--with-stringer", "--generate-getters", "--with-enum-ci",
 			"--model-package=models", "-m=models", "--api-package=operations", "-a=operations",
 		} {
 			_, err := flags.ParseArgs(&generate.Server{}, []string{arg})

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -34,6 +34,7 @@ type modelCodegenOptions struct {
 	StructTags                 []string `description:"the struct tags to generate, repeat for multiple (defaults to json)"                                          long:"struct-tags"`
 	RootedErrorPath            bool     `description:"extends validation errors with the type name instead of an empty path, in the case of arrays and maps"        long:"rooted-error-path"`
 	WithStringer               bool     `description:"generate a fmt.Stringer String() method on models, rendering field values as JSON (see issue #872)"           long:"with-stringer"`
+	GenerateGetters            bool     `description:"generate a Get<Field> method for each field on models"                                                        long:"generate-getters"`
 	NoDefaultOmitEmpty         bool     `description:"do not default to omitempty struct tags unless x-omitempty is explicitly set on a property (see issue #2386)" long:"no-default-omit-empty"`
 }
 
@@ -44,6 +45,7 @@ func (mo modelCodegenOptions) apply(opts *generator.GenOpts) {
 	opts.StructTags = mo.StructTags
 	opts.WantsRootedErrorPath = mo.RootedErrorPath
 	opts.WantsStringer = mo.WithStringer
+	opts.WantsGetters = mo.GenerateGetters
 	opts.NoDefaultOmitEmpty = mo.NoDefaultOmitEmpty
 }
 

--- a/generator/genopts.go
+++ b/generator/genopts.go
@@ -85,6 +85,7 @@ type GenOpts struct {
 	AcceptDefinitionsOnly  bool
 	WantsRootedErrorPath   bool
 	WantsStringer          bool
+	WantsGetters           bool // generate a Get<Field> method for each field on models (--generate-getters)
 	ReturnErrors           bool
 	WithCustomFormatter    bool
 	WithExtraInitialisms   []string

--- a/generator/model.go
+++ b/generator/model.go
@@ -262,6 +262,7 @@ func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema,
 		StructTags:                 opts.StructTags,
 		WantsRootedErrorPath:       opts.WantsRootedErrorPath,
 		WantsStringer:              opts.WantsStringer,
+		WantsGetters:               opts.WantsGetters,
 		mangler:                    opts.LanguageOpts.Mangler,
 		pascalize:                  pascalize,
 		jsonify:                    jsonify,
@@ -464,6 +465,7 @@ type schemaGenContext struct {
 	StrictAdditionalProperties bool
 	WantsRootedErrorPath       bool
 	WantsStringer              bool
+	WantsGetters               bool
 	WithXML                    bool
 	Index                      int
 
@@ -1733,6 +1735,7 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	sg.GenSchema.ExtraImports = make(map[string]string)
 	sg.GenSchema.WantsRootedErrorPath = sg.WantsRootedErrorPath
 	sg.GenSchema.WantsStringer = sg.WantsStringer
+	sg.GenSchema.WantsGetters = sg.WantsGetters
 	sg.GenSchema.IsElem = sg.IsElem
 	sg.GenSchema.IsProperty = sg.IsProperty
 	sg.GenSchema.GoName = schemaGoName(&sg.Schema, sg.Name, sg.mangler)
@@ -1883,6 +1886,13 @@ func (sg *schemaGenContext) makeGenSchema() error {
 	// Restricted to the struct/tuple/map shapes that use a pointer receiver, mirroring
 	// MarshalBinary (see issue #872).
 	sg.GenSchema.WantsStringer = sg.WantsStringer && !gs.IsInterface && !gs.IsStream && !gs.IsBaseType &&
+		(gs.IsTuple || gs.IsComplexObject || gs.IsAdditionalProperties)
+
+	// generate a Get<Field> method for each property when the --generate-getters option is set.
+	// Restricted to the struct/tuple/map shapes that use a pointer receiver, mirroring
+	// WantsStringer/WantsMarshalBinary (see issue #872). Base types are skipped because
+	// they already expose getters via the polymorphic path.
+	sg.GenSchema.WantsGetters = sg.WantsGetters && !gs.IsInterface && !gs.IsStream && !gs.IsBaseType &&
 		(gs.IsTuple || gs.IsComplexObject || gs.IsAdditionalProperties)
 
 	return nil

--- a/generator/model_test.go
+++ b/generator/model_test.go
@@ -2929,3 +2929,98 @@ func TestIssue872(t *testing.T) {
 		assertNotInCode(t, "func (m *ModelError) String() string {", res)
 	})
 }
+
+// TestGenerateGetters covers the opt-in Get<Field> methods on generated models.
+//
+// The --generate-getters flag emits a getter for each property of a model struct,
+// returning the field value by its declared type. This test exercises the variety
+// of return types (scalar, pointer, slice, date-time, nested struct) and asserts
+// that the default output is unchanged when the option is not set.
+func TestGenerateGetters(t *testing.T) {
+	specDoc, err := loads.Spec("../testdata/enhancements/generate-getters/fixture.yaml")
+	require.NoError(t, err)
+
+	definitions := specDoc.Spec().Definitions
+	const model = "GetterModel"
+
+	render := func(t *testing.T, opts *GenOpts) string {
+		t.Helper()
+
+		genModel, err := makeGenDefinition(model, "models", definitions[model], specDoc, opts)
+		require.NoError(t, err)
+
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, opts.templates.MustGet("model").Execute(buf, genModel))
+
+		ct, err := opts.LanguageOpts.FormatContent("model.go", buf.Bytes())
+		require.NoErrorf(t, err, "format error: %v\n%s", err, buf.String())
+
+		return string(ct)
+	}
+
+	t.Run("with WantsGetters option", func(t *testing.T) {
+		opts := opts()
+		opts.WantsGetters = true
+
+		res := render(t, opts)
+
+		// each non-base-type property gets a Get<Field> getter with a pointer receiver
+		// and the field's declared type. The Go formatter expands the one-liner body
+		// to multi-line, so we assert on the signature + return statement separately.
+
+		// scalar types: int64, bool, float32
+		assertInCode(t, "func (m *GetterModel) GetID() int64 {", res)
+		assertInCode(t, "return m.ID", res)
+		assertInCode(t, "func (m *GetterModel) GetActive() bool {", res)
+		assertInCode(t, "return m.Active", res)
+		assertInCode(t, "func (m *GetterModel) GetRatio() float32 {", res)
+		assertInCode(t, "return m.Ratio", res)
+
+		// required string -> pointer
+		assertInCode(t, "func (m *GetterModel) GetName() *string {", res)
+		assertInCode(t, "return m.Name", res)
+
+		// slice
+		assertInCode(t, "func (m *GetterModel) GetTags() []string {", res)
+		assertInCode(t, "return m.Tags", res)
+
+		// date-time format -> strfmt.DateTime
+		assertInCode(t, "func (m *GetterModel) GetWhen() strfmt.DateTime {", res)
+		assertInCode(t, "return m.When", res)
+
+		// nested struct -> pointer
+		assertInCode(t, "func (m *GetterModel) GetChild() *Child {", res)
+		assertInCode(t, "return m.Child", res)
+
+		// map (additionalProperties) -> map[string]string
+		assertInCode(t, "func (m *GetterModel) GetMetadata() map[string]string {", res)
+		assertInCode(t, "return m.Metadata", res)
+
+		// polymorphic base-type property: the existing polymorphic path generates
+		// a getter WITHOUT the "Get" prefix (and a setter). Our --generate-getters
+		// block must NOT emit a duplicate "GetPet" getter for this property.
+		assertInCode(t, "func (m *GetterModel) Pet() Pet {", res)
+		assertInCode(t, "func (m *GetterModel) SetPet(val Pet) {", res)
+		assertNotInCode(t, "func (m *GetterModel) GetPet(", res)
+	})
+
+	t.Run("without WantsGetters option (default)", func(t *testing.T) {
+		opts := opts()
+
+		res := render(t, opts)
+
+		// opt-in: the default output is unchanged, no Get<Field> methods are emitted.
+		// The polymorphic getter for the base-type property still exists (it is
+		// generated unconditionally by the existing polymorphic path).
+		assertNotInCode(t, "func (m *GetterModel) GetID(", res)
+		assertNotInCode(t, "func (m *GetterModel) GetName(", res)
+		assertNotInCode(t, "func (m *GetterModel) GetTags(", res)
+		assertNotInCode(t, "func (m *GetterModel) GetWhen(", res)
+		assertNotInCode(t, "func (m *GetterModel) GetChild(", res)
+		assertNotInCode(t, "func (m *GetterModel) GetActive(", res)
+		assertNotInCode(t, "func (m *GetterModel) GetRatio(", res)
+		assertNotInCode(t, "func (m *GetterModel) GetMetadata(", res)
+		assertNotInCode(t, "func (m *GetterModel) GetPet(", res)
+		assertInCode(t, "func (m *GetterModel) Pet() Pet {", res)
+	})
+}

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -104,6 +104,7 @@ type GenSchema struct {
 	Default                    any
 	WantsMarshalBinary         bool // do we generate MarshalBinary interface?
 	WantsStringer              bool // do we generate the fmt.Stringer String() method?
+	WantsGetters               bool // do we generate a Get<Field> method for each field?
 	StructTags                 []string
 	ExtraImports               map[string]string // non-standard imports detected when using external types
 	ExternalDocs               *spec.ExternalDocumentation

--- a/generator/templates/schema.gotmpl
+++ b/generator/templates/schema.gotmpl
@@ -115,6 +115,17 @@ func ({{.ReceiverName}} {{ if or .IsTuple .IsComplexObject .IsAdditionalProperti
 {{- if .WantsStringer }}
   {{ template "stringerSerializer" . }}
 {{- end }}
+{{- if .WantsGetters }}
+  {{- range .Properties }}
+    {{- if not .IsBaseType }}
+
+// Get{{ .GoName }} gets the {{ humanize .Name }} of this {{ $.GoName }}
+func ({{ $.ReceiverName }} *{{ $.GoName }}) Get{{ .GoName }}() {{ template "schemaType" . }} {
+  return {{ $.ReceiverName }}.{{ .GoName }}
+}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- define "mapOrSliceGetter" }}{{/* signature for AdditionalProperties and AdditionalItems getter funcs */}}
   {{- if not .IsBaseType }}
     {{- if .HasAdditionalProperties }}

--- a/testdata/enhancements/generate-getters/fixture.yaml
+++ b/testdata/enhancements/generate-getters/fixture.yaml
@@ -1,0 +1,86 @@
+swagger: "2.0"
+info:
+  description: 'fixture for --generate-getters: exercise getter return types across field kinds'
+  title: generate-getters
+  version: "0.0.0"
+paths:
+  /v1/model:
+    get:
+      produces:
+        - application/json
+      responses:
+        default:
+          description: model
+          schema:
+            $ref: '#/definitions/GetterModel'
+
+definitions:
+  GetterModel:
+    type: object
+    required:
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: an optional scalar (int64)
+      name:
+        type: string
+        description: a required string (generated as a pointer)
+      tags:
+        type: array
+        items:
+          type: string
+        description: a slice of strings
+      when:
+        type: string
+        format: date-time
+        description: a date-time field (strfmt.DateTime)
+      child:
+        $ref: '#/definitions/Child'
+        description: a nested object (pointer to struct)
+      active:
+        type: boolean
+        description: a boolean field
+      ratio:
+        type: number
+        format: float
+        description: a float field
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+        description: a map of string to string (additionalProperties)
+      pet:
+        $ref: '#/definitions/Pet'
+        description: a polymorphic base type property (exercises the IsBaseType guard)
+
+  Child:
+    type: object
+    properties:
+      label:
+        type: string
+        description: a label for the child
+
+  Pet:
+    type: object
+    discriminator: kind
+    required:
+      - kind
+    properties:
+      kind:
+        type: string
+        description: the discriminator field
+      name:
+        type: string
+        description: the pet name
+
+  Dog:
+    type: object
+    allOf:
+      - $ref: '#/definitions/Pet'
+      - type: object
+        properties:
+          breed:
+            type: string
+            description: the dog breed


### PR DESCRIPTION
the --generate-getters param lets us generate getters on all fields. That way interfaces can be written to accept multiple generated models.

Proposal mentioned in Discord and [this examples PR](https://github.com/go-swagger/examples/pull/94)
