### PR TITLE
fix: onboard fixes from spec, analysis and validate

### DIFF
--- a/generator/spec.go
+++ b/generator/spec.go
@@ -60,6 +60,8 @@ func (g *specAnalyzer) validateAndFlattenSpec() (*loads.Document, error) {
 	}
 
 	// Validate if needed
+	//
+	// NOTE: since v0.26.4, [validate.Spec] no longer mutates silently the spec.
 	if g.ValidateSpec {
 		log.Printf("validating spec %v", g.Spec)
 		validationErrors := validate.Spec(specDoc, strfmt.Default, validate.WithPathLoader(g.loader))
@@ -80,10 +82,6 @@ func (g *specAnalyzer) validateAndFlattenSpec() (*loads.Document, error) {
 
 			return nil, errors.New(b.String())
 		}
-
-		// TODO(fredbi): due to uncontrolled $ref state in spec, we need to reload the spec atm, or flatten won't
-		// work properly (validate expansion alters the $ref cache in go-openapi/spec)
-		specDoc, _ = loads.Spec(g.Spec, loads.WithDocLoader(g.loader))
 	}
 
 	// Flatten spec

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,20 @@
 module github.com/go-swagger/go-swagger
 
-go 1.25.0
+go 1.26.0
 
 toolchain go1.27.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/SladkyCitron/slogcolor v1.9.0
-	github.com/go-openapi/analysis v0.26.0
+	github.com/go-openapi/analysis v0.26.1
 	github.com/go-openapi/codescan v0.36.4
 	github.com/go-openapi/errors v0.22.8
 	github.com/go-openapi/inflect v1.0.0
 	github.com/go-openapi/loads v0.25.1
 	github.com/go-openapi/runtime v0.33.1
 	github.com/go-openapi/runtime/server-middleware v0.33.1
-	github.com/go-openapi/spec v0.22.9
+	github.com/go-openapi/spec v0.22.10
 	github.com/go-openapi/strfmt v0.27.0
 	github.com/go-openapi/swag/conv v0.29.1
 	github.com/go-openapi/swag/jsonutils v0.29.1
@@ -24,8 +24,8 @@ require (
 	github.com/go-openapi/swag/stringutils v0.29.1
 	github.com/go-openapi/swag/typeutils v0.29.1
 	github.com/go-openapi/swag/yamlutils v0.29.1
-	github.com/go-openapi/testify/v2 v2.6.1
-	github.com/go-openapi/validate v0.26.3
+	github.com/go-openapi/testify/v2 v2.7.0
+	github.com/go-openapi/validate v0.26.4
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/jessevdk/go-flags v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
-github.com/go-openapi/analysis v0.26.0 h1:1xECln1iMMmQnTjgcknC1vi1hA4KISt6IHpSwnqcuwI=
-github.com/go-openapi/analysis v0.26.0/go.mod h1:40gERFi/2dyXA1FaqRRLxkv1IlC6X+GPDNd1xrYAjZE=
+github.com/go-openapi/analysis v0.26.1 h1:BqYuDaQiFflcgPWGDQc7niUFE2pHTVq1H3iwDsRYMqM=
+github.com/go-openapi/analysis v0.26.1/go.mod h1:E2siwFrz00/Z1sifwhy63h+hMkg0USofwD4gYPYeQME=
 github.com/go-openapi/codescan v0.36.4 h1:ngm19zhpNK2+NibLflXZTGbsJ0MsH9xEspMyWSBgjZU=
 github.com/go-openapi/codescan v0.36.4/go.mod h1:0SOMEOGEok11EOBRiK9GSoSHVSn4XeqjN4JEg8GGV1E=
 github.com/go-openapi/errors v0.22.8 h1:oP7sW7TWc3wFFjrzzj0nI83H2qMBkNjNfSd+XRejk/I=
@@ -37,8 +37,8 @@ github.com/go-openapi/runtime v0.33.1 h1:jCvhI+wAdsn29byy+RgcPcg+j39YT6E304QOE/W
 github.com/go-openapi/runtime v0.33.1/go.mod h1:Dl5SMVRnJz+d8bX6Y1zxy0QKpqe/ysvVeUEh1nCpEZ4=
 github.com/go-openapi/runtime/server-middleware v0.33.1 h1:IAeKbwWnBnpsYTpuPVS8t73ZrPpKvRZnK2iJ2KJGUV0=
 github.com/go-openapi/runtime/server-middleware v0.33.1/go.mod h1:2Gej5fDxqeJxY+w38vxXYW0BgFASfgBsJ5rXwN1Fseg=
-github.com/go-openapi/spec v0.22.9 h1:/vKIFDcGKp0ktZWGbym/tJEWbk6/XOEmAVU0kqKMH+w=
-github.com/go-openapi/spec v0.22.9/go.mod h1:b/mNUYIOQOyIiUzUzXEE8xzyZqf93KvM9hQGP91yfl0=
+github.com/go-openapi/spec v0.22.10 h1:5cp1dq++t4U/4WCg6f1wqReZowUrJ5kl8Eri4SMl51s=
+github.com/go-openapi/spec v0.22.10/go.mod h1:aWRr+Ntv5tHoMQo0C1slTNLFo1FOYdZXFlUqViCN7yM=
 github.com/go-openapi/strfmt v0.27.0 h1:kbcTeaD9TXuXD0hhMXzuYa1sdTo6+dWGvwjW93E80IM=
 github.com/go-openapi/strfmt v0.27.0/go.mod h1:s/qhDqfY72irigXUGJmtgid2Rm+3tnz3k8hZaRmvWYc=
 github.com/go-openapi/swag/conv v0.29.1 h1:AC4Eh/5c/eUDOUCzzsRC9ghmFgOSBHeRMGIngY0ZUGA=
@@ -65,10 +65,10 @@ github.com/go-openapi/swag/yamlutils v0.29.1 h1:69w3tsBajm7MR/fejLy7HD/3J68Ys1Se
 github.com/go-openapi/swag/yamlutils v0.29.1/go.mod h1:rgsp3vT/QdWzKwn43CigDwjOGIenPyTZMKnxEM8jZOA=
 github.com/go-openapi/testify/enable/yaml/v2 v2.6.1 h1:Jm+/ze2rMtbD98yen92AhATGLGREDYXG56Xr4gMjEtE=
 github.com/go-openapi/testify/enable/yaml/v2 v2.6.1/go.mod h1:YDPnwCRDu38/oJBVMBVXOUDiJ9cIeBHWvfImHaXqnv4=
-github.com/go-openapi/testify/v2 v2.6.1 h1:6CNJhTjMzgaeaH8WhshcsZNPIvRemiOcFpU7seO/y7Q=
-github.com/go-openapi/testify/v2 v2.6.1/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
-github.com/go-openapi/validate v0.26.3 h1:OkfZgLvLDnGP2hrRGD+42WBiPWWkoHomTJ+IVI+KaDc=
-github.com/go-openapi/validate v0.26.3/go.mod h1:7DOOa4raU6NRe7A8VQSKbm3VcuUIioREYHFt+er9Sk8=
+github.com/go-openapi/testify/v2 v2.7.0 h1:bycOreEj6wfBvijg3YFogZ/sFjTCDmQnwSodSzHa3X8=
+github.com/go-openapi/testify/v2 v2.7.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/go-openapi/validate v0.26.4 h1:MoiZYinqehNWMxPfKsyo8kxs7uYoFAf6k+4QfTHRvBI=
+github.com/go-openapi/validate v0.26.4/go.mod h1:qRkL7p9Dk183ZK3aZ6F+cekhKCioj9NLnFLnTNuPcXM=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/testdata/bugs/2306/fixture-2306.json
+++ b/testdata/bugs/2306/fixture-2306.json
@@ -20194,6 +20194,9 @@
     "basic": {
       "type": "basic"
     },
+    "token": {
+      "type": "basic"
+    },
     "csrf_token": {
       "in": "header",
       "name": "X-CSRFToken",

--- a/testdata/bugs/2730/2730.yaml
+++ b/testdata/bugs/2730/2730.yaml
@@ -23,6 +23,15 @@ tags:
         description: Find out more about our store
         url: http://swagger.io
       name: user
+securityDefinitions:
+  petstore_auth:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth'
+    tokenUrl: 'https://www.googleapis.com/oauth2/v4/token'
+    scopes:
+      write:pets: Can write pets
+      read:pets: Can read pets
 paths:
     /pet:
         post:

--- a/testdata/codegen/billforward.discriminators.yml
+++ b/testdata/codegen/billforward.discriminators.yml
@@ -43,7 +43,9 @@ definitions:
   PricingComponent:
     type: object
     discriminator: chargeModel
+    required: [chargeModel]
     properties:
+      chargeModel: {type: string}
       priceExplanation: {type: array, items: {type: string}}
       priceExplanationString: {type: string}
     xml:

--- a/testdata/goparsing/spec/go.mod
+++ b/testdata/goparsing/spec/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-swagger/go-swagger/testdata/goparsing/spec
 
-go 1.25.0
+go 1.26.0
 
 require github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013


### PR DESCRIPTION
* onboarded fixes from go-openapi/spec: fixes edge cases bugs on expand (circular $ref) and their counterpart in go-openapi/analysis
* onboarded improvements to go-openapi/validate: new validation rules on security requirements (now checked against their definition) and discriminators (now checked for existence and required property).

Other upgrades:
* upgraded minimum required go to v1.26.0
* test: upgraded testify to v2.7.0