### PR TITLE
doc(cli): generate CLI usage documentation as markdown

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - dupl  # temporary => should be disabled sparingly
     - err113 # temporary
     - exhaustruct # temporary
+    - exhaustruct_v5 # temporary
     - funlen # temporary
     - gochecknoglobals  # agree, but breaking
     - gochecknoinits # agree, but breaking

--- a/cmd/swagger/doc.go
+++ b/cmd/swagger/doc.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+// Command swagger is a CLI tool to work with Swagger specifications.
+package main
+
+import (
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	flags "github.com/jessevdk/go-flags"
+)
+
+type docCommand struct {
+	Destination string `default:"./docs" description:"Output destination folder" long:"dest" short:"d"`
+	parser      *flags.Parser
+}
+
+func (d *docCommand) Execute(_ []string) error {
+	return d.gendoc()
+}
+
+func (d *docCommand) gendoc() (err error) {
+	if d.Destination == "" {
+		const defaultFolder = "docs"
+		d.Destination = defaultFolder
+	}
+
+	const writableMode = 0o755
+	if err = os.MkdirAll(d.Destination, writableMode); err != nil {
+		return err
+	}
+
+	for documented := range documentCLI(d.parser) {
+		file, err := os.Create(filepath.Join(d.Destination, documented.Target))
+		if err != nil {
+			return err
+		}
+
+		// front matter
+		fmt.Fprintln(file, "---")
+		fmt.Fprintf(file, "title: %q\n", documented.Title)
+		fmt.Fprintf(file, "description: %q\n", documented.Description)
+		fmt.Fprintf(file, "weight: %d\n", documented.Index)
+		fmt.Fprintln(file, "---")
+		fmt.Fprintln(file, "")
+
+		// markdown formatting
+		fmt.Fprintf(file, "## %s\n", documented.Title)
+		fmt.Fprintln(file, "")
+		fmt.Fprintln(file, "```cmd")
+
+		// go-flags formats a help message by polling the width of the stdin terminal: we give it a pseudo-tty, sized at 132 cols.
+		const desiredTermWidth = 132
+		restore, err := setTermsize(desiredTermWidth)
+		if err != nil {
+			return err
+		}
+		defer restore()
+
+		// go-flags writes help messages to stdout: redirecting here
+		stdout := os.Stdout
+		stderr := os.Stderr
+		defer func() {
+			os.Stdout = stdout
+			os.Stderr = stderr
+		}()
+
+		os.Stdout = file
+		os.Stderr = file
+
+		// run the command with --help flag; swallow the error systematically returned by go-flag on --help
+		_ = run(d.parser, documented.Args)
+
+		fmt.Fprintln(file, "```")
+		err = file.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type doc struct {
+	Title       string
+	Description string
+	Target      string
+	Args        []string
+	Index       int // the index in the tree of commands: used to weight the produced pages
+}
+
+// documentCLI yields an iterator over the tree of commands and their subcommands.
+func documentCLI(parser *flags.Parser) iter.Seq[doc] {
+	return func(yield func(doc) bool) {
+		i := 0
+		rootDoc := doc{
+			Title:       "Commands",
+			Description: "All swagger commands",
+			Index:       i,
+			Target:      "commands.md",
+			Args:        []string{"--help"},
+		}
+		if !yield(rootDoc) {
+			return
+		}
+
+		i++
+		for cmdDoc := range documentCommands([]string{}, &i, parser.Commands()) {
+			if !yield(cmdDoc) {
+				return
+			}
+			i++
+		}
+	}
+}
+
+func documentCommands(parents []string, index *int, commands []*flags.Command) iter.Seq[doc] {
+	var prefix, parent string
+	if len(parents) > 0 {
+		prefix = strings.Join(parents, "_") + "_"
+		parent = strings.Join(parents, " ") + " "
+	}
+
+	return func(yield func(doc) bool) {
+		for _, cmd := range commands {
+			const addedArgs = 2
+			args := make([]string, 0, len(parents)+addedArgs)
+			args = append(args, parents...)
+			args = append(args, cmd.Name, "--help")
+
+			cmdDoc := doc{
+				Title:       parent + cmd.Name,
+				Description: cmd.ShortDescription,
+				Target:      prefix + cmd.Name + ".md",
+				Args:        args,
+				Index:       *index,
+			}
+			if !yield(cmdDoc) {
+				return
+			}
+			*index++
+
+			children := slices.Clone(parents)
+			children = slices.Grow(children, 1)
+			children = append(children, cmd.Name)
+			for subCmd := range documentCommands(children, index, cmd.Commands()) {
+				if !yield(subCmd) {
+					return
+				}
+				*index++
+			}
+		}
+	}
+}

--- a/cmd/swagger/doc_others.go
+++ b/cmd/swagger/doc_others.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+func setTermsize(cols uint16) (restore func(), err error) {
+	return func() {}, nil // noop on windows
+}

--- a/cmd/swagger/doc_test.go
+++ b/cmd/swagger/doc_test.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+)
+
+func TestDoc(t *testing.T) {
+	parser, err := register()
+	require.NoError(t, err)
+
+	d := &docCommand{
+		Destination: t.TempDir(),
+		parser:      parser,
+	}
+
+	require.NoError(t, d.gendoc())
+}

--- a/cmd/swagger/doc_unix.go
+++ b/cmd/swagger/doc_unix.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"syscall"
+
+	"github.com/creack/pty"
+	"golang.org/x/sys/unix"
+)
+
+func setTermsize(cols uint16) (restore func(), err error) {
+	master, slave, err := pty.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	const termRows uint16 = 80
+	size := &pty.Winsize{Rows: termRows, Cols: cols, X: 0, Y: 0}
+	err = pty.Setsize(slave, size)
+	if err != nil {
+		return nil, err
+	}
+
+	stdin, err := unix.Dup(syscall.Stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = unix.Dup2(int(slave.Fd()), syscall.Stdin); err != nil {
+		return nil, err
+	}
+
+	return func() {
+		// close pseudo-tty machinery
+		_ = slave.Close()
+		_ = master.Close()
+		// restore stdin
+		_ = unix.Dup2(stdin, syscall.Stdin)
+	}, nil
+}

--- a/cmd/swagger/swagger.go
+++ b/cmd/swagger/swagger.go
@@ -21,56 +21,72 @@ var opts struct {
 }
 
 func main() {
-	parser := flags.NewParser(&opts, flags.Default)
+	parser, err := register()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err = run(parser, os.Args[1:]); err != nil {
+		os.Exit(1)
+	}
+}
+
+func register() (*flags.Parser, error) {
+	parser := flags.NewNamedParser("swagger", flags.Default)
+	_, err := parser.AddGroup("Application Options", "", &opts)
+	if err != nil {
+		return nil, err
+	}
+
 	parser.ShortDescription = "helps you keep your API well described"
 	parser.LongDescription = `
 Swagger tries to support you as best as possible when building APIs.
 
 It aims to represent the contract of your API with a language agnostic description of your application in json or yaml.
 `
-	_, err := parser.AddCommand("validate", "validate the swagger document", "validate the provided swagger document against a swagger spec", &commands.ValidateSpec{})
+	_, err = parser.AddCommand("validate", "validate the swagger document", "validate the provided swagger document against a swagger spec", &commands.ValidateSpec{})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	_, err = parser.AddCommand("init", "initialize a spec document", "initialize a swagger spec document", &commands.InitCmd{})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	_, err = parser.AddCommand("version", "print the version", "print the version of the swagger command", &commands.PrintVersion{})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	_, err = parser.AddCommand("serve", "serve spec and docs", "serve a spec and swagger or redoc documentation ui", &commands.ServeCmd{})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	_, err = parser.AddCommand("expand", "expand $ref fields in a swagger spec", "expands the $refs in a swagger document to inline schemas", &commands.ExpandSpec{})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	_, err = parser.AddCommand("flatten", "flattens a swagger document", "expand the remote references in a spec and move inline schemas to definitions, after flattening there are no complex inlined anymore", &commands.FlattenSpec{})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	_, err = parser.AddCommand("mixin", "merge swagger documents", "merge additional specs into first/primary spec by copying their paths and definitions", &commands.MixinSpec{})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	_, err = parser.AddCommand("diff", "diff swagger documents", "diff specs showing which changes will break existing clients", &commands.DiffCommand{})
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	genpar, err := parser.AddCommand("generate", "generate go code", "generate go code for the swagger spec file", &commands.Generate{})
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 	for _, cmd := range genpar.Commands() {
 		switch cmd.Name {
@@ -101,6 +117,15 @@ It aims to represent the contract of your API with a language agnostic descripti
 		}
 	}
 
+	_, err = parser.AddCommand("doc", "generate CLI usage documentation as markdown", "", &docCommand{parser: parser})
+	if err != nil {
+		return nil, err
+	}
+
+	return parser, nil
+}
+
+func run(parser *flags.Parser, args []string) error {
 	opts.Quiet = func() {
 		log.SetOutput(io.Discard)
 	}
@@ -113,7 +138,7 @@ It aims to represent the contract of your API with a language agnostic descripti
 		log.SetOutput(f)
 	}
 
-	if _, err := parser.Parse(); err != nil {
-		os.Exit(1)
-	}
+	_, err := parser.ParseArgs(args)
+
+	return err
 }

--- a/cmd/swagger/swagger_test.go
+++ b/cmd/swagger/swagger_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+)
+
+func TestSwagger(t *testing.T) {
+	stdout := os.Stdout
+	t.Cleanup(func() {
+		os.Stdout = stdout
+	})
+	os.Stdout = discard(t)
+	parser, err := register()
+	require.NoError(t, err)
+
+	err = run(parser, []string{"--help"})
+	require.Error(t, err)
+}
+
+func discard(t *testing.T) *os.File {
+	discard, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+
+	return discard
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.27.0
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/SladkyCitron/slogcolor v1.9.0
+	github.com/creack/pty v1.1.24
 	github.com/go-openapi/analysis v0.26.2
 	github.com/go-openapi/codescan v0.36.4
 	github.com/go-openapi/errors v0.22.8
@@ -33,6 +34,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/toqueteos/webbrowser v1.2.1
 	go.yaml.in/yaml/v3 v3.0.5
+	golang.org/x/sys v0.47.0
 	golang.org/x/tools v0.49.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -70,7 +72,6 @@ require (
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/SladkyCitron/slogcolor v1.9.0 h1:fr4LeG+T6pZ1RYNNOP925jaBYrTdpA6BLzGy29yd4vI=
 github.com/SladkyCitron/slogcolor v1.9.0/go.mod h1:ft8LEVIl4isUkebakhv+ngNXJjWBumnwhXfxTLApf3M=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=


### PR DESCRIPTION
The "swagger doc" command produces markdown files
(with frontmatter header) with an up-to-date description of CLI flags and subcommands.

This will feed our documentation site in a forthcoming PR.

> NOTE: the implementation of the formatting doesn't work well on Windows,
> which falls back to a default 80-columns formatting.
> Prefer running in on linux or macos for accurate formatting.