### PR TITLE
removed deprecated PreferServerCipherSuites from generated server

### DIFF
--- a/generator/templates/server/server.gotmpl
+++ b/generator/templates/server/server.gotmpl
@@ -393,9 +393,6 @@ func (s *Server) Serve() (err error) {
 
 		// Inspired by https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
 		httpsServer.TLSConfig = &tls.Config{
-			// Causes servers to use Go's default ciphersuite preferences,
-			// which are tuned to avoid attacks. Does nothing on clients.
-			PreferServerCipherSuites: true,
 			// Only use curves which have assembly implementations
 			// https://github.com/golang/go/tree/master/src/crypto/elliptic
 			CurvePreferences: []tls.CurveID{tls.CurveP256},


### PR DESCRIPTION
does what it says on the tin. Fixed #[3487](https://github.com/go-swagger/go-swagger/issues/3487)
It really took a lot of time, energy, effort, and I would like to thank the reviewers who dedicate the *hours* to reviewing its complexity. Lol.