### PR TITLE
fix:#3485 support params with getters generation.

### DIFF
--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -34,7 +34,7 @@ type modelCodegenOptions struct {
 	StructTags                 []string `description:"the struct tags to generate, repeat for multiple (defaults to json)"                                          long:"struct-tags"`
 	RootedErrorPath            bool     `description:"extends validation errors with the type name instead of an empty path, in the case of arrays and maps"        long:"rooted-error-path"`
 	WithStringer               bool     `description:"generate a fmt.Stringer String() method on models, rendering field values as JSON (see issue #872)"           long:"with-stringer"`
-	GenerateGetters            bool     `description:"generate a Get<Field> method for each field on models and each parameter on operations"                      long:"generate-getters"`
+	GenerateGetters            bool     `description:"generate a Get<Field> method for each field on models and each parameter on operations"                       long:"generate-getters"`
 	NoDefaultOmitEmpty         bool     `description:"do not default to omitempty struct tags unless x-omitempty is explicitly set on a property (see issue #2386)" long:"no-default-omit-empty"`
 }
 

--- a/cmd/swagger/commands/generate/model.go
+++ b/cmd/swagger/commands/generate/model.go
@@ -34,7 +34,7 @@ type modelCodegenOptions struct {
 	StructTags                 []string `description:"the struct tags to generate, repeat for multiple (defaults to json)"                                          long:"struct-tags"`
 	RootedErrorPath            bool     `description:"extends validation errors with the type name instead of an empty path, in the case of arrays and maps"        long:"rooted-error-path"`
 	WithStringer               bool     `description:"generate a fmt.Stringer String() method on models, rendering field values as JSON (see issue #872)"           long:"with-stringer"`
-	GenerateGetters            bool     `description:"generate a Get<Field> method for each field on models"                                                        long:"generate-getters"`
+	GenerateGetters            bool     `description:"generate a Get<Field> method for each field on models and each parameter on operations"                      long:"generate-getters"`
 	NoDefaultOmitEmpty         bool     `description:"do not default to omitempty struct tags unless x-omitempty is explicitly set on a property (see issue #2386)" long:"no-default-omit-empty"`
 }
 

--- a/generator/operation.go
+++ b/generator/operation.go
@@ -351,6 +351,7 @@ func (b *codeGenOpBuilder) MakeOperation() (GenOperation, error) {
 		PrincipalIsNullable:  principalIsNullable(b.GenOpts.Principal, b.GenOpts.PrincipalCustomIface),
 		ExternalDocs:         trimExternalDoc(operation.ExternalDocs),
 		ReturnErrors:         b.GenOpts.ReturnErrors,
+		WantsGetters:         b.GenOpts.WantsGetters,
 	}, nil
 }
 

--- a/generator/parameter_test.go
+++ b/generator/parameter_test.go
@@ -4359,3 +4359,67 @@ func TestGenParameter_StreamingMultipartFormNameIsDeconflicted(t *testing.T) {
 
 	assert.EqualT(t, "RequestMultipartForm", deconflictMultipartFormName(params))
 }
+
+// TestGenerateParameterGetters covers the opt-in Get<Field> methods on generated operation parameters.
+//
+// The --generate-getters flag emits a getter for each parameter of the <Operation>Params struct,
+// returning the field value by its declared type.
+// This test exercises the variety of return types (scalar, pointer, slice, date-time)
+// and asserts that the default output is unchanged when the option is not set.
+func TestGenerateParameterGetters(t *testing.T) {
+	defer discardOutput()()
+
+	render := func(t *testing.T, wantsGetters bool) string {
+		t.Helper()
+
+		b, err := opBuilder("listModels", "../testdata/enhancements/generate-getters/fixture.yaml")
+		require.NoError(t, err)
+		b.GenOpts.WantsGetters = wantsGetters
+
+		op, err := b.MakeOperation()
+		require.NoError(t, err)
+
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, b.GenOpts.templates.MustGet("serverParameter").Execute(buf, op))
+
+		ff, err := b.GenOpts.LanguageOpts.FormatContent("list_models_parameters.go", buf.Bytes())
+		require.NoErrorf(t, err, "format error: %v\n%s", err, buf.String())
+
+		return string(ff)
+	}
+
+	t.Run("with WantsGetters option", func(t *testing.T) {
+		res := render(t, true)
+
+		// optional scalar query param (int64) -> pointer
+		assertInCode(t, "func (o *ListModelsParams) GetDollarTop() *int64 {", res)
+		assertInCode(t, "return o.DollarTop", res)
+
+		// required scalar query param (int64) -> non-pointer
+		assertInCode(t, "func (o *ListModelsParams) GetDollarSkip() int64 {", res)
+		assertInCode(t, "return o.DollarSkip", res)
+
+		// optional string query param -> pointer
+		assertInCode(t, "func (o *ListModelsParams) GetName() *string {", res)
+		assertInCode(t, "return o.Name", res)
+
+		// slice query param
+		assertInCode(t, "func (o *ListModelsParams) GetTags() []string {", res)
+		assertInCode(t, "return o.Tags", res)
+
+		// date-time query param -> *strfmt.DateTime (optional, so pointer)
+		assertInCode(t, "func (o *ListModelsParams) GetWhen() *strfmt.DateTime {", res)
+		assertInCode(t, "return o.When", res)
+	})
+
+	t.Run("without WantsGetters option (default)", func(t *testing.T) {
+		res := render(t, false)
+
+		// opt-in: the default output is unchanged, no Get<Field> methods are emitted.
+		assertNotInCode(t, "func (o *ListModelsParams) GetDollarTop(", res)
+		assertNotInCode(t, "func (o *ListModelsParams) GetDollarSkip(", res)
+		assertNotInCode(t, "func (o *ListModelsParams) GetName(", res)
+		assertNotInCode(t, "func (o *ListModelsParams) GetTags(", res)
+		assertNotInCode(t, "func (o *ListModelsParams) GetWhen(", res)
+	})
+}

--- a/generator/structs.go
+++ b/generator/structs.go
@@ -669,6 +669,7 @@ type GenOperation struct {
 
 	StrictResponders bool
 	ReturnErrors     bool
+	WantsGetters     bool // generate a Get<Field> method for each parameter on the Params struct (--generate-getters)
 	ExternalDocs     *spec.ExternalDocumentation
 	Produces         []string // original produces for operation (for doc)
 	Consumes         []string // original consumes for operation (for doc)

--- a/generator/templates/server/parameter.gotmpl
+++ b/generator/templates/server/parameter.gotmpl
@@ -419,6 +419,17 @@ type {{ pascalize .Name }}Params struct {
   {{ if not .Schema }}{{ .ID }} {{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}*{{ end }}{{.GoType}}{{ else }}{{ .ID }} {{ if and (not .Schema.IsBaseType) .IsNullable (not .Schema.IsStream) }}*{{ end }}{{.GoType}}{{ end }}
   {{- end}}
 }
+{{- if .WantsGetters }}
+  {{- range .ServerParams }}
+    {{- if not .IsFileParam }}
+
+// Get{{ .GoName }} gets the {{ humanize .Name }} parameter of this {{ pascalize $.Name }}Params
+func ({{ $.ReceiverName }} *{{ pascalize $.Name }}Params) Get{{ .GoName }}() {{ if not .Schema }}{{ if and (not .IsArray) (not .HasDiscriminator) (not .IsInterface) (not .IsStream) .IsNullable }}*{{ end }}{{.GoType}}{{ else }}{{ if and (not .Schema.IsBaseType) .IsNullable (not .Schema.IsStream) }}*{{ end }}{{.GoType}}{{ end }} {
+  return {{ $.ReceiverName }}.{{ .ID }}
+}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
 // for simple values it will use straight method calls.

--- a/testdata/enhancements/generate-getters/fixture.yaml
+++ b/testdata/enhancements/generate-getters/fixture.yaml
@@ -4,15 +4,46 @@ info:
   title: generate-getters
   version: "0.0.0"
 paths:
-  /v1/model:
+  /v1/models:
     get:
+      operationId: listModels
       produces:
         - application/json
+      parameters:
+        - name: "$top"
+          in: query
+          type: integer
+          format: int64
+          description: OData $top — an optional scalar query param (int64)
+        - name: "$skip"
+          in: query
+          type: integer
+          format: int64
+          required: true
+          description: OData $skip — a required query param (int64, non-pointer)
+        - name: name
+          in: query
+          type: string
+          description: an optional string query param (pointer)
+        - name: tags
+          in: query
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          description: a slice query param
+        - name: when
+          in: query
+          type: string
+          format: date-time
+          description: a date-time query param (strfmt.DateTime)
       responses:
         default:
-          description: model
+          description: model list
           schema:
-            $ref: '#/definitions/GetterModel'
+            type: array
+            items:
+              $ref: '#/definitions/GetterModel'
 
 definitions:
   GetterModel:


### PR DESCRIPTION
does what it says on the tin. I updated the test model to highlight what this will likely get used for, common OData parsing. Now you can have getters on the params as well.